### PR TITLE
updated and hopefully fixed render_readme.yml

### DIFF
--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -23,18 +23,15 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
 
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v1
+        uses: r-lib/actions/setup-pandoc@v2
     
       - name: Install dependencies
-        run: |
-          Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS = "true")
-          options(install.packages.check.source = "no")
-          pkgs <- c("rmarkdown", "devtools")
-          install.packages(pkgs, repos = "https://cloud.r-project.org/")
-        shell: Rscript {0}
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rmarkdown, local::.
  
       - name: Compile the readme
         run: |

--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -9,45 +9,36 @@ name: render-readme
 on:
   workflow_dispatch:
   push:
-    branches:
-      - 'main'
-    paths: 
+    paths:
       - 'README.Rmd'
-      
-# A workflow is made up of one or more jobs that can run sequentially or in parallel
-# Important: ubuntu-latest is not set up properly for R, so use macOS
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   render-readme:
     runs-on: macos-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Checkout repo
+      - name: Checkout repos
         uses: actions/checkout@v2
-        with:
-          ref: main
-          fetch-depth: 0
-          persist-credentials: false # to avoid reusing these credentials when pushing
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
-      
+        uses: r-lib/actions/setup-r@v1
+
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
-      
+        uses: r-lib/actions/setup-pandoc@v1
+    
       - name: Install dependencies
         run: |
-          Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNNINGS = "true")
+          Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS = "true")
           options(install.packages.check.source = "no")
-          pkgs <- c("rmarkdown", "remotes")
+          pkgs <- c("rmarkdown", "devtools")
           install.packages(pkgs, repos = "https://cloud.r-project.org/")
-          remotes::install_github("epiverse-trace/epiparameter")
         shell: Rscript {0}
-        
-        
+ 
       - name: Compile the readme
         run: |
-          rmarkdown::render("readme.Rmd")
+          rmarkdown::render("README.Rmd")
         shell: Rscript {0}
         
       - name: Commit files
@@ -56,11 +47,4 @@ jobs:
           git config --local user.name "GitHub Action"
           git add README.md
           git diff-index --quiet HEAD || git commit -m "Automatic readme update"
-          
-          
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: {{ secrets.GITHUB_TOKEN }}
-          branch: 'main'
-          force: true
+          git push origin || echo "No changes to push"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 <!-- badges: start -->
 
+[![License:
+MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![R-CMD-check](https://github.com/epiverse-trace/epiparameter/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/epiverse-trace/epiparameter/actions/workflows/R-CMD-check.yaml)
 [![Codecov test
 coverage](https://codecov.io/gh/epiverse-trace/epiparameter/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/epiparameter?branch=main)
@@ -35,8 +37,8 @@ incubation period of influenza H7N9:
 
 ``` r
 # View available distributions
-epiparameter::list_distributions(type="incubation")
-#>             pathogen_ID        study_ID year size distribution
+epiparameter::list_distributions(delay_dist = "incubation")
+#>             pathogen_id        study_id year size distribution
 #> 1            adenovirus    Lessler_etal 2009   14        lnorm
 #> 2                 ebola        WHO_team 2014  500        gamma
 #> 3             human_CoV    Lessler_etal 2009   13        lnorm
@@ -58,7 +60,10 @@ epiparameter::list_distributions(type="incubation")
 #> 19            monkeypox           Nolen 2016   16        lnorm
 
 # Extract incubation period distribution
-incubation_H7N9 <- epiparameter::epidist(pathogen="influenza_H7N9",type="incubation")
+incubation_H7N9 <- epiparameter::epidist(
+  pathogen = "influenza_H7N9", 
+  delay_dist = "incubation"
+)
 
 # Plot probability mass function
 plot(0:10,incubation_H7N9$pmf(0:10),xlab="time since infection")


### PR DESCRIPTION
I had based the render_readme.yml from `readepi`. However, there have been some updates to the same workflow on `linelist`. The render_readme.yml now matches the `linelist` yaml with the exception of the packages installed. 