### PR TITLE
Use flexible regexp for error message expectation

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    branches:
+      - "*"
 
 name: R-CMD-check
 

--- a/tests/testthat/test-epidist.R
+++ b/tests/testthat/test-epidist.R
@@ -73,7 +73,8 @@ test_that("epidist fails as expected", {
   # regexp is removed due to oldrel R version
   # regexp = paste0("'arg' should be ", dQuote("WHO_team")
   expect_error(
-    epidist(pathogen = "ebola", delay_dist = "incubation", study = "study")
+    epidist(pathogen = "ebola", delay_dist = "incubation", study = "study"),
+    regexp = "(\\'arg\\')*(should be)*(WHO_team)"
   )
 })
 


### PR DESCRIPTION
Draft PR to check whether CI passes using a more flexible error expectation regexp.