### PR TITLE
Suggestions for improve_extract

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+    branches:
+      - "*"
 
 name: R-CMD-check
 

--- a/R/convert_param.R
+++ b/R/convert_param.R
@@ -12,8 +12,8 @@
 #' @examples
 #' lnorm_musigma2meansd(1.5, 0.9)
 lnorm_musigma2meansd <- function(mu, sigma) {
-  checkmate::assert_numeric(mu)
-  checkmate::assert_numeric(sigma, lower = 0)
+  checkmate::assert_number(mu)
+  checkmate::assert_number(sigma, lower = 0)
   mean <- exp(mu + 0.5 * sigma^2)
   sd <- exp(mu + 0.5 * sigma^2) * sqrt(exp(sigma^2) - 1)
   list(mean = mean, sd = sd)
@@ -31,8 +31,8 @@ lnorm_musigma2meansd <- function(mu, sigma) {
 #' @examples
 #' lnorm_meansd2musigma(1.0, 0.4)
 lnorm_meansd2musigma <- function(mean, sd) {
-  checkmate::assert_numeric(mean, lower = 0)
-  checkmate::assert_numeric(sd, lower = 0)
+  checkmate::assert_number(mean, lower = 0)
+  checkmate::assert_number(sd, lower = 0)
   sigma <- sqrt(log(sd^2 / mean^2 + 1))
   mu <- log(mean^2 / sqrt(sd^2 + mean^2))
   list(mu = mu, sigma = sigma)
@@ -50,8 +50,8 @@ lnorm_meansd2musigma <- function(mean, sd) {
 #' @examples
 #' gamma_shapescale2meansd(shape = 0.5, scale = 0.2)
 gamma_shapescale2meansd <- function(shape, scale) {
-  checkmate::assert_numeric(shape, lower = 0)
-  checkmate::assert_numeric(scale, lower = 0)
+  checkmate::assert_number(shape, lower = 0)
+  checkmate::assert_number(scale, lower = 0)
   mean <- shape * scale
   sd <- sqrt(shape) * scale
   list(mean = mean, sd = sd)
@@ -69,8 +69,8 @@ gamma_shapescale2meansd <- function(shape, scale) {
 #' @examples
 #' gamma_meansd2shapescale(mean = 2.2, sd = 0.9)
 gamma_meansd2shapescale <- function(mean, sd) {
-  checkmate::assert_numeric(mean, lower = 0)
-  checkmate::assert_numeric(sd, lower = 0)
+  checkmate::assert_number(mean, lower = 0)
+  checkmate::assert_number(sd, lower = 0)
   shape <- mean^2 / sd^2
   scale <- sd^2 / mean
   list(shape = shape, scale = scale)
@@ -114,9 +114,8 @@ gamma_meansd2shapescale <- function(mean, sd) {
 #' var(r)
 #' # 0.9995295
 weibull_meansd2shapescale <- function(mean, sd) {
-
-  checkmate::assert_numeric(mean, lower = 0)
-  checkmate::assert_numeric(sd, lower = 0)
+  checkmate::assert_number(mean, lower = 0)
+  checkmate::assert_number(sd, lower = 0)
 
   # give warning message about numerial inaccuracies
   message("Numerical approximation used, results may be unreliable.")
@@ -144,8 +143,8 @@ weibull_meansd2shapescale <- function(mean, sd) {
 #' @examples
 #' weibull_shapescale2meansd(shape = 2, scale = 1)
 weibull_shapescale2meansd <- function(shape, scale) {
-  checkmate::assert_numeric(shape, lower = 0)
-  checkmate::assert_numeric(scale, lower = 0)
+  checkmate::assert_number(shape, lower = 0)
+  checkmate::assert_number(scale, lower = 0)
   mean <- scale * gamma(1 + 1 / shape)
   sd <- sqrt(scale^2 * (gamma(1 + 2 / shape) - gamma(1 + 1 / shape))^2)
   list(mean = mean, sd = sd)

--- a/R/epidist.R
+++ b/R/epidist.R
@@ -183,7 +183,6 @@ print.epidist <- function(x, ...) {
 #' ebola_si <- epidist(pathogen = "ebola", delay_dist = "serial_interval")
 #' plot(ebola_si)
 plot.epidist <- function(x, day_range = 0:10, ...) {
-
   if (!inherits(x, "epidist")) {
     stop("x must be an epidist object")
   }
@@ -199,7 +198,7 @@ plot.epidist <- function(x, day_range = 0:10, ...) {
     day_range,
     x$pmf(day_range),
     ylab = "",
-    xlab = "time since infection",
+    xlab = "Time since infection",
     type = "p",
     pch = 16,
     main = "Probability Mass Function"
@@ -210,7 +209,7 @@ plot.epidist <- function(x, day_range = 0:10, ...) {
     day_range,
     x$pdf(day_range),
     ylab = "",
-    xlab = "time since infection",
+    xlab = "Time since infection",
     type = "p",
     pch = 16,
     main = "Probability Density Function"
@@ -221,7 +220,7 @@ plot.epidist <- function(x, day_range = 0:10, ...) {
     day_range,
     x$cdf(day_range),
     ylab = "",
-    xlab = "time since infection",
+    xlab = "Time since infection",
     type = "p",
     pch = 16,
     ylim = c(0, 1),

--- a/R/epidist.R
+++ b/R/epidist.R
@@ -157,15 +157,15 @@ epidist <- function(pathogen,
 
 ##' @export
 print.epidist <- function(x, ...) {
-
-  cat(sprintf("Pathogen: %s\n", x$pathogen))
-  cat(sprintf("Delay Distribution: %s\n", x$delay_dist))
-  cat(sprintf("Distribution: %s\n", x$dist))
-  p_vals <- x$param
-  cat(sprintf("Parameters:\n"))
-  cat(sprintf("  %s: %s\n", names(p_vals), as.character(p_vals)))
-
-  invisible(x)
+  writeLines(
+    c(
+      sprintf("Pathogen: %s", x$pathogen),
+      sprintf("Delay Distribution: %s", x$delay_dist),
+      sprintf("Distribution: %s", x$dist),
+      sprintf("Parameters:"),
+      sprintf(" %s: %s", names(x$param), x$param)
+    )
+  )
 }
 
 #' Plots an `epidist` object by displaying the probability mass function (PMF),

--- a/R/extract_param.R
+++ b/R/extract_param.R
@@ -76,36 +76,41 @@ extract_param <- function(type = c("percentiles", "range"),
   # intialise the for the loop
   optim_conv <- FALSE
   optim_params_list <- list()
+  i <- 0
+
+  # Switch for which extract_param_* to use
+  fn_extract_param <- switch(type,
+    percentiles = extract_param_percentile,
+    range = extract_param_range
+  )
+
+  # Switch for whether percentiles or samples are passed
+  data_ <- switch(type,
+    percentiles = percentiles,
+    range = samples
+  )
 
   # check numerical stability of results with different starting parameters
-  while (isFALSE(optim_conv)) {
-    # Percentile extraction
-    # Extract distribution parameters by optimising for specific distribution
-    if (type == "percentiles") {
-      optim_params <- extract_param_percentile(
-        values = values,
-        distribution = distribution,
-        percentiles = percentiles
+  while (!optim_conv) {
+    # Extract the value requested
+    optim_params <- do.call(
+      fn_extract_param,
+      list(
+        values,
+        distribution,
+        data_
       )
-    }
-
-    # Range extraction
-    if (type == "range") {
-      optim_params <- extract_param_range(
-        values = values,
-        distribution = distribution,
-        samples = samples
-      )
-    }
+    )
 
     # add last optimisation to list
-    optim_params_list[[length(optim_params_list) + 1]] <- optim_params
+    optim_params_list[[i + 1]] <- optim_params
 
     optim_conv <- check_optim_conv(
       optim_params_list = optim_params_list,
       optim_params = optim_params,
       optim_conv = optim_conv
     )
+    i <- i + 1
   }
 
   # warn about local optima

--- a/R/extract_param.R
+++ b/R/extract_param.R
@@ -289,11 +289,11 @@ check_optim_conv <- function(optim_params_list,
   if (length(optim_params_list) > 1) {
 
     # extract parameters from list
-    params <- lapply(optim_params_list, "[[", 1)
+    params <- lapply(optim_params_list, "[[", "par")
 
     # calculate pairwise comparison across all iterations
-    param_a_dist <- stats::dist(unlist(lapply(params, "[[", 1)))
-    param_b_dist <- stats::dist(unlist(lapply(params, "[[", 2)))
+    param_a_dist <- stats::dist(sapply(params, "[[", 1))
+    param_b_dist <- stats::dist(sapply(params, "[[", 2))
 
     # any convergence within tolerance for parameters
     res_diff <- length(which(param_a_dist < 1e-5)) &&
@@ -302,7 +302,7 @@ check_optim_conv <- function(optim_params_list,
     # any convergence within tolerance for function value
     res_diff <- res_diff &&
       (abs(optim_params_list[[length(optim_params_list)]]$value -
-             min(unlist(lapply(optim_params_list, "[[", "value")))) < 1e-5)
+        min(sapply(optim_params_list, "[[", "value"))) < 1e-5)
     optim_conv <- res_diff && optim_params$convergence == 0
   }
   optim_conv

--- a/R/extract_param.R
+++ b/R/extract_param.R
@@ -228,36 +228,42 @@ extract_param_range <- function(values,
   names(values) <- c("median", "lower", "upper")
   values_in <- c(values, n = samples)
 
-  if (distribution == "lnorm") {
-    names(param) <- c("meanlog", "sdlog")
-    optim_params <- stats::optim(
-      param,
-      fit_function_lnorm_range,
-      method = "L-BFGS-B",
-      val = values_in,
+  # Switch parameter names based on distribution
+  param_names <- switch(distribution,
+    lnorm = c("meanlog", "sdlog"),
+    gamma = c("shape", "scale"),
+    weibull = c("shape", "scale")
+  )
+  names(param) <- param_names
+
+  # Switch function and lower bounds based on distribution
+  optim_args <- switch(distribution,
+    lnorm = list(
+      fn = fit_function_lnorm_range,
       lower = c(-1e5, 1e-10)
-    )
-  }
-  if (distribution == "gamma") {
-    names(param) <- c("shape", "scale")
-    optim_params <- stats::optim(
-      param,
-      fit_function_gamma_range,
-      method = "L-BFGS-B",
-      val = values_in,
+    ),
+    gamma = list(
+      fn = fit_function_gamma_range,
+      lower = c(1e-10, 1e-10)
+    ),
+    weibull = list(
+      fn = fit_function_weibull_range,
       lower = c(1e-10, 1e-10)
     )
-  }
-  if (distribution == "weibull") {
-    names(param) <- c("shape", "scale")
-    optim_params <- stats::optim(
-      param,
-      fit_function_weibull_range,
-      method = "L-BFGS-B",
-      val = values_in,
-      lower = c(1e-10, 1e-10)
+  )
+
+  # Run optim
+  optim_params <- do.call(
+    stats::optim,
+    c(
+      list(
+        par = param,
+        method = "L-BFGS-B",
+        val = values_in
+      ),
+      optim_args
     )
-  }
+  )
   optim_params
 }
 

--- a/R/pathogen_summary.R
+++ b/R/pathogen_summary.R
@@ -22,14 +22,6 @@ pathogen_summary <- function(pathogen) {
     mustWork = TRUE
   ))
 
-  # order params by pathogen, delay dist and study
-  params <- params[order(
-    tolower(params$pathogen_id),
-    tolower(params$type_id),
-    tolower(params$study_id),
-    method = "radix"
-  ), ]
-
   # match pathogen names against data
   pathogen <- match.arg(
     arg = pathogen,


### PR DESCRIPTION
Just opening this PR to show some suggested changes that are too long for the review on #53.

1. https://github.com/epiverse-trace/epiparameter/commit/a37c789dd37eb10e88b01910518692fa11baea55 uses `checkmate::assert_number` rather than `checkmate::assert_numeric` as the parameters seem to be intended to be single numbers (at least from tests).
2. https://github.com/epiverse-trace/epiparameter/commit/5c895c235a6bd973da0f2cd36d1c444fb0a92f9d tackles `epidist.R`, and
 * Removes the `param` ordering step which does not seem to affect the function
 * Adds a check when a `study` is specified and has two entries after filtering for pathogen, distribution, and study. Could happen if one study reports on two unrelated outbreaks of the same disease
 * Replaces `pick_study` with `params`
3. https://github.com/epiverse-trace/epiparameter/commit/b3f4c9ade5f634af1117046fa6352f968b781ce4 simplifies `print.epidist` and resolves misalignment of the first and second parameters.
4. https://github.com/epiverse-trace/epiparameter/commit/87563d18403361b6a00624cffc694aacb31beba4 makes the "Time" in axis titles capital
5. https://github.com/epiverse-trace/epiparameter/commit/4f3862ff17a4b6080b479f3f98059b99ffad8d7f, https://github.com/epiverse-trace/epiparameter/commit/26e3f471995ceb4fe0abe7635f72b6e77e03ddc5, and https://github.com/epiverse-trace/epiparameter/commit/26e3f471995ceb4fe0abe7635f72b6e77e03ddc5 use switches rather than multiple `if` statements
6. https://github.com/epiverse-trace/epiparameter/commit/493ffe683d3dd337a9e44049385e1829c3ccc45e replaces `unlist(lapply(...))` with `sapply`, and runs this on `param$par` rather than unnamed first element
7. https://github.com/epiverse-trace/epiparameter/commit/b7e65f3114183e6c57303bd030b05ed02c26d83a removes the `params` ordering step from `pathogen_summary` as it doesn't seem to be important