### PR TITLE
Added new introductory vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ Imports:
 Suggests: 
     covr,
     knitr,
+    bookdown,
     rmarkdown,
     vdiffr,
     dplyr (>= 1.0.0),

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -83,6 +83,9 @@ To see a full list of the diseases and distributions stored in the library use t
 head(list_distributions(epi_dist_db))
 ```
 
+More details on the data collation and the library of parameters can be found in
+the [Data Collation and Synthesis Protocol vignette](https://epiverse-trace.github.io/epiparameter/articles/data_protocol.html).
+
 ### Single set of epidemiolgical parameters
 
 The second class introduced in the {epiparameter} package is the `<epidist>` class. This holds a single set of epidemiological parameters. 

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -29,6 +29,8 @@ An outbreak of a known or potentially novel pathogen is detected and the paramet
 This vignette will provide a introduction to the data stored within {epiparameter}, how to read it into R, manipulate
 the data, and the functions (and methods) implemented in the package to facilitate easy application of parameters into epidemiological pipelines.
 
+The {distributional} package is loaded as some of the {epiparameter} methods uses S3 generics from this package.
+
 ```{r setup}
 library(epiparameter)
 library(distributional)

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -14,7 +14,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-It is often the case that in an infectious disease outbreak epidemiological parameters are required in order to characterise and model the dynamics of disease transmission and evaluate control strategies. In those scenarios, epidemiological parameters are commonly retrieved from the literature, and there is no currently library of parameters in order to contrast and compare different reported parameters for a range of infectious diseases and pathogens, from different published studies over time, of which some may be meta-analyses.
+It is often the case that in an infectious disease outbreak epidemiological parameters are required in order to characterise and model the dynamics of disease transmission and evaluate control strategies. In those scenarios, epidemiological parameters are commonly retrieved from the literature, and there is currently no library of parameters in order to contrast and compare different reported parameters for a range of infectious diseases and pathogens, from different published studies over time, of which some may be meta-analyses.
 
 The {epiparameter} R package is a library of epidemiological parameters, with classes to handle this data and a set of functions to manipulate and use epidemiological parameters and distributions. The package also contains functionality for converting and extracting distribution parameters from summary statistics.
 

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -29,7 +29,7 @@ An outbreak of a known or potentially novel pathogen is detected and the paramet
 This vignette will provide a introduction to the data stored within {epiparameter}, how to read it into R, manipulate
 the data, and the functions (and methods) implemented in the package to facilitate easy application of parameters into epidemiological pipelines.
 
-The {distributional} package is loaded as some of the {epiparameter} methods uses S3 generics from this package.
+The {distributional} package is loaded as some of the {epiparameter} methods use S3 generics from this package.
 
 ```{r setup}
 library(epiparameter)
@@ -70,7 +70,7 @@ colnames(epi_dist_db)
 
 If subsetting of the `<epiparam>` object removes one of the crucial columns then the object is 
 converted to a data frame. Here removing the `disease` column causes the `<epiparam>` object
-to be converted to a data frame. See this [Epiverse-TRACE blog post](https://epiverse-trace.github.io/posts/extend-dataframes/) for a more technical description.
+to be converted to a data frame. See the Epiverse-TRACE [blog post on extending data frames](https://epiverse-trace.github.io/posts/extend-dataframes/) for a more technical description.
 
 ```{r, epiparam-subset-disease}
 epi_dist_df <- epi_dist_db[-which(colnames(epi_dist_db) == "disease")]

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -70,10 +70,17 @@ colnames(epi_dist_db)
 
 If subsetting of the `<epiparam>` object removes one of the crucial columns then the object is 
 converted to a data frame. Here removing the `disease` column causes the `<epiparam>` object
-to be converted to a data frame.
+to be converted to a data frame. See this [Epiverse-TRACE blog post](https://epiverse-trace.github.io/posts/extend-dataframes/) for a more technical description.
 
 ```{r, epiparam-subset-disease}
 epi_dist_df <- epi_dist_db[-which(colnames(epi_dist_db) == "disease")]
+```
+
+To see a full list of the diseases and distributions stored in the library use the 
+`list_distributions()` function. Here we show the first six rows of the output.
+
+```{r, list_distributions}
+head(list_distributions(epi_dist_db))
 ```
 
 ### Single set of epidemiolgical parameters

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -189,6 +189,8 @@ The default plotting range for time since infection is from zero to ten days. Th
 plot(ebola_incubation, day_range = 1:25)
 ```
 
+This plotting function can be useful for visually comparing epidemiological distributions from different publications on the same disease. In addition, plotting the distribution after manually creating an `<epidist>` help to check that the parameters are sensible and produce the expected distribution. 
+
 ## Parameter conversion and extraction
 
 ### Conversion

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -23,7 +23,7 @@ The {epiparameter} R package is a library of epidemiological parameters, with cl
 
 An outbreak of a known or potentially novel pathogen is detected and the parameters and a delay distribution (e.g. incubation period or serial interval) is required. 
 
-{epiparameter} can provide a these distributions from a selection of published sources in order to provide reliable epidemiological parameters.
+{epiparameter} can provide these distributions from a selection of published sources in order to provide reliable epidemiological parameters.
 :::
 
 This vignette will provide a introduction to the data stored within {epiparameter}, how to read it into R, manipulate

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -26,7 +26,7 @@ An outbreak of a known or potentially novel pathogen is detected and the paramet
 {epiparameter} can provide a these distributions from a selection of published sources in order to provide reliable epidemiological parameters.
 :::
 
-This vignette will provide a introduction the data stored within {epiparameter}, how to read it into R, manipulate
+This vignette will provide a introduction to the data stored within {epiparameter}, how to read it into R, manipulate
 the data, and the functions (and methods) implemented in the package to facilitate easy application of parameters into epidemiological pipelines.
 
 ```{r setup}
@@ -43,7 +43,7 @@ library(epiparameter)
 
 #### Library of epidemiological parameters
 
-First, we will introduce the library, or database, of epidemiological parameters available from {epiparameter}. The `<epiparam>` class is introduced to enable users to easily explore the range of parameters that are available. The library can be read into R using the `epiparam()` function.
+First, we will introduce the library, or database, of epidemiological parameters available from {epiparameter}. The `<epiparam>` class is introduced to enable users to easily explore the range of parameters that are available. The library can be read into R using the `epiparam()` function. By default all entries in the library are supplied.
 
 ```{r read-in-library}
 epi_dist_db <- epiparam()
@@ -66,7 +66,8 @@ colnames(epi_dist_db)
 ```
 
 If subsetting of the `<epiparam>` object removes one of the crucial columns then the object is 
-converted to a data frame.
+converted to a data frame. Here removing the `disease` column causes the `<epiparam>` object
+to be converted to a data frame.
 
 ```{r, epiparam-subset-disease}
 epi_dist_df <- epi_dist_db[-which(colnames(epi_dist_db) == "disease")]
@@ -101,7 +102,19 @@ The opposite conversion from `<epidist>` to `<epiparam>` can also be achieved us
 as_epiparam(covid_incub)
 ```
 
-Alternatively to using entries from the {epiparameter} library,  `<epidist>` objects can be manually created.
+There are two alternatives to reading in `<epiparam>` objects and subsetting to `<epidist>`. 
+
+1. Extract an `<epidist>` directly from the library with `epidist_db()`.
+2. Create `<epidist>` manually with constructor function.
+
+The `epidist_db()` allows direct subsetting of the library and returns an `<epidist>` of a 
+single set of epidemiological parameters.
+
+```{r epidist_db}
+epidist_db(disease = "COVID-19", epi_dist = "incubation_period", author = "Bui_etal")
+```
+
+Additionally to using entries from the {epiparameter} library, `<epidist>` objects can be manually created.
 This may be especially useful if new parameter estimates become available but are not yet incorporated into the library.
 
 ```{r}
@@ -119,9 +132,9 @@ ebola_incubation <- epidist(
 By providing a consistent and robust object to store epidemiological parameters, `<epidist>` objects can be applied in epidemiological pipelines, for example [{episoap}](https://github.com/epiverse-trace/episoap). The data contained within the object (e.g. parameter values, pathogen type, etc.) can be modified but the pipeline will operate as the class is unchanged.
 :::
 
-## Adding library entries
-
 The probability distribution (`prob_distribution`) argument requires the distribution specified in the standard R naming. Examples of where the distribution name and R name differ are lognormal and lnorm, negative binomial and nbinom, among others. If unsure of the name in R google will usually provide a answer. Extra arguments are also available in `epidist()` to add information on uncertainty and citation information.
+
+## Adding library entries
 
 To add entries to the library the `bind_epiparam()` function appends a row to an existing `<epiparam>` object using either an `<epiparam>`, `<epidist>` or data frame.
 
@@ -143,7 +156,7 @@ quantile(ebola_incubation, p = 0.5)
 
 ## Plotting epidemiological distributions
 
-`<epidist>` objects can easily be plotted to see the pdf and cdf of distribution.
+`<epidist>` objects can easily be plotted to see the PDF and CDF of distribution.
 
 ```{r plot-epidist, fig.width=7}
 plot(ebola_incubation)
@@ -159,7 +172,7 @@ plot(ebola_incubation, day_range = 1:25)
 
 #### Conversion
 
-Parameters are often reported as mean and standard deviaton (or variance). These can be (analytically) converted to the parameters of the distribution using the range of conversion functions in the package. These have the naming convention `summary_stats2params()`. For example `gamma_meansd2shapescale()` or `lnorm_meansd2musigma()`.
+Parameters are often reported as mean and standard deviaton (or variance). These can be (analytically) converted to the parameters of the distribution using the conversion functions in the package. These have the naming convention `summary_stats2params()`. For example `gamma_meansd2shapescale()` or `lnorm_meansd2musigma()`.
 
 We also provide conversion functions in the opposite direction, parameters to summary statistics. These follow the same naming convention, for example `weibull_shapescale2meansd()`.
 
@@ -169,4 +182,4 @@ The functions `extract_param()` handles all the extraction of parameter estimate
 
 ## Contributing to {epiparameter}
 
-The library of epidemiological parameters is a living database, as new studies are published we hope to incorporate these. Due to the large time requirement of searching for and recording parameters in the database we welcome others to add parameters to the contributing spreadsheet. These will be incorporated into the database by the package maintainers.
+The library of epidemiological parameters is a living database, as new studies are published we hope to incorporate these. Due to the large time requirement of searching for and recording parameters in the database we welcome others to add parameters to the contributing spreadsheet. These will be incorporated into the database by the package maintainers. See the [Data Collation and Synthesis Protocol](https://epiverse-trace.github.io/epiparameter/articles/data_protocol.html) vignette on information about contributing to the library of epidemiological parameters.

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -31,6 +31,7 @@ the data, and the functions (and methods) implemented in the package to facilita
 
 ```{r setup}
 library(epiparameter)
+library(distributional)
 ```
 
 ## Working with {epiparameter} data

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -42,7 +42,7 @@ library(distributional)
 
 - `<epiparam>`: library of epidemiolgical parameters
 - `<epidist>`: singular set of epidemiolgical parameters 
-- `<vb_epidist>`: a singular set of epidemiolgical parameters containing both an extrinsic and intrinsic distribution.
+- `<vb_epidist>`: a singular set of epidemiolgical parameters for a vector-borne disease containing both an extrinsic and intrinsic distribution. This object contains two sets of parameters, one for the human (intrinsic) and one for the vector (extrinsic).
 
 ### Library of epidemiological parameters
 

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -1,0 +1,172 @@
+---
+title: "Getting Started with {epiparameter}"
+output: bookdown::html_vignette2
+vignette: >
+  %\VignetteIndexEntry{Getting Started with {epiparameter}}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+It is often the case that in an infectious disease outbreak epidemiological parameters are required in order to characterise and model the dynamics of disease transmission and evaluate control strategies. In those scenarios, epidemiological parameters are commonly retrieved from the literature, and there is no currently library of parameters in order to contrast and compare different reported parameters for a range of infectious diseases and pathogens, from different published studies over time, of which some may be meta-analyses.
+
+The {epiparameter} R package is a library of epidemiological parameters, with classes to handle this data and a set of functions to manipulate and use epidemiological parameters and distributions. The package also contains functionality for converting and extracting distribution parameters from summary statistics.
+
+::: {.alert .alert-primary}
+### Use case 
+
+An outbreak of a known or potentially novel pathogen is detected and the parameters and a delay distribution (e.g. incubation period or serial interval) is required. 
+
+{epiparameter} can provide a these distributions from a selection of published sources in order to provide reliable epidemiological parameters.
+:::
+
+This vignette will provide a introduction the data stored within {epiparameter}, how to read it into R, manipulate
+the data, and the functions (and methods) implemented in the package to facilitate easy application of parameters into epidemiological pipelines.
+
+```{r setup}
+library(epiparameter)
+```
+
+## Working with {epiparameter} data
+
+{epiparameter} introduces three new classes for working with epidemiological parameters in R:
+
+- `<epiparam>`: library of epidemiolgical parameters
+- `<epidist>`: singular set of epidemiolgical parameters 
+- `<vb_epidist>`: a singular set of epidemiolgical parameters containing both an extrinsic and intrinsic distribution.
+
+#### Library of epidemiological parameters
+
+First, we will introduce the library, or database, of epidemiological parameters available from {epiparameter}. The `<epiparam>` class is introduced to enable users to easily explore the range of parameters that are available. The library can be read into R using the `epiparam()` function.
+
+```{r read-in-library}
+epi_dist_db <- epiparam()
+epi_dist_db
+```
+
+The `<epiparam>` class has a custom printing method which gives a summary of the information included in the database including the number of distributions, number of diseases, number of different studies among other summary metrics, as well as the first six rows of the diseases, epidemiological distributions (`epi_distribution`) and probability distribution (`prob_distribution`).
+
+The `<epiparam>` class is based (i.e. inherits from) the data frame, and therefore the same subsetting and manipulation can be carried out, including the `head()` and `tail()` of the database.
+
+```{r, subsetting-head-tail-epiparam}
+head(epi_dist_db)[, 1:5]
+tail(epi_dist_db)[, 1:5]
+```
+
+The epidemiological library contains quite a few different columns:
+
+```{r, epiparam-cols}
+colnames(epi_dist_db)
+```
+
+If subsetting of the `<epiparam>` object removes one of the crucial columns then the object is 
+converted to a data frame.
+
+```{r, epiparam-subset-disease}
+epi_dist_df <- epi_dist_db[-which(colnames(epi_dist_db) == "disease")]
+```
+
+#### Single set of epidemiolgical parameters
+
+The second class introduced in the {epiparameter} package is the `<epidist>` class. This holds a single set of epidemiological parameters. 
+
+An `<epidist>` object can be converted from one of the rows of the `<epiparam>` object or can be created manually. First we will show the conversion of `<epiparam>` &rarr; `<epidist>`. This uses the `as_epidist()` function.
+
+```{r convert-epiparam-epidist}
+# find entry for COVID-19
+epi_dist_covid <- epi_dist_db[which(epi_dist_db$disease == "COVID-19"), ]
+
+# find entry for COVID-19 incubation period
+epi_dist_covid_incub <- epi_dist_covid[which(epi_dist_covid$epi_distribution == "incubation_period"), ]
+
+# select one of the COVID-19 incubation period
+covid_incub <- epi_dist_covid_incub[10, ]
+
+# convert epiparam entry to epidist
+covid_incub <- as_epidist(covid_incub)
+covid_incub
+```
+
+The `<epidist>` object also has a custom printing method which shows the disease, pathogen (if known), the epidemiological distribution, a short citation of the study the parameters are from and the probability distribution and parameter of that distribution (if available).
+
+The opposite conversion from `<epidist>` to `<epiparam>` can also be achieved using `as_epiparam()`.
+
+```{r convert-epidist-epiparam}
+as_epiparam(covid_incub)
+```
+
+Alternatively to using entries from the {epiparameter} library,  `<epidist>` objects can be manually created.
+This may be especially useful if new parameter estimates become available but are not yet incorporated into the library.
+
+```{r}
+ebola_incubation <- epidist(
+  disease = "ebola", 
+  epi_dist= "incubation_period", 
+  prob_distribution = "lnorm", 
+  prob_distribution_params = c(meanlog = 1, sdlog = 1) 
+)
+```
+
+::: {.alert .alert-success}
+### Benefit of `<epidist>`
+
+By providing a consistent and robust object to store epidemiological parameters, `<epidist>` objects can be applied in epidemiological pipelines, for example [{episoap}](https://github.com/epiverse-trace/episoap). The data contained within the object (e.g. parameter values, pathogen type, etc.) can be modified but the pipeline will operate as the class is unchanged.
+:::
+
+## Adding library entries
+
+The probability distribution (`prob_distribution`) argument requires the distribution specified in the standard R naming. Examples of where the distribution name and R name differ are lognormal and lnorm, negative binomial and nbinom, among others. If unsure of the name in R google will usually provide a answer. Extra arguments are also available in `epidist()` to add information on uncertainty and citation information.
+
+To add entries to the library the `bind_epiparam()` function appends a row to an existing `<epiparam>` object using either an `<epiparam>`, `<epidist>` or data frame.
+
+```{r add-to-library}
+bind_epiparam(epiparam = epi_dist_db, epi_obj = ebola_incubation)
+bind_epiparam(epiparam = epi_dist_db, epi_obj = as_epiparam(ebola_incubation))
+```
+
+## Distribution functions
+
+It is commonly required to extract the probability density function, cumulative distribution function, quantile or generate random numbers from the distribution stored in the `<epidist>` object. The distribution functions in {epiparameter} allow users to easily access these aspects.
+
+```{r epidist-dist-methods}
+density(ebola_incubation, at = 0.5)
+#cdf(ebola_incubation, q = 0.5)
+quantile(ebola_incubation, p = 0.5)
+#generate(ebola_incubation, times = 10)
+```
+
+## Plotting epidemiological distributions
+
+`<epidist>` objects can easily be plotted to see the pdf and cdf of distribution.
+
+```{r plot-epidist, fig.width=7}
+plot(ebola_incubation)
+```
+
+The default plotting range for time since infection is from zero to ten days. This can be altered by specifying the `day_range` argument when plotting an `<epidist>` object.
+
+```{r plot-epidist-dayrange, fig.width=7}
+plot(ebola_incubation, day_range = 1:25)
+```
+
+## Parameter conversion and extraction
+
+#### Conversion
+
+Parameters are often reported as mean and standard deviaton (or variance). These can be (analytically) converted to the parameters of the distribution using the range of conversion functions in the package. These have the naming convention `summary_stats2params()`. For example `gamma_meansd2shapescale()` or `lnorm_meansd2musigma()`.
+
+We also provide conversion functions in the opposite direction, parameters to summary statistics. These follow the same naming convention, for example `weibull_shapescale2meansd()`.
+
+#### Extraction
+
+The functions `extract_param()` handles all the extraction of parameter estimates from summary statistics. The two extractions currently supported in {epiparameter} are from percentiles and from median and range.
+
+## Contributing to {epiparameter}
+
+The library of epidemiological parameters is a living database, as new studies are published we hope to incorporate these. Due to the large time requirement of searching for and recording parameters in the database we welcome others to add parameters to the contributing spreadsheet. These will be incorporated into the database by the package maintainers.

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -166,7 +166,7 @@ Note that this only adds the parameters to the library (`<epiparam>` object) in 
 
 ## Distribution functions
 
-It is commonly required to extract the probability density function, cumulative distribution function, quantile or generate random numbers from the distribution stored in the `<epidist>` object. The distribution functions in {epiparameter} allow users to easily access these aspects.
+`<epidist>` objects store distributions, and mathematical functions of these distribution can easily be extracted directly from them. It is commonly required to extract the probability density function, cumulative distribution function, quantile or generate random numbers from the distribution in the `<epidist>` object. The distribution functions in {epiparameter} allow users to easily access these aspects.
 
 ```{r epidist-dist-methods}
 density(ebola_incubation, at = 0.5)

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -44,7 +44,7 @@ library(distributional)
 - `<epidist>`: singular set of epidemiolgical parameters 
 - `<vb_epidist>`: a singular set of epidemiolgical parameters containing both an extrinsic and intrinsic distribution.
 
-#### Library of epidemiological parameters
+### Library of epidemiological parameters
 
 First, we will introduce the library, or database, of epidemiological parameters available from {epiparameter}. The `<epiparam>` class is introduced to enable users to easily explore the range of parameters that are available. The library can be read into R using the `epiparam()` function. By default all entries in the library are supplied.
 
@@ -76,7 +76,7 @@ to be converted to a data frame.
 epi_dist_df <- epi_dist_db[-which(colnames(epi_dist_db) == "disease")]
 ```
 
-#### Single set of epidemiolgical parameters
+### Single set of epidemiolgical parameters
 
 The second class introduced in the {epiparameter} package is the `<epidist>` class. This holds a single set of epidemiological parameters. 
 
@@ -177,13 +177,13 @@ plot(ebola_incubation, day_range = 1:25)
 
 ## Parameter conversion and extraction
 
-#### Conversion
+### Conversion
 
 Parameters are often reported as mean and standard deviaton (or variance). These can be (analytically) converted to the parameters of the distribution using the conversion functions in the package. These have the naming convention `summary_stats2params()`. For example `gamma_meansd2shapescale()` or `lnorm_meansd2musigma()`.
 
 We also provide conversion functions in the opposite direction, parameters to summary statistics. These follow the same naming convention, for example `weibull_shapescale2meansd()`.
 
-#### Extraction
+### Extraction
 
 The functions `extract_param()` handles all the extraction of parameter estimates from summary statistics. The two extractions currently supported in {epiparameter} are from percentiles and from median and range.
 

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -84,7 +84,7 @@ An `<epidist>` object can be converted from one of the rows of the `<epiparam>` 
 epi_dist_covid <- epi_dist_db[which(epi_dist_db$disease == "COVID-19"), ]
 
 # find entry for COVID-19 incubation period
-epi_dist_covid_incub <- epi_dist_covid[which(epi_dist_covid$epi_distribution == "incubation_period"), ]
+epi_dist_covid_incub <- epi_dist_covid[which(epi_dist_covid$epi_distribution == "incubation_period"), ] # nolint
 
 # select one of the COVID-19 incubation period
 covid_incub <- epi_dist_covid_incub[10, ]
@@ -111,7 +111,11 @@ The `epidist_db()` allows direct subsetting of the library and returns an `<epid
 single set of epidemiological parameters.
 
 ```{r epidist_db}
-epidist_db(disease = "COVID-19", epi_dist = "incubation_period", author = "Bui_etal")
+epidist_db(
+  disease = "COVID-19",
+  epi_dist = "incubation_period",
+  author = "Bui_etal"
+)
 ```
 
 Additionally to using entries from the {epiparameter} library, `<epidist>` objects can be manually created.
@@ -119,10 +123,10 @@ This may be especially useful if new parameter estimates become available but ar
 
 ```{r}
 ebola_incubation <- epidist(
-  disease = "ebola", 
-  epi_dist= "incubation_period", 
-  prob_distribution = "lnorm", 
-  prob_distribution_params = c(meanlog = 1, sdlog = 1) 
+  disease = "ebola",
+  epi_dist = "incubation_period",
+  prob_distribution = "lnorm",
+  prob_distribution_params = c(meanlog = 1, sdlog = 1)
 )
 ```
 

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -149,9 +149,9 @@ It is commonly required to extract the probability density function, cumulative 
 
 ```{r epidist-dist-methods}
 density(ebola_incubation, at = 0.5)
-#cdf(ebola_incubation, q = 0.5)
+cdf(ebola_incubation, q = 0.5)
 quantile(ebola_incubation, p = 0.5)
-#generate(ebola_incubation, times = 10)
+generate(ebola_incubation, times = 10)
 ```
 
 ## Plotting epidemiological distributions

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -153,12 +153,16 @@ The probability distribution (`prob_distribution`) argument requires the distrib
 
 ## Adding library entries
 
+If a set of epidemiological parameter has been inferred and known to the user but has not yet been incorporated into the {epiparameter} database, these parameters can be manually added to the library.
+
 To add entries to the library the `bind_epiparam()` function appends a row to an existing `<epiparam>` object using either an `<epiparam>`, `<epidist>` or data frame.
 
 ```{r add-to-library}
 bind_epiparam(epiparam = epi_dist_db, epi_obj = ebola_incubation)
 bind_epiparam(epiparam = epi_dist_db, epi_obj = as_epiparam(ebola_incubation))
 ```
+
+Note that this only adds the parameters to the library (`<epiparam>` object) in the environment, and does not save to the database file in the package.
 
 ## Distribution functions
 

--- a/vignettes/epiparameter.Rmd
+++ b/vignettes/epiparameter.Rmd
@@ -149,7 +149,7 @@ ebola_incubation <- epidist(
 By providing a consistent and robust object to store epidemiological parameters, `<epidist>` objects can be applied in epidemiological pipelines, for example [{episoap}](https://github.com/epiverse-trace/episoap). The data contained within the object (e.g. parameter values, pathogen type, etc.) can be modified but the pipeline will operate as the class is unchanged.
 :::
 
-The probability distribution (`prob_distribution`) argument requires the distribution specified in the standard R naming. Examples of where the distribution name and R name differ are lognormal and lnorm, negative binomial and nbinom, among others. If unsure of the name in R google will usually provide a answer. Extra arguments are also available in `epidist()` to add information on uncertainty and citation information.
+The probability distribution (`prob_distribution`) argument requires the distribution specified in the standard R naming. In some cases these are the same as the distribution's name, e.g., `gamma` and `weibull`. Examples of where the distribution name and R name differ are lognormal and `lnorm`, negative binomial and `nbinom`, geometric and `geom`, and poisson and `pois`. Extra arguments are also available in `epidist()` to add information on uncertainty and citation information.
 
 ## Adding library entries
 


### PR DESCRIPTION
Added new getting started vignette to give a brief overview of the {epiparameter} package, including functions and classes.

This is part of issue #75 which aims to change from having one or a few large vignettes to having several shorter topic-specific vignettes. PR #132 removed the original introductory vignette which included information on both the {epiparameter} package and its applications. 

This new vignette is exclusively describing the functionality and data in {epiparameter}. For other upcoming vignettes, see checklist in #75. 