### PR TITLE
Adds vignette on parameter extraction bias

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,6 +48,7 @@ Suggests:
     rmarkdown,
     vdiffr,
     dplyr (>= 1.0.0),
+    ggplot2,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/vignettes/extract-bias.Rmd
+++ b/vignettes/extract-bias.Rmd
@@ -67,10 +67,10 @@ lower_percentiles <- c(2.5, 5, 25, 40)
 upper_percentiles <- c(60, 95, 97.5)
 
 parameters_perc <- expand.grid(
-  dist = distributions, 
-  param_1 = dist_parameters, 
-  param_2 = dist_parameters, 
-  lower = lower_percentiles, 
+  dist = distributions,
+  param_1 = dist_parameters,
+  param_2 = dist_parameters,
+  lower = lower_percentiles,
   upper = upper_percentiles
 )
 
@@ -99,10 +99,10 @@ set.seed(1)
 estim_params <- vector("list", nrow(parameters_perc))
 # Loop through parameter space estimating parameters
 for (params_idx in seq_len(nrow(parameters_perc))) {
-  
+
   dist <- as.character(parameters_perc[params_idx, "dist"])
   percen <- unname(unlist(parameters_perc[params_idx, c("lower", "upper")]))
-  
+
   if (dist == "lnorm") {
     true_values <- do.call(
       paste0("q", dist),
@@ -122,7 +122,7 @@ for (params_idx in seq_len(nrow(parameters_perc))) {
       )
     )
   }
-  
+
   # message about stochastic optimisation suppressed
   estim_params[[params_idx]] <- suppressMessages(
     extract_param(
@@ -138,13 +138,13 @@ for (params_idx in seq_len(nrow(parameters_perc))) {
 results <- cbind(parameters_perc, do.call(rbind, estim_params))
 
 colnames(results) <- c(
-  "dist", "param_1", "param_2", "lower", "upper", 
+  "dist", "param_1", "param_2", "lower", "upper",
   "deg_asym", "estim_param_1", "estim_param_2"
-)  
+)
 
 # calculate absolute difference between true parameter and estimated value
 results <- cbind(
-  results, 
+  results,
   diff_param_1 = abs(results$param_1 - results$estim_param_1),
   diff_param_2 = abs(results$param_2 - results$estim_param_2)
 )
@@ -163,13 +163,13 @@ The extraction precision/bias can be explored:
 # plot differences by distribution
 ggplot(data = results) +
   geom_point(mapping = aes(
-    x = diff_param_1, 
-    y = diff_param_2, 
+    x = diff_param_1,
+    y = diff_param_2,
     colour = deg_asym
-  )) + 
+  )) +
   scale_x_continuous(name = "Parameter 1 Difference (|true - estimated|)") +
   scale_y_continuous(name = "Parameter 2 Difference (|true - estimated|)") +
-  labs(colour = "Percentile Asym.") + 
+  labs(colour = "Percentile Asym.") +
   theme_bw() +
   scale_color_viridis_c() +
   facet_wrap(facets = vars(dist), scales = "free") +
@@ -199,10 +199,10 @@ parameters_range <- expand.grid(
 estim_params <- vector("list", nrow(parameters_range))
 # Loop through parameter space estimating parameters
 for (params_idx in seq_len(nrow(parameters_range))) {
-  
+
   dist <- as.character(parameters_range[params_idx, "dist"])
   n_samples <- parameters_range[params_idx, "n_samples"]
-  
+
   if (dist == "lnorm") {
     true_median <- do.call(
       paste0("q", dist),
@@ -240,9 +240,9 @@ for (params_idx in seq_len(nrow(parameters_range))) {
     )
     true_range <- c(min(true_range), max(true_range))
   }
-  
+
   true_values <- c(true_median, true_range)
-  
+
   # message about stochastic optimisation suppressed
   estim_params[[params_idx]] <- suppressMessages(
     expr =  extract_param(
@@ -263,7 +263,7 @@ colnames(results) <- c(
 
 # calculate absolute difference between true parameter and estimated value
 results <- cbind(
-  results, 
+  results,
   diff_param_1 = abs(results$param_1 - results$estim_param_1),
   diff_param_2 = abs(results$param_2 - results$estim_param_2)
 )
@@ -276,16 +276,16 @@ Plot results:
 ggplot(data = results) +
   geom_point(
     mapping = aes(
-      x = diff_param_1, 
-      y = diff_param_2, 
+      x = diff_param_1,
+      y = diff_param_2,
       colour = n_samples
     )
   ) +
   scale_x_continuous(name = "Parameter 1 Difference (|true - estimated|)") +
   scale_y_continuous(name = "Parameter 2 Difference (|true - estimated|)") +
-  labs(colour = "No. Samples") + 
+  labs(colour = "No. Samples") +
   theme_bw() +
-  scale_color_viridis_c() + 
+  scale_color_viridis_c() +
   facet_wrap(facets = vars(dist), scales = "free") +
   theme(strip.background = element_blank())
 
@@ -309,10 +309,10 @@ compute the variance of parameter estimates over those replicates.
 estim_param_var <- vector("list", nrow(parameters_perc))
 # Loop through parameter space estimating parameters
 for (params_idx in seq_len(nrow(parameters_perc))) {
-  
+
   dist <- as.character(parameters_perc[params_idx, "dist"])
   percen <- unname(unlist(parameters_perc[params_idx, c("lower", "upper")]))
-  
+
   if (dist == "lnorm") {
     true_values <- do.call(
       paste0("q", dist),
@@ -332,7 +332,7 @@ for (params_idx in seq_len(nrow(parameters_perc))) {
       )
     )
   }
-  
+
   # message about stochastic optimisation suppressed
   estim <- suppressMessages(
     replicate(
@@ -352,23 +352,23 @@ for (params_idx in seq_len(nrow(parameters_perc))) {
 results <- cbind(parameters_perc, do.call(rbind, estim_param_var))
 
 colnames(results) <- c(
-  "dist", "param_1", "param_2", "lower", "upper", 
+  "dist", "param_1", "param_2", "lower", "upper",
   "deg_asym", "estim_param_1_var", "estim_param_2_var"
-)  
+)
 ```
 
 ```{r, plot-results, fig.cap="Parameter extraction stability, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and Weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and Weibull distributions, or sdlog for the lognormal distribution."}
 ggplot(data = results) +
   geom_point(mapping = aes(
-    x = estim_param_1_var, 
-    y = estim_param_2_var, 
+    x = estim_param_1_var,
+    y = estim_param_2_var,
     colour = deg_asym
-  )) + 
+  )) +
   scale_x_continuous(name = "Parameter 1 Variance") +
   scale_y_continuous(name = "Parameter 2 Variance") +
-  labs(colour = "Percentile Asym.") + 
+  labs(colour = "Percentile Asym.") +
   theme_bw() +
-  scale_color_viridis_c() + 
+  scale_color_viridis_c() +
   facet_wrap(facets = vars(dist), scales = "free") +
   theme(strip.background = element_blank())
 ```
@@ -382,10 +382,10 @@ The same test of estimation consistency can be performed for the extraction from
 estim_param_var <- vector("list", nrow(parameters_range))
 # Loop through parameter space estimating parameters
 for (params_idx in seq_len(nrow(parameters_range))) {
-  
+
   dist <- as.character(parameters_range[params_idx, "dist"])
   n_samples <- parameters_range[params_idx, "n_samples"]
-  
+
   if (dist == "lnorm") {
     true_median <- do.call(
       paste0("q", dist),
@@ -423,9 +423,9 @@ for (params_idx in seq_len(nrow(parameters_range))) {
     )
     true_range <- c(min(true_range), max(true_range))
   }
-  
+
   true_values <- c(true_median, true_range)
-  
+
   # message about stochastic optimisation suppressed
   estim <- suppressMessages(
     replicate(
@@ -445,23 +445,23 @@ for (params_idx in seq_len(nrow(parameters_range))) {
 results <- cbind(parameters_range, do.call(rbind, estim_param_var))
 
 colnames(results) <- c(
-  "dist", "param_1", "param_2", "n_samples", "estim_param_1_var", 
+  "dist", "param_1", "param_2", "n_samples", "estim_param_1_var",
   "estim_param_2_var"
-)  
+)
 ```
 
 ```{r, plot-estim-var-range, fig.cap="Parameter extraction stability, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and Weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and Weibull distributions, or sdlog for the lognormal distribution."}
 ggplot(data = results) +
   geom_point(mapping = aes(
-    x = estim_param_1_var, 
-    y = estim_param_2_var, 
+    x = estim_param_1_var,
+    y = estim_param_2_var,
     colour = n_samples
-  )) + 
+  )) +
   scale_x_continuous(name = "Parameter 1 Variance") +
   scale_y_continuous(name = "Parameter 2 Variance") +
-  labs(colour = "No. Samples") + 
+  labs(colour = "No. Samples") +
   theme_bw() +
-  scale_color_viridis_c() + 
+  scale_color_viridis_c() +
   facet_wrap(facets = vars(dist), scales = "free") +
   theme(strip.background = element_blank())
 ```

--- a/vignettes/extract-bias.Rmd
+++ b/vignettes/extract-bias.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-::: {.alert .alert-warning}
+::: {.alert .alert-info}
 If you are unfamiliar with the parameter extraction functionality in {epiparameter} 
 the Conversion and Extraction vignette is a great place to start.
 :::

--- a/vignettes/extract-bias.Rmd
+++ b/vignettes/extract-bias.Rmd
@@ -38,8 +38,8 @@ supported in {epiparameter} for parameter extraction: gamma, lognormal and Weibu
 
 ::: {.alert .alert-warning}
 This is not an in depth analysis of the estimation methods implemented in {epiparameter}, 
-but rather a supplementary article exploring the bias and consistency of the functions.
-It is specific to the case of {epiparameter} and should not be taken as a generalised results.
+but rather a supplementary article exploring the bias and precision of the functions.
+It is specific to the case of {epiparameter} and should not be taken as a generalisable result.
 :::
 
 ```{r setup}
@@ -56,7 +56,7 @@ First we explore extraction from percentiles.
 If a study reports the percentiles of a distribution, they are usually symmetrical
 (e.g. 5th and 95th, or 2.5th and 97.5th). However, in a few instances, only asymmetrical
 percentiles are available. We test whether asymmetry to varying degrees influences the
-precision of parameter extraction for all distributions.
+bias of parameter extraction for all distributions.
 
 We set up the parameter space to explore:
 
@@ -155,9 +155,9 @@ until convergence to a set tolerance is achieved (or a maximum number of
 iterations is reached) to more reliably return the global 
 optimum. In theory, this should help to minimise bias and instability in the 
 parameter estimation. See the function documentation (`?extract_param()`) or 
-the extraction and conversion vignette for more details.
+the [Conversion and Extraction vignette](extract_convert.html) for more details.
 
-The extraction precision/bias can be explored:
+The extraction bias can be explored:
 
 ```{r, plot-results-percentiles, fig.cap="Parameter estimation bias facetted by distribution. Parameter 1 is either the shape parameter, for gamma and Weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and Weibull distributions, or sdlog for the lognormal distribution."}
 # plot differences by distribution
@@ -174,7 +174,7 @@ ggplot(data = results) +
   scale_color_viridis_c() +
   facet_wrap(facets = vars(dist), scales = "free") +
   theme(
-    strip.background = element_blank(), 
+    strip.background = element_blank(),
     axis.text.x = element_text(angle = 30, vjust = 0.5)
   )
 ```
@@ -291,13 +291,13 @@ ggplot(data = results) +
   scale_color_viridis_c() +
   facet_wrap(facets = vars(dist), scales = "free") +
   theme(
-    strip.background = element_blank(), 
+    strip.background = element_blank(),
     axis.text.x = element_text(angle = 30, vjust = 0.5)
   )
 
 ```
 
-## Extraction stability
+## Extraction precision
 
 ### Extraction by percentiles
 
@@ -305,13 +305,13 @@ The two analyses above used a single extraction (replicate), however, it may be 
 the estimation of the parameters is unstable for a given set of percentiles or median 
 range. Therefore, we finish with a test of whether repeated extraction of parameters 
 from a single percentile has large variance which would indicate the parameter extraction
-is unstable and potentially untrustworthy.
+is unstable, imprecise, and potentially untrustworthy.
 
 We use the same parameter space for percentiles as defined above 
 (`parameters_perc`). Now we can run the extraction for a set of replicates to 
 compute the variance of parameter estimates over those replicates.
 
-```{r, run-extraction-stability-percentile}
+```{r, run-extraction-precision-percentile}
 estim_param_var <- vector("list", nrow(parameters_perc))
 # Loop through parameter space estimating parameters
 for (params_idx in seq_len(nrow(parameters_perc))) {
@@ -363,7 +363,7 @@ colnames(results) <- c(
 )
 ```
 
-```{r, plot-results, fig.cap="Parameter extraction stability, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and Weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and Weibull distributions, or sdlog for the lognormal distribution."}
+```{r, plot-results, fig.cap="Parameter extraction precision, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and Weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and Weibull distributions, or sdlog for the lognormal distribution."}
 ggplot(data = results) +
   geom_point(mapping = aes(
     x = estim_param_1_var,
@@ -384,10 +384,10 @@ ggplot(data = results) +
 
 ### Extraction by median and range
 
-The same test of estimation consistency can be performed for the extraction from median and range.
+The same test of estimation precision can be performed for the extraction from median and range.
 
 
-```{r, run-extraction-stability-range}
+```{r, run-extraction-precision-range}
 estim_param_var <- vector("list", nrow(parameters_range))
 # Loop through parameter space estimating parameters
 for (params_idx in seq_len(nrow(parameters_range))) {
@@ -459,7 +459,7 @@ colnames(results) <- c(
 )
 ```
 
-```{r, plot-estim-var-range, fig.cap="Parameter extraction stability, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and Weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and Weibull distributions, or sdlog for the lognormal distribution."}
+```{r, plot-estim-var-range, fig.cap="Parameter extraction precision, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and Weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and Weibull distributions, or sdlog for the lognormal distribution."}
 ggplot(data = results) +
   geom_point(mapping = aes(
     x = estim_param_1_var,

--- a/vignettes/extract-bias.Rmd
+++ b/vignettes/extract-bias.Rmd
@@ -1,0 +1,483 @@
+---
+title: "{epiparameter} Extraction Bias Analysis"
+output: 
+  bookdown::html_vignette2:
+    fig_caption: yes
+vignette: >
+  %\VignetteIndexEntry{{epiparameter} Extraction Bias Analysis}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.width = 6,
+  fig.height = 5,
+  fig.align = 'center'
+)
+```
+
+```{r setup}
+library(epiparameter)
+```
+
+The {epiparameter} R package contains a set of functions to extract parameters
+of probability distributions from summary statistics. These summary statistics can
+be the values at given percentiles of a distribution, or the median and range of
+a distribution. Using these and specifying the distribution (e.g. gamma, lognormal, etc.)
+the parameters of the distribution can be extracted by optimisation using least-squares.
+
+The precision and bias of this approach needs to be explored across the parameter space
+of the different distributions to understand potential erroneous inferences. This
+vignette aims to explore this inference bias for the three distribution currently 
+supported in {epiparameter} for parameter extraction: gamma, lognormal and weibull.
+
+## Extraction by percentiles
+
+First we explore extraction from percentiles.
+
+If a study reports the percentiles of a distribution, they are usually symmetrical
+(e.g. 5th and 95th, or 2.5th and 97.5th). However, in a few instances, only asymmetrical
+percentiles are available. We test whether asymetry to varying degrees influences the
+precision of parameter extraction for all distributions.
+
+We set up the parameter space to explore:
+
+```{r, set-up-parameter-space-percentiles}
+distributions <- c("gamma", "lnorm", "weibull")
+dist_parameters <- seq(0.5, 2, 0.5)
+lower_percentiles <- c(2.5, 5, 25, 40)
+upper_percentiles <- c(60, 95, 97.5)
+
+parameters <- expand.grid(
+  dist = distributions, 
+  param_1 = dist_parameters, 
+  param_2 = dist_parameters, 
+  lower = lower_percentiles, 
+  upper = upper_percentiles
+)
+
+# calculate the degree of asymmetry for each percentile combination
+lw_interval_diff <- abs(0 - parameters$lower)
+up_interval_diff <- abs(100 - parameters$upper)
+deg_asym <- abs(lw_interval_diff - up_interval_diff)
+
+# add degree of asymmetry to percentiles
+parameters <- cbind(parameters, deg_asym)
+
+# divide percentiles by 100 to make them probabilities for quantile functions
+parameters$lower <- parameters$lower / 100
+parameters$upper <- parameters$upper / 100
+```
+
+Now we can run the extraction for each point in parameter space:
+
+```{r, run-extraction-percentiles}
+estim_params <- list()
+# Loop through parameter space estimating parameters
+for (params_idx in seq_len(nrow(parameters))) {
+  
+  percen <- unname(unlist(parameters[params_idx, c("lower", "upper")]))
+  
+  dist <- as.character(parameters[params_idx, "dist"])
+  
+  if (dist == "lnorm") {
+    true_values <- do.call(
+      paste0("q", dist), 
+      list(
+        p = percen, 
+        meanlog = parameters[params_idx, "param_1"], 
+        sdlog = parameters[params_idx, "param_2"]
+      )
+    )
+  } else {
+    true_values <- do.call(
+      paste0("q", dist), 
+      list(
+        p = percen, 
+        shape = parameters[params_idx, "param_1"], 
+        scale = parameters[params_idx, "param_2"]
+      )
+    )  
+  }
+  
+  # message about stochastic optimisation suppressed
+  estim_params[[params_idx]] <- suppressMessages(
+    epiparameter::extract_param(
+      type = "percentiles",
+      values = true_values, 
+      distribution = dist, 
+      percentiles = percen * 100, 
+      control = list(tolerance = 10)
+    )
+  )
+}
+```
+
+
+In the above code chunk the the `extract_param()` function re-runs the optimisation
+until convergence to a set tolerance is acheived to more reliably return the global 
+optimum. For this analysis we set the tolerance to be arbitrarily large (i.e. 10) 
+to meet the convergence criteria immediately in order to save computation time. Therefore
+these results may be more biased than if the function were run with the default tolerance
+(`1e-5`).
+
+The results are collated and tidied for plotting.
+
+```{r, tidy-results-percentiles}
+# combine results
+results <- cbind(parameters, do.call(rbind, estim_params))
+colnames(results) <- c(
+  "dist", "param_1", "param_2", "lower", "upper", 
+  "deg_asym", "estim_param_1", "estim_param_2"
+)
+
+# calculate absolute difference between true parameter and estimated value
+results <- cbind(
+  results, 
+  diff_param_1 = abs(results$param_1 - results$estim_param_1),
+  diff_param_2 = abs(results$param_2 - results$estim_param_2)
+)
+```
+
+The extraction precision/bias can be explored:
+
+```{r, plot-results-percentiles, fig.cap="Parameter extraction precision"}
+# plot differences
+param_diff_plot <- ggplot2::ggplot(data = results) +
+  ggplot2::geom_point(mapping = ggplot2::aes(
+    x = diff_param_1, 
+    y = diff_param_2, 
+    colour = deg_asym
+  )) + 
+  ggplot2::scale_x_continuous(name = "Parameter 1 Difference (|true - estimated|)") +
+  ggplot2::scale_y_continuous(name = "Parameter 2 Difference (|true - estimated|)") +
+  ggplot2::labs(colour = "Percentile Asym.") + 
+  ggplot2::theme_bw() +
+  ggplot2::scale_color_viridis_c()
+
+param_diff_plot
+
+```
+
+```{r, plot-results-percentiles-dist, fig.cap="Parameter extraction precision by distribution", fig.cap="Parameter estimation precision facetted by distribution."}
+# plot differences by distribution
+param_diff_plot + 
+  ggplot2::facet_wrap(facets = ggplot2::vars(dist)) +
+  ggplot2::theme(strip.background = ggplot2::element_blank())
+```
+
+```{r, pivot-results-percentiles}
+# tidy parameter differences to plot side-by-side
+results <- tidyr::pivot_longer(
+  data = results, cols = c("diff_param_1", "diff_param_2"), 
+  names_to = "diff_param", 
+  values_to = "diff"
+)
+```
+
+```{r, bar-plot}
+# bar plot for parameter 1 differences
+param_1_diff_bar <- ggplot2::ggplot(data = results) +
+  ggplot2::geom_col(mapping = ggplot2::aes(x = param_1, y = diff, fill = diff_param), position = "dodge") +
+  ggplot2::scale_x_continuous(name = "Parameter 1 true value") +
+  ggplot2::scale_y_continuous(name = "Parameter Difference (|true - estimated|)") +
+  ggplot2::scale_fill_brewer(labels = c("Parameter 1", "Parameter 2"), palette = "Set1") +
+  ggplot2::labs(fill = "Parameter Difference")
+param_1_diff_bar
+
+param_1_diff_bar + 
+  ggplot2::facet_wrap(facets = ggplot2::vars(dist))
+
+# bar plot for parameter 2 differences
+param_2_diff_bar <- ggplot2::ggplot(data = results) +
+  ggplot2::geom_col(mapping = ggplot2::aes(x = param_2, y = diff, fill = diff_param), position = "dodge") +
+  ggplot2::scale_x_continuous(name = "Parameter 2 true value") +
+  ggplot2::scale_y_continuous(name = "Parameter Difference (|true - estimated|)") +
+  ggplot2::scale_fill_brewer(labels = c("Parameter 1", "Parameter 2"), palette = "Set1") +
+  ggplot2::labs(fill = "Parameter Difference")
+param_2_diff_bar
+
+param_2_diff_bar + 
+  ggplot2::facet_wrap(facets = ggplot2::vars(dist))
+
+```
+
+## Extraction by median and range
+
+The same analysis as above can be repeated, this time using the other summary
+statistic possibly reported in studies: an inferred distribution's median and range.
+For this extraction the number of samples used to infer the distribution is required
+as this can impact the possible range exhibited by the data.
+
+Set up the parameter space:
+
+```{r, set-up-parameter-space-med-range}
+distributions <- c("gamma", "lnorm", "weibull")
+dist_parameters <- seq(0.5, 2, 0.5)
+n_samples <- c(10, 50, 100)
+
+parameters <- expand.grid(
+  dist = distributions, 
+  param_1 = dist_parameters, 
+  param_2 = dist_parameters, 
+  n_samples = n_samples
+)
+```
+
+```{r run-extraction-med-range}
+estim_params <- list()
+# Loop through parameter space estimating parameters
+for (params_idx in seq_len(nrow(parameters))) {
+  
+  dist <- as.character(parameters[params_idx, "dist"])
+  
+  n_samples <- parameters[params_idx, "n_samples"]
+  
+  if (dist == "lnorm") {
+    true_median <- do.call(
+      paste0("q", dist), 
+      list(
+        p = 0.5, 
+        meanlog = parameters[params_idx, "param_1"], 
+        sdlog = parameters[params_idx, "param_2"]
+      )
+    )
+    true_range <- do.call(
+      paste0("r", dist), 
+      list(
+        n = n_samples,
+        meanlog = parameters[params_idx, "param_1"], 
+        sdlog = parameters[params_idx, "param_2"]
+      )
+    )
+    true_range <- c(min(true_range), max(true_range))
+  } else {
+    true_median <- do.call(
+      paste0("q", dist), 
+      list(
+        p = 0.5, 
+        shape = parameters[params_idx, "param_1"], 
+        scale = parameters[params_idx, "param_2"]
+      )
+    )
+    true_range <- do.call(
+      paste0("r", dist), 
+      list(
+        n = n_samples,
+        shape = parameters[params_idx, "param_1"], 
+        scale = parameters[params_idx, "param_2"]
+      )
+    )
+    true_range <- c(min(true_range), max(true_range))
+  }
+  
+  true_values <- c(true_median, true_range)
+  
+  # message about stochastic optimisation suppressed
+  estim_params[[params_idx]] <- suppressMessages(
+    epiparameter::extract_param(
+      type = "range",
+      values = true_values, 
+      distribution = dist, 
+      samples = n_samples, 
+      control = list(tolerance = 10)
+    )
+  )
+}
+```
+
+```{r, tidy-results-med-range}
+# combine results
+results <- cbind(parameters, do.call(rbind, estim_params))
+colnames(results) <- c(
+  "dist", "param_1", "param_2", "n_samples", "estim_param_1", "estim_param_2"
+)
+
+# calculate absolute difference between true parameter and estimated value
+results <- cbind(
+  results, 
+  diff_param_1 = abs(results$param_1 - results$estim_param_1),
+  diff_param_2 = abs(results$param_2 - results$estim_param_2)
+)
+```
+
+Plot results:
+
+```{r, plot-results-med-range, fig.cap="Parameter extraction precision."}
+# plot differences
+param_diff_plot <- ggplot2::ggplot(data = results) +
+  ggplot2::geom_point(mapping = ggplot2::aes(x = diff_param_1, y = diff_param_2, colour = n_samples)) +
+  ggplot2::scale_x_continuous(name = "Parameter 1 Difference (|true - estimated|)") +
+  ggplot2::scale_y_continuous(name = "Parameter 2 Difference (|true - estimated|)") +
+  ggplot2::labs(colour = "No. Samples") + 
+  ggplot2::theme_bw() +
+  ggplot2::scale_color_viridis_c()
+
+param_diff_plot
+
+```
+
+```{r, plot-results-med-range-dist, fig.cap="Parameter extraction precision facetted by distribution."}
+
+# plot differences by distribution
+param_diff_plot + 
+  ggplot2::facet_wrap(facets = ggplot2::vars(dist)) +
+  ggplot2::theme(strip.background = ggplot2::element_blank())
+
+```
+
+```{r, pivot-results-med-range}
+# tidy parameter differences to plot side-by-side
+results <- tidyr::pivot_longer(
+  data = results, cols = c("diff_param_1", "diff_param_2"), 
+  names_to = "diff_param", 
+  values_to = "diff"
+)
+```
+
+
+```{r, bar-plots}
+# bar plot for parameter 1 differences
+param_1_diff_bar <- ggplot2::ggplot(data = results) +
+  ggplot2::geom_col(mapping = ggplot2::aes(x = param_1, y = diff, fill = diff_param), position = "dodge") +
+  ggplot2::scale_x_continuous(name = "Parameter 1 true value") +
+  ggplot2::scale_y_continuous(name = "Parameter Difference (|true - estimated|)") +
+  ggplot2::scale_fill_brewer(labels = c("Parameter 1", "Parameter 2"), palette = "Set1") +
+  ggplot2::labs(fill = "Parameter Difference")
+param_1_diff_bar
+
+param_1_diff_bar + 
+  ggplot2::facet_wrap(facets = ggplot2::vars(dist))
+
+# bar plot for parameter 2 differences
+param_2_diff_bar <- ggplot2::ggplot(data = results) +
+  ggplot2::geom_col(mapping = ggplot2::aes(x = param_2, y = diff, fill = diff_param), position = "dodge") +
+  ggplot2::scale_x_continuous(name = "Parameter 2 true value") +
+  ggplot2::scale_y_continuous(name = "Parameter Difference (|true - estimated|)") +
+  ggplot2::scale_fill_brewer(labels = c("Parameter 1", "Parameter 2"), palette = "Set1") +
+  ggplot2::labs(fill = "Parameter Difference")
+param_2_diff_bar
+
+param_2_diff_bar + 
+  ggplot2::facet_wrap(facets = ggplot2::vars(dist))
+```
+
+## Extraction stability
+
+The two analyses above used a single extraction (replicate), however, it may be that
+the estimation of the parameters is unstable for a given set of percentiles or median 
+range. Therefore, we finish with a test of whether repeated extraction of parameters 
+from a single percentile has large variance which would indicate the parameter extraction
+is unstable and potentially untrustworthy.
+
+
+```{r, setup-parameter-space-stability}
+distributions <- c("gamma", "lnorm", "weibull")
+dist_parameters <- seq(0.5, 2, 0.5)
+lower_percentiles <- c(2.5, 5, 25, 40)
+upper_percentiles <- c(60, 95, 97.5)
+
+parameters <- expand.grid(
+  dist = distributions, 
+  param_1 = dist_parameters, 
+  param_2 = dist_parameters, 
+  lower = lower_percentiles, 
+  upper = upper_percentiles
+)
+
+# calculate the degree of asymmetry for each percentile combination
+lw_interval_diff <- abs(0 - parameters$lower)
+up_interval_diff <- abs(100 - parameters$upper)
+deg_asym <- abs(lw_interval_diff - up_interval_diff)
+
+# add degree of asymmetry to percentiles
+parameters <- cbind(parameters, deg_asym)
+
+# divide percentiles by 100 to make them probabilities for quantile functions
+parameters$lower <- parameters$lower / 100
+parameters$upper <- parameters$upper / 100
+```
+
+Now we can run the extraction for a set of replicates to compute the variance of
+parameter estimates over those replicates.
+
+```{r, run-extraction-stability}
+estim_params_var <- list()
+# Loop through parameter space estimating parameters
+for (params_idx in seq_len(nrow(parameters))) {
+  
+  percen <- unname(unlist(parameters[params_idx, c("lower", "upper")]))
+  
+  dist <- as.character(parameters[params_idx, "dist"])
+  
+  if (dist == "lnorm") {
+    true_values <- do.call(
+      paste0("q", dist), 
+      list(
+        p = percen, 
+        meanlog = parameters[params_idx, "param_1"], 
+        sdlog = parameters[params_idx, "param_2"]
+      )
+    )
+  } else {
+    true_values <- do.call(
+      paste0("q", dist), 
+      list(
+        p = percen, 
+        shape = parameters[params_idx, "param_1"], 
+        scale = parameters[params_idx, "param_2"]
+      )
+    )  
+  }
+  
+  # message about stochastic optimisation suppressed
+  
+  estim_params <- suppressMessages(
+    replicate(
+      n = 5, 
+      expr =  epiparameter::extract_param(
+        type = "percentiles",
+        values = true_values, 
+        distribution = dist, 
+        percentiles = percen * 100, 
+        control = list(tolerance = 10)
+      )
+    )
+  )
+  
+  estim_params_var[[params_idx]] <- apply(estim_params,MARGIN = 1, FUN = var)
+}
+```
+
+```{r, tidy-results-stability}
+
+# combine results
+results <- cbind(parameters, do.call(rbind, estim_params_var))
+colnames(results) <- c(
+  "dist", "param_1", "param_2", "lower", "upper", 
+  "deg_asym", "estim_param_1_var", "estim_param_2_var"
+)
+```
+
+```{r, plot-results}
+# plot differences
+param_diff_plot <- ggplot2::ggplot(data = results) +
+  ggplot2::geom_point(mapping = ggplot2::aes(
+    x = estim_param_1_var, 
+    y = estim_param_2_var, 
+    colour = deg_asym
+  )) + 
+  ggplot2::scale_x_continuous(name = "Parameter 1 Difference (|true - estimated|)") +
+  ggplot2::scale_y_continuous(name = "Parameter 2 Difference (|true - estimated|)") +
+  ggplot2::labs(colour = "Percentile Asym.") + 
+  ggplot2::theme_bw() +
+  ggplot2::scale_color_viridis_c()
+
+param_diff_plot
+```
+
+
+

--- a/vignettes/extract-bias.Rmd
+++ b/vignettes/extract-bias.Rmd
@@ -52,7 +52,7 @@ dist_parameters <- seq(0.5, 2, 0.5)
 lower_percentiles <- c(2.5, 5, 25, 40)
 upper_percentiles <- c(60, 95, 97.5)
 
-parameters <- expand.grid(
+parameters_perc <- expand.grid(
   dist = distributions, 
   param_1 = dist_parameters, 
   param_2 = dist_parameters, 
@@ -61,79 +61,76 @@ parameters <- expand.grid(
 )
 
 # calculate the degree of asymmetry for each percentile combination
-lw_interval_diff <- abs(0 - parameters$lower)
-up_interval_diff <- abs(100 - parameters$upper)
+lw_interval_diff <- abs(0 - parameters_perc$lower)
+up_interval_diff <- abs(100 - parameters_perc$upper)
 deg_asym <- abs(lw_interval_diff - up_interval_diff)
 
 # add degree of asymmetry to percentiles
-parameters <- cbind(parameters, deg_asym)
+parameters_perc <- cbind(parameters_perc, deg_asym)
 
 # divide percentiles by 100 to make them probabilities for quantile functions
-parameters$lower <- parameters$lower / 100
-parameters$upper <- parameters$upper / 100
+parameters_perc$lower <- parameters_perc$lower / 100
+parameters_perc$upper <- parameters_perc$upper / 100
 ```
 
-Now we can run the extraction for each point in parameter space:
+Now we can run the extraction for each point in parameter space. We set a seed
+to control for stochasticity when estimating the parameters, however changing or
+removing the seed should not drastically change the results or interpretation.
 
-```{r, run-extraction-percentiles}
+```{r, set-seed}
+set.seed(1)
+```
+
+We define a function that can be reused throughout the vignette.
+
+```{r, define-run-extraction}
 estim_params <- list()
 # Loop through parameter space estimating parameters
-for (params_idx in seq_len(nrow(parameters))) {
+for (params_idx in seq_len(nrow(parameters_perc))) {
   
-  percen <- unname(unlist(parameters[params_idx, c("lower", "upper")]))
-  
-  dist <- as.character(parameters[params_idx, "dist"])
+  dist <- as.character(parameters_perc[params_idx, "dist"])
+  percen <- unname(unlist(parameters_perc[params_idx, c("lower", "upper")]))
   
   if (dist == "lnorm") {
     true_values <- do.call(
-      paste0("q", dist), 
+      paste0("q", dist),
       list(
-        p = percen, 
-        meanlog = parameters[params_idx, "param_1"], 
-        sdlog = parameters[params_idx, "param_2"]
+        p = percen,
+        meanlog = parameters_perc[params_idx, "param_1"],
+        sdlog = parameters_perc[params_idx, "param_2"]
       )
     )
   } else {
     true_values <- do.call(
-      paste0("q", dist), 
+      paste0("q", dist),
       list(
-        p = percen, 
-        shape = parameters[params_idx, "param_1"], 
-        scale = parameters[params_idx, "param_2"]
+        p = percen,
+        shape = parameters_perc[params_idx, "param_1"],
+        scale = parameters_perc[params_idx, "param_2"]
       )
-    )  
+    )
   }
-  
+
   # message about stochastic optimisation suppressed
   estim_params[[params_idx]] <- suppressMessages(
     epiparameter::extract_param(
       type = "percentiles",
-      values = true_values, 
-      distribution = dist, 
-      percentiles = percen * 100, 
+      values = true_values,
+      distribution = dist,
+      percentiles = percen,
       control = list(tolerance = 10)
     )
   )
+
 }
-```
 
-
-In the above code chunk the the `extract_param()` function re-runs the optimisation
-until convergence to a set tolerance is acheived to more reliably return the global 
-optimum. For this analysis we set the tolerance to be arbitrarily large (i.e. 10) 
-to meet the convergence criteria immediately in order to save computation time. Therefore
-these results may be more biased than if the function were run with the default tolerance
-(`1e-5`).
-
-The results are collated and tidied for plotting.
-
-```{r, tidy-results-percentiles}
 # combine results
-results <- cbind(parameters, do.call(rbind, estim_params))
+results <- cbind(parameters_perc, do.call(rbind, estim_params))
+
 colnames(results) <- c(
   "dist", "param_1", "param_2", "lower", "upper", 
   "deg_asym", "estim_param_1", "estim_param_2"
-)
+)  
 
 # calculate absolute difference between true parameter and estimated value
 results <- cbind(
@@ -142,6 +139,13 @@ results <- cbind(
   diff_param_2 = abs(results$param_2 - results$estim_param_2)
 )
 ```
+
+In the above code chunk the `extract_param()` function re-runs the optimisation
+until convergence to a set tolerance is achieved to more reliably return the global 
+optimum. For this analysis we set the tolerance to be arbitrarily large (i.e. 10) 
+to meet the convergence criteria immediately in order to save computation time. Therefore
+these results may be more biased than if the function were run with the default tolerance
+(`1e-5`).
 
 The extraction precision/bias can be explored:
 
@@ -167,62 +171,6 @@ shape or meanlog depending on the distribution, than for parameter 2, which is e
 or sdlog. There is no clear pattern of higher asymmetry in percentiles resulting in higher
 bias in parameter extraction.
 
-```{r, pivot-results-percentiles}
-# tidy parameter differences to plot side-by-side
-results <- tidyr::pivot_longer(
-  data = results, cols = c("diff_param_1", "diff_param_2"), 
-  names_to = "diff_param", 
-  values_to = "diff"
-)
-```
-
-To determine whether the bias in parameter estimates varies across true values
-of the underlying distribution parameters, the plots below show the bias at
-each simulated value of either the shape -- for gamma and weibull -- or meanlog
-for lognormal.
-
-```{r, bar-plot-param1, fig.cap="Parameter estimation bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
-# bar plot for parameter 1 differences
-param_1_diff_bar <- ggplot2::ggplot(data = results) +
-  ggplot2::geom_col(
-    mapping = ggplot2::aes(
-      x = param_1, 
-      y = diff, 
-      fill = diff_param), 
-    position = "dodge"
-  ) +
-  ggplot2::scale_x_continuous(name = "Parameter 1 true value") +
-  ggplot2::scale_y_continuous(name = "Parameter Difference (|true - estimated|)") +
-  ggplot2::scale_fill_brewer(labels = c("Parameter 1", "Parameter 2"), palette = "Set1") +
-  ggplot2::labs(fill = "Parameter Difference") +
-  ggplot2::theme_bw()
-param_1_diff_bar
-```
-
-```{r, bar-plot-param1-facet, fig.cap="Parameter extraction bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
-param_1_diff_bar + 
-  ggplot2::facet_wrap(facets = ggplot2::vars(dist)) +
-  ggplot2::theme(strip.background = ggplot2::element_blank())
-```
-
-```{r, bar-plot-param2, fig.cap="Parameter extraction bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
-# bar plot for parameter 2 differences
-param_2_diff_bar <- ggplot2::ggplot(data = results) +
-  ggplot2::geom_col(mapping = ggplot2::aes(x = param_2, y = diff, fill = diff_param), position = "dodge") +
-  ggplot2::scale_x_continuous(name = "Parameter 2 true value") +
-  ggplot2::scale_y_continuous(name = "Parameter Difference (|true - estimated|)") +
-  ggplot2::scale_fill_brewer(labels = c("Parameter 1", "Parameter 2"), palette = "Set1") +
-  ggplot2::labs(fill = "Parameter Difference") + 
-  ggplot2::theme_bw()
-param_2_diff_bar
-```
-
-```{r, bar-plot-param2-facet, fig.cap="Parameter extraction bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
-param_2_diff_bar + 
-  ggplot2::facet_wrap(facets = ggplot2::vars(dist)) +
-  ggplot2::theme(strip.background = ggplot2::element_blank())
-```
-
 ## Extraction by median and range
 
 The same analysis as above can be repeated, this time using the other summary
@@ -233,14 +181,11 @@ as this can impact the possible range exhibited by the data.
 Set up the parameter space:
 
 ```{r, set-up-parameter-space-med-range}
-distributions <- c("gamma", "lnorm", "weibull")
-dist_parameters <- seq(0.5, 2, 0.5)
 n_samples <- c(10, 50, 100)
-
-parameters <- expand.grid(
-  dist = distributions, 
-  param_1 = dist_parameters, 
-  param_2 = dist_parameters, 
+parameters_range <- expand.grid(
+  dist = distributions, # same as above
+  param_1 = dist_parameters, # same as above
+  param_2 = dist_parameters, # same as above
   n_samples = n_samples
 )
 ```
@@ -248,45 +193,44 @@ parameters <- expand.grid(
 ```{r run-extraction-med-range}
 estim_params <- list()
 # Loop through parameter space estimating parameters
-for (params_idx in seq_len(nrow(parameters))) {
+for (params_idx in seq_len(nrow(parameters_range))) {
   
-  dist <- as.character(parameters[params_idx, "dist"])
-  
-  n_samples <- parameters[params_idx, "n_samples"]
+  dist <- as.character(parameters_range[params_idx, "dist"])
+  n_samples <- parameters_range[params_idx, "n_samples"]
   
   if (dist == "lnorm") {
     true_median <- do.call(
-      paste0("q", dist), 
+      paste0("q", dist),
       list(
-        p = 0.5, 
-        meanlog = parameters[params_idx, "param_1"], 
-        sdlog = parameters[params_idx, "param_2"]
+        p = 0.5,
+        meanlog = parameters_range[params_idx, "param_1"],
+        sdlog = parameters_range[params_idx, "param_2"]
       )
     )
     true_range <- do.call(
-      paste0("r", dist), 
+      paste0("r", dist),
       list(
         n = n_samples,
-        meanlog = parameters[params_idx, "param_1"], 
-        sdlog = parameters[params_idx, "param_2"]
+        meanlog = parameters_range[params_idx, "param_1"],
+        sdlog = parameters_range[params_idx, "param_2"]
       )
     )
     true_range <- c(min(true_range), max(true_range))
   } else {
     true_median <- do.call(
-      paste0("q", dist), 
+      paste0("q", dist),
       list(
-        p = 0.5, 
-        shape = parameters[params_idx, "param_1"], 
-        scale = parameters[params_idx, "param_2"]
+        p = 0.5,
+        shape = parameters_range[params_idx, "param_1"],
+        scale = parameters_range[params_idx, "param_2"]
       )
     )
     true_range <- do.call(
-      paste0("r", dist), 
+      paste0("r", dist),
       list(
         n = n_samples,
-        shape = parameters[params_idx, "param_1"], 
-        scale = parameters[params_idx, "param_2"]
+        shape = parameters_range[params_idx, "param_1"],
+        scale = parameters_range[params_idx, "param_2"]
       )
     )
     true_range <- c(min(true_range), max(true_range))
@@ -296,20 +240,19 @@ for (params_idx in seq_len(nrow(parameters))) {
   
   # message about stochastic optimisation suppressed
   estim_params[[params_idx]] <- suppressMessages(
-    epiparameter::extract_param(
+    expr =  epiparameter::extract_param(
       type = "range",
-      values = true_values, 
-      distribution = dist, 
-      samples = n_samples, 
+      values = true_values,
+      distribution = dist,
+      samples = n_samples,
       control = list(tolerance = 10)
     )
   )
 }
-```
 
-```{r, tidy-results-med-range}
 # combine results
-results <- cbind(parameters, do.call(rbind, estim_params))
+results <- cbind(parameters_range, do.call(rbind, estim_params))
+
 colnames(results) <- c(
   "dist", "param_1", "param_2", "n_samples", "estim_param_1", "estim_param_2"
 )
@@ -328,7 +271,13 @@ Plot results:
 
 # plot differences by distribution
 ggplot2::ggplot(data = results) +
-  ggplot2::geom_point(mapping = ggplot2::aes(x = diff_param_1, y = diff_param_2, colour = n_samples)) +
+  ggplot2::geom_point(
+    mapping = ggplot2::aes(
+      x = diff_param_1, 
+      y = diff_param_2, 
+      colour = n_samples
+    )
+  ) +
   ggplot2::scale_x_continuous(name = "Parameter 1 Difference (|true - estimated|)") +
   ggplot2::scale_y_continuous(name = "Parameter 2 Difference (|true - estimated|)") +
   ggplot2::labs(colour = "No. Samples") + 
@@ -339,52 +288,6 @@ ggplot2::ggplot(data = results) +
 
 ```
 
-```{r, pivot-results-med-range}
-# tidy parameter differences to plot side-by-side
-results <- tidyr::pivot_longer(
-  data = results, cols = c("diff_param_1", "diff_param_2"), 
-  names_to = "diff_param", 
-  values_to = "diff"
-)
-```
-
-
-```{r, bar-plots}
-# bar plot for parameter 1 differences
-param_1_diff_bar <- ggplot2::ggplot(data = results) +
-  ggplot2::geom_col(mapping = ggplot2::aes(x = param_1, y = diff, fill = diff_param), position = "dodge") +
-  ggplot2::scale_x_continuous(name = "Parameter 1 true value") +
-  ggplot2::scale_y_continuous(name = "Parameter Difference (|true - estimated|)") +
-  ggplot2::scale_fill_brewer(labels = c("Parameter 1", "Parameter 2"), palette = "Set1") +
-  ggplot2::labs(fill = "Parameter Difference") + 
-  ggplot2::theme_bw() 
-param_1_diff_bar
-```
-
-```{r}
-param_1_diff_bar + 
-  ggplot2::facet_wrap(facets = ggplot2::vars(dist)) +
-  ggplot2::theme(strip.background = ggplot2::element_blank())
-```
-
-```{r}
-# bar plot for parameter 2 differences
-param_2_diff_bar <- ggplot2::ggplot(data = results) +
-  ggplot2::geom_col(mapping = ggplot2::aes(x = param_2, y = diff, fill = diff_param), position = "dodge") +
-  ggplot2::scale_x_continuous(name = "Parameter 2 true value") +
-  ggplot2::scale_y_continuous(name = "Parameter Difference (|true - estimated|)") +
-  ggplot2::scale_fill_brewer(labels = c("Parameter 1", "Parameter 2"), palette = "Set1") +
-  ggplot2::labs(fill = "Parameter Difference") + 
-  ggplot2::theme_bw()
-param_2_diff_bar
-```
-
-```{r}
-param_2_diff_bar + 
-  ggplot2::facet_wrap(facets = ggplot2::vars(dist)) +
-  ggplot2::theme(strip.background = ggplot2::element_blank())
-```
-
 ## Extraction stability
 
 The two analyses above used a single extraction (replicate), however, it may be that
@@ -393,93 +296,62 @@ range. Therefore, we finish with a test of whether repeated extraction of parame
 from a single percentile has large variance which would indicate the parameter extraction
 is unstable and potentially untrustworthy.
 
+We use the same parameter space for percentiles as defined above 
+(`parameters_perc`). Now we can run the extraction for a set of replicates to 
+compute the variance of parameter estimates over those replicates.
 
-```{r, setup-parameter-space-stability}
-distributions <- c("gamma", "lnorm", "weibull")
-dist_parameters <- seq(0.5, 2, 0.5)
-lower_percentiles <- c(2.5, 5, 25, 40)
-upper_percentiles <- c(60, 95, 97.5)
-
-parameters <- expand.grid(
-  dist = distributions, 
-  param_1 = dist_parameters, 
-  param_2 = dist_parameters, 
-  lower = lower_percentiles, 
-  upper = upper_percentiles
-)
-
-# calculate the degree of asymmetry for each percentile combination
-lw_interval_diff <- abs(0 - parameters$lower)
-up_interval_diff <- abs(100 - parameters$upper)
-deg_asym <- abs(lw_interval_diff - up_interval_diff)
-
-# add degree of asymmetry to percentiles
-parameters <- cbind(parameters, deg_asym)
-
-# divide percentiles by 100 to make them probabilities for quantile functions
-parameters$lower <- parameters$lower / 100
-parameters$upper <- parameters$upper / 100
-```
-
-Now we can run the extraction for a set of replicates to compute the variance of
-parameter estimates over those replicates.
-
-```{r, run-extraction-stability}
-estim_params_var <- list()
+```{r, run-extraction-stability-percentile}
+estim_param_var <- list()
 # Loop through parameter space estimating parameters
-for (params_idx in seq_len(nrow(parameters))) {
+for (params_idx in seq_len(nrow(parameters_perc))) {
   
-  percen <- unname(unlist(parameters[params_idx, c("lower", "upper")]))
-  
-  dist <- as.character(parameters[params_idx, "dist"])
+  dist <- as.character(parameters_perc[params_idx, "dist"])
+  percen <- unname(unlist(parameters_perc[params_idx, c("lower", "upper")]))
   
   if (dist == "lnorm") {
     true_values <- do.call(
-      paste0("q", dist), 
+      paste0("q", dist),
       list(
-        p = percen, 
-        meanlog = parameters[params_idx, "param_1"], 
-        sdlog = parameters[params_idx, "param_2"]
+        p = percen,
+        meanlog = parameters_perc[params_idx, "param_1"],
+        sdlog = parameters_perc[params_idx, "param_2"]
       )
     )
   } else {
     true_values <- do.call(
-      paste0("q", dist), 
+      paste0("q", dist),
       list(
-        p = percen, 
-        shape = parameters[params_idx, "param_1"], 
-        scale = parameters[params_idx, "param_2"]
+        p = percen,
+        shape = parameters_perc[params_idx, "param_1"],
+        scale = parameters_perc[params_idx, "param_2"]
       )
-    )  
+    )
   }
   
   # message about stochastic optimisation suppressed
-  
-  estim_params <- suppressMessages(
-    replicate(
-      n = 5, 
-      expr =  epiparameter::extract_param(
-        type = "percentiles",
-        values = true_values, 
-        distribution = dist, 
-        percentiles = percen * 100, 
-        control = list(tolerance = 10)
+
+    estim <- suppressMessages(
+      replicate(
+        n = 5,
+        expr =  epiparameter::extract_param(
+          type = "percentiles",
+          values = true_values,
+          distribution = dist,
+          percentiles = percen,
+          control = list(tolerance = 10)
+        )
       )
     )
-  )
-  
-  estim_params_var[[params_idx]] <- apply(estim_params,MARGIN = 1, FUN = var)
+    estim_param_var[[params_idx]] <- apply(estim, MARGIN = 1, FUN = var)
 }
-```
-
-```{r, tidy-results-stability}
 
 # combine results
-results <- cbind(parameters, do.call(rbind, estim_params_var))
+results <- cbind(parameters_perc, do.call(rbind, estim_param_var))
+
 colnames(results) <- c(
   "dist", "param_1", "param_2", "lower", "upper", 
   "deg_asym", "estim_param_1_var", "estim_param_2_var"
-)
+)  
 ```
 
 ```{r, plot-results, fig.cap="Parameter extraction stability, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
@@ -489,11 +361,105 @@ ggplot2::ggplot(data = results) +
     y = estim_param_2_var, 
     colour = deg_asym
   )) + 
-  ggplot2::scale_x_continuous(name = "Parameter 1 Difference (|true - estimated|)") +
-  ggplot2::scale_y_continuous(name = "Parameter 2 Difference (|true - estimated|)") +
+  ggplot2::scale_x_continuous(name = "Parameter 1 Variance") +
+  ggplot2::scale_y_continuous(name = "Parameter 2 Variance") +
   ggplot2::labs(colour = "Percentile Asym.") + 
   ggplot2::theme_bw() +
   ggplot2::scale_color_viridis_c() + 
   ggplot2::facet_wrap(facets = ggplot2::vars(dist), scales = "free") +
   ggplot2::theme(strip.background = ggplot2::element_blank())
 ```
+
+
+The same test of estimation consistency can be performed for the extraction from median and range.
+
+
+```{r, run-extraction-stability-range}
+estim_param_var <- list()
+# Loop through parameter space estimating parameters
+for (params_idx in seq_len(nrow(parameters_range))) {
+  
+  dist <- as.character(parameters_range[params_idx, "dist"])
+  n_samples <- parameters_range[params_idx, "n_samples"]
+  
+  if (dist == "lnorm") {
+    true_median <- do.call(
+      paste0("q", dist),
+      list(
+        p = 0.5,
+        meanlog = parameters_range[params_idx, "param_1"],
+        sdlog = parameters_range[params_idx, "param_2"]
+      )
+    )
+    true_range <- do.call(
+      paste0("r", dist),
+      list(
+        n = n_samples,
+        meanlog = parameters_range[params_idx, "param_1"],
+        sdlog = parameters_range[params_idx, "param_2"]
+      )
+    )
+    true_range <- c(min(true_range), max(true_range))
+  } else {
+    true_median <- do.call(
+      paste0("q", dist),
+      list(
+        p = 0.5,
+        shape = parameters_range[params_idx, "param_1"],
+        scale = parameters_range[params_idx, "param_2"]
+      )
+    )
+    true_range <- do.call(
+      paste0("r", dist),
+      list(
+        n = n_samples,
+        shape = parameters_range[params_idx, "param_1"],
+        scale = parameters_range[params_idx, "param_2"]
+      )
+    )
+    true_range <- c(min(true_range), max(true_range))
+  }
+  
+  true_values <- c(true_median, true_range)
+  
+  # message about stochastic optimisation suppressed
+  estim <- suppressMessages(
+    replicate(
+      n = 5,
+      expr =  epiparameter::extract_param(
+        type = "range",
+        values = true_values,
+        distribution = dist,
+        samples = n_samples,
+        control = list(tolerance = 10)
+      )
+    )
+  )
+  estim_param_var[[params_idx]] <- apply(estim, MARGIN = 1, FUN = var)
+}
+
+# combine results
+results <- cbind(parameters_range, do.call(rbind, estim_param_var))
+
+colnames(results) <- c(
+  "dist", "param_1", "param_2", "n_samples", "estim_param_1_var", 
+  "estim_param_2_var"
+)  
+```
+
+```{r, plot-estim-var-range, fig.cap="Parameter extraction stability, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
+ggplot2::ggplot(data = results) +
+  ggplot2::geom_point(mapping = ggplot2::aes(
+    x = estim_param_1_var, 
+    y = estim_param_2_var, 
+    colour = n_samples
+  )) + 
+  ggplot2::scale_x_continuous(name = "Parameter 1 Variance") +
+  ggplot2::scale_y_continuous(name = "Parameter 2 Variance") +
+  ggplot2::labs(colour = "No. Samples") + 
+  ggplot2::theme_bw() +
+  ggplot2::scale_color_viridis_c() + 
+  ggplot2::facet_wrap(facets = ggplot2::vars(dist), scales = "free") +
+  ggplot2::theme(strip.background = ggplot2::element_blank())
+```
+

--- a/vignettes/extract-bias.Rmd
+++ b/vignettes/extract-bias.Rmd
@@ -95,9 +95,7 @@ removing the seed should not drastically change the results or interpretation.
 set.seed(1)
 ```
 
-We define a function that can be reused throughout the vignette.
-
-```{r, define-run-extraction}
+```{r, run-extraction-percentile}
 estim_params <- list()
 # Loop through parameter space estimating parameters
 for (params_idx in seq_len(nrow(parameters_perc))) {
@@ -124,7 +122,7 @@ for (params_idx in seq_len(nrow(parameters_perc))) {
       )
     )
   }
-
+  
   # message about stochastic optimisation suppressed
   estim_params[[params_idx]] <- suppressMessages(
     extract_param(
@@ -135,7 +133,6 @@ for (params_idx in seq_len(nrow(parameters_perc))) {
       control = list(tolerance = 10)
     )
   )
-
 }
 
 # combine results
@@ -180,12 +177,7 @@ ggplot(data = results) +
   theme(strip.background = element_blank())
 ```
 
-The magnitude of the error is larger for parameter 1 (see axis breaks) which is either
-shape or meanlog depending on the distribution, than for parameter 2, which is either scale
-or sdlog. There is no clear pattern of higher asymmetry in percentiles resulting in higher
-bias in parameter extraction.
-
-## Extraction by median and range
+### Extraction by median and range
 
 The same analysis as above can be repeated, this time using the other summary
 statistic possibly reported in studies: an inferred distribution's median and range.
@@ -282,7 +274,6 @@ results <- cbind(
 Plot results:
 
 ```{r, plot-results-med-range, fig.cap="Parameter extraction bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
-
 # plot differences by distribution
 ggplot(data = results) +
   geom_point(
@@ -345,20 +336,19 @@ for (params_idx in seq_len(nrow(parameters_perc))) {
   }
   
   # message about stochastic optimisation suppressed
-
-    estim <- suppressMessages(
-      replicate(
-        n = 5,
-        expr =  extract_param(
-          type = "percentiles",
-          values = true_values,
-          distribution = dist,
-          percentiles = percen,
-          control = list(tolerance = 10)
-        )
+  estim <- suppressMessages(
+    replicate(
+      n = 5,
+      expr =  extract_param(
+        type = "percentiles",
+        values = true_values,
+        distribution = dist,
+        percentiles = percen,
+        control = list(tolerance = 10)
       )
     )
-    estim_param_var[[params_idx]] <- apply(estim, MARGIN = 1, FUN = var)
+  )
+  estim_param_var[[params_idx]] <- apply(estim, MARGIN = 1, FUN = var)
 }
 
 # combine results
@@ -479,4 +469,3 @@ ggplot(data = results) +
   facet_wrap(facets = vars(dist), scales = "free") +
   theme(strip.background = element_blank())
 ```
-

--- a/vignettes/extract-bias.Rmd
+++ b/vignettes/extract-bias.Rmd
@@ -145,9 +145,9 @@ results <- cbind(
 
 The extraction precision/bias can be explored:
 
-```{r, plot-results-percentiles, fig.cap="Parameter extraction bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
-# plot differences
-param_diff_plot <- ggplot2::ggplot(data = results) +
+```{r, plot-results-percentiles, fig.cap="Parameter estimation bias facetted by distribution. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
+# plot differences by distribution
+ggplot2::ggplot(data = results) +
   ggplot2::geom_point(mapping = ggplot2::aes(
     x = diff_param_1, 
     y = diff_param_2, 
@@ -157,22 +157,15 @@ param_diff_plot <- ggplot2::ggplot(data = results) +
   ggplot2::scale_y_continuous(name = "Parameter 2 Difference (|true - estimated|)") +
   ggplot2::labs(colour = "Percentile Asym.") + 
   ggplot2::theme_bw() +
-  ggplot2::scale_color_viridis_c()
-
-param_diff_plot
+  ggplot2::scale_color_viridis_c() +
+  ggplot2::facet_wrap(facets = ggplot2::vars(dist), scales = "free") +
+  ggplot2::theme(strip.background = ggplot2::element_blank())
 ```
 
 The magnitude of the error is larger for parameter 1 (see axis breaks) which is either
 shape or meanlog depending on the distribution, than for parameter 2, which is either scale
 or sdlog. There is no clear pattern of higher asymmetry in percentiles resulting in higher
 bias in parameter extraction.
-
-```{r, plot-results-percentiles-dist, fig.cap="Parameter estimation bias facetted by distribution. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
-# plot differences by distribution
-param_diff_plot + 
-  ggplot2::facet_wrap(facets = ggplot2::vars(dist), scales = "free") +
-  ggplot2::theme(strip.background = ggplot2::element_blank())
-```
 
 ```{r, pivot-results-percentiles}
 # tidy parameter differences to plot side-by-side
@@ -332,23 +325,16 @@ results <- cbind(
 Plot results:
 
 ```{r, plot-results-med-range, fig.cap="Parameter extraction bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
-# plot differences
-param_diff_plot <- ggplot2::ggplot(data = results) +
+
+# plot differences by distribution
+ggplot2::ggplot(data = results) +
   ggplot2::geom_point(mapping = ggplot2::aes(x = diff_param_1, y = diff_param_2, colour = n_samples)) +
   ggplot2::scale_x_continuous(name = "Parameter 1 Difference (|true - estimated|)") +
   ggplot2::scale_y_continuous(name = "Parameter 2 Difference (|true - estimated|)") +
   ggplot2::labs(colour = "No. Samples") + 
   ggplot2::theme_bw() +
-  ggplot2::scale_color_viridis_c()
-
-param_diff_plot
-```
-
-```{r, plot-results-med-range-dist, fig.cap="Parameter extraction bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
-
-# plot differences by distribution
-param_diff_plot + 
-  ggplot2::facet_wrap(facets = ggplot2::vars(dist)) +
+  ggplot2::scale_color_viridis_c() + 
+  ggplot2::facet_wrap(facets = ggplot2::vars(dist), scales = "free") +
   ggplot2::theme(strip.background = ggplot2::element_blank())
 
 ```
@@ -496,9 +482,8 @@ colnames(results) <- c(
 )
 ```
 
-```{r, plot-results, fig.cap="Parameter extraction stability. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
-# plot differences
-param_diff_plot <- ggplot2::ggplot(data = results) +
+```{r, plot-results, fig.cap="Parameter extraction stability, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
+ggplot2::ggplot(data = results) +
   ggplot2::geom_point(mapping = ggplot2::aes(
     x = estim_param_1_var, 
     y = estim_param_2_var, 
@@ -508,13 +493,7 @@ param_diff_plot <- ggplot2::ggplot(data = results) +
   ggplot2::scale_y_continuous(name = "Parameter 2 Difference (|true - estimated|)") +
   ggplot2::labs(colour = "Percentile Asym.") + 
   ggplot2::theme_bw() +
-  ggplot2::scale_color_viridis_c()
-
-param_diff_plot
-```
-
-```{r, fig.cap="Parameter extraction stability, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
-param_diff_plot + 
-  ggplot2::facet_wrap(facets = ggplot2::vars(dist)) +
+  ggplot2::scale_color_viridis_c() + 
+  ggplot2::facet_wrap(facets = ggplot2::vars(dist), scales = "free") +
   ggplot2::theme(strip.background = ggplot2::element_blank())
 ```

--- a/vignettes/extract-bias.Rmd
+++ b/vignettes/extract-bias.Rmd
@@ -24,10 +24,11 @@ library(epiparameter)
 ```
 
 The {epiparameter} R package contains a set of functions to extract parameters
-of probability distributions from summary statistics. These summary statistics can
+of probability distributions given a set of summary statistics. These summary statistics can
 be the values at given percentiles of a distribution, or the median and range of
-a distribution. Using these and specifying the distribution (e.g. gamma, lognormal, etc.)
-the parameters of the distribution can be extracted by optimisation using least-squares.
+a data set to which a distribution can be fit. Using these and specifying the distribution 
+(e.g. gamma, lognormal, etc.) the parameters of the distribution can be extracted by 
+optimisation using least-squares.
 
 The precision and bias of this approach needs to be explored across the parameter space
 of the different distributions to understand potential erroneous inferences. This
@@ -144,7 +145,7 @@ results <- cbind(
 
 The extraction precision/bias can be explored:
 
-```{r, plot-results-percentiles, fig.cap="Parameter extraction precision"}
+```{r, plot-results-percentiles, fig.cap="Parameter extraction bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
 # plot differences
 param_diff_plot <- ggplot2::ggplot(data = results) +
   ggplot2::geom_point(mapping = ggplot2::aes(
@@ -159,13 +160,17 @@ param_diff_plot <- ggplot2::ggplot(data = results) +
   ggplot2::scale_color_viridis_c()
 
 param_diff_plot
-
 ```
 
-```{r, plot-results-percentiles-dist, fig.cap="Parameter extraction precision by distribution", fig.cap="Parameter estimation precision facetted by distribution."}
+The magnitude of the error is larger for parameter 1 (see axis breaks) which is either
+shape or meanlog depending on the distribution, than for parameter 2, which is either scale
+or sdlog. There is no clear pattern of higher asymmetry in percentiles resulting in higher
+bias in parameter extraction.
+
+```{r, plot-results-percentiles-dist, fig.cap="Parameter estimation bias facetted by distribution. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
 # plot differences by distribution
 param_diff_plot + 
-  ggplot2::facet_wrap(facets = ggplot2::vars(dist)) +
+  ggplot2::facet_wrap(facets = ggplot2::vars(dist), scales = "free") +
   ggplot2::theme(strip.background = ggplot2::element_blank())
 ```
 
@@ -178,31 +183,51 @@ results <- tidyr::pivot_longer(
 )
 ```
 
-```{r, bar-plot}
+To determine whether the bias in parameter estimates varies across true values
+of the underlying distribution parameters, the plots below show the bias at
+each simulated value of either the shape -- for gamma and weibull -- or meanlog
+for lognormal.
+
+```{r, bar-plot-param1, fig.cap="Parameter estimation bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
 # bar plot for parameter 1 differences
 param_1_diff_bar <- ggplot2::ggplot(data = results) +
-  ggplot2::geom_col(mapping = ggplot2::aes(x = param_1, y = diff, fill = diff_param), position = "dodge") +
+  ggplot2::geom_col(
+    mapping = ggplot2::aes(
+      x = param_1, 
+      y = diff, 
+      fill = diff_param), 
+    position = "dodge"
+  ) +
   ggplot2::scale_x_continuous(name = "Parameter 1 true value") +
   ggplot2::scale_y_continuous(name = "Parameter Difference (|true - estimated|)") +
   ggplot2::scale_fill_brewer(labels = c("Parameter 1", "Parameter 2"), palette = "Set1") +
-  ggplot2::labs(fill = "Parameter Difference")
+  ggplot2::labs(fill = "Parameter Difference") +
+  ggplot2::theme_bw()
 param_1_diff_bar
+```
 
+```{r, bar-plot-param1-facet, fig.cap="Parameter extraction bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
 param_1_diff_bar + 
-  ggplot2::facet_wrap(facets = ggplot2::vars(dist))
+  ggplot2::facet_wrap(facets = ggplot2::vars(dist)) +
+  ggplot2::theme(strip.background = ggplot2::element_blank())
+```
 
+```{r, bar-plot-param2, fig.cap="Parameter extraction bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
 # bar plot for parameter 2 differences
 param_2_diff_bar <- ggplot2::ggplot(data = results) +
   ggplot2::geom_col(mapping = ggplot2::aes(x = param_2, y = diff, fill = diff_param), position = "dodge") +
   ggplot2::scale_x_continuous(name = "Parameter 2 true value") +
   ggplot2::scale_y_continuous(name = "Parameter Difference (|true - estimated|)") +
   ggplot2::scale_fill_brewer(labels = c("Parameter 1", "Parameter 2"), palette = "Set1") +
-  ggplot2::labs(fill = "Parameter Difference")
+  ggplot2::labs(fill = "Parameter Difference") + 
+  ggplot2::theme_bw()
 param_2_diff_bar
+```
 
+```{r, bar-plot-param2-facet, fig.cap="Parameter extraction bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
 param_2_diff_bar + 
-  ggplot2::facet_wrap(facets = ggplot2::vars(dist))
-
+  ggplot2::facet_wrap(facets = ggplot2::vars(dist)) +
+  ggplot2::theme(strip.background = ggplot2::element_blank())
 ```
 
 ## Extraction by median and range
@@ -306,7 +331,7 @@ results <- cbind(
 
 Plot results:
 
-```{r, plot-results-med-range, fig.cap="Parameter extraction precision."}
+```{r, plot-results-med-range, fig.cap="Parameter extraction bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
 # plot differences
 param_diff_plot <- ggplot2::ggplot(data = results) +
   ggplot2::geom_point(mapping = ggplot2::aes(x = diff_param_1, y = diff_param_2, colour = n_samples)) +
@@ -317,10 +342,9 @@ param_diff_plot <- ggplot2::ggplot(data = results) +
   ggplot2::scale_color_viridis_c()
 
 param_diff_plot
-
 ```
 
-```{r, plot-results-med-range-dist, fig.cap="Parameter extraction precision facetted by distribution."}
+```{r, plot-results-med-range-dist, fig.cap="Parameter extraction bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
 
 # plot differences by distribution
 param_diff_plot + 
@@ -346,23 +370,33 @@ param_1_diff_bar <- ggplot2::ggplot(data = results) +
   ggplot2::scale_x_continuous(name = "Parameter 1 true value") +
   ggplot2::scale_y_continuous(name = "Parameter Difference (|true - estimated|)") +
   ggplot2::scale_fill_brewer(labels = c("Parameter 1", "Parameter 2"), palette = "Set1") +
-  ggplot2::labs(fill = "Parameter Difference")
+  ggplot2::labs(fill = "Parameter Difference") + 
+  ggplot2::theme_bw() 
 param_1_diff_bar
+```
 
+```{r}
 param_1_diff_bar + 
-  ggplot2::facet_wrap(facets = ggplot2::vars(dist))
+  ggplot2::facet_wrap(facets = ggplot2::vars(dist)) +
+  ggplot2::theme(strip.background = ggplot2::element_blank())
+```
 
+```{r}
 # bar plot for parameter 2 differences
 param_2_diff_bar <- ggplot2::ggplot(data = results) +
   ggplot2::geom_col(mapping = ggplot2::aes(x = param_2, y = diff, fill = diff_param), position = "dodge") +
   ggplot2::scale_x_continuous(name = "Parameter 2 true value") +
   ggplot2::scale_y_continuous(name = "Parameter Difference (|true - estimated|)") +
   ggplot2::scale_fill_brewer(labels = c("Parameter 1", "Parameter 2"), palette = "Set1") +
-  ggplot2::labs(fill = "Parameter Difference")
+  ggplot2::labs(fill = "Parameter Difference") + 
+  ggplot2::theme_bw()
 param_2_diff_bar
+```
 
+```{r}
 param_2_diff_bar + 
-  ggplot2::facet_wrap(facets = ggplot2::vars(dist))
+  ggplot2::facet_wrap(facets = ggplot2::vars(dist)) +
+  ggplot2::theme(strip.background = ggplot2::element_blank())
 ```
 
 ## Extraction stability
@@ -462,7 +496,7 @@ colnames(results) <- c(
 )
 ```
 
-```{r, plot-results}
+```{r, plot-results, fig.cap="Parameter extraction stability. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
 # plot differences
 param_diff_plot <- ggplot2::ggplot(data = results) +
   ggplot2::geom_point(mapping = ggplot2::aes(
@@ -479,5 +513,8 @@ param_diff_plot <- ggplot2::ggplot(data = results) +
 param_diff_plot
 ```
 
-
-
+```{r, fig.cap="Parameter extraction stability, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
+param_diff_plot + 
+  ggplot2::facet_wrap(facets = ggplot2::vars(dist)) +
+  ggplot2::theme(strip.background = ggplot2::element_blank())
+```

--- a/vignettes/extract-bias.Rmd
+++ b/vignettes/extract-bias.Rmd
@@ -173,7 +173,10 @@ ggplot(data = results) +
   theme_bw() +
   scale_color_viridis_c() +
   facet_wrap(facets = vars(dist), scales = "free") +
-  theme(strip.background = element_blank())
+  theme(
+    strip.background = element_blank(), 
+    axis.text.x = element_text(angle = 30, vjust = 0.5)
+  )
 ```
 
 ### Extraction by median and range
@@ -287,7 +290,10 @@ ggplot(data = results) +
   theme_bw() +
   scale_color_viridis_c() +
   facet_wrap(facets = vars(dist), scales = "free") +
-  theme(strip.background = element_blank())
+  theme(
+    strip.background = element_blank(), 
+    axis.text.x = element_text(angle = 30, vjust = 0.5)
+  )
 
 ```
 
@@ -370,7 +376,10 @@ ggplot(data = results) +
   theme_bw() +
   scale_color_viridis_c() +
   facet_wrap(facets = vars(dist), scales = "free") +
-  theme(strip.background = element_blank())
+  theme(
+    strip.background = element_blank(),
+    axis.text.x = element_text(angle = 30, vjust = 0.5)
+  )
 ```
 
 ### Extraction by median and range
@@ -463,7 +472,10 @@ ggplot(data = results) +
   theme_bw() +
   scale_color_viridis_c() +
   facet_wrap(facets = vars(dist), scales = "free") +
-  theme(strip.background = element_blank())
+  theme(
+    strip.background = element_blank(),
+    axis.text.x = element_text(angle = 30, vjust = 0.5)
+  )
 ```
 
 ::: {.alert .alert-primary}

--- a/vignettes/extract-bias.Rmd
+++ b/vignettes/extract-bias.Rmd
@@ -21,6 +21,7 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 library(epiparameter)
+library(ggplot2)
 ```
 
 The {epiparameter} R package contains a set of functions to extract parameters
@@ -113,7 +114,7 @@ for (params_idx in seq_len(nrow(parameters_perc))) {
 
   # message about stochastic optimisation suppressed
   estim_params[[params_idx]] <- suppressMessages(
-    epiparameter::extract_param(
+    extract_param(
       type = "percentiles",
       values = true_values,
       distribution = dist,
@@ -151,19 +152,19 @@ The extraction precision/bias can be explored:
 
 ```{r, plot-results-percentiles, fig.cap="Parameter estimation bias facetted by distribution. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
 # plot differences by distribution
-ggplot2::ggplot(data = results) +
-  ggplot2::geom_point(mapping = ggplot2::aes(
+ggplot(data = results) +
+  geom_point(mapping = aes(
     x = diff_param_1, 
     y = diff_param_2, 
     colour = deg_asym
   )) + 
-  ggplot2::scale_x_continuous(name = "Parameter 1 Difference (|true - estimated|)") +
-  ggplot2::scale_y_continuous(name = "Parameter 2 Difference (|true - estimated|)") +
-  ggplot2::labs(colour = "Percentile Asym.") + 
-  ggplot2::theme_bw() +
-  ggplot2::scale_color_viridis_c() +
-  ggplot2::facet_wrap(facets = ggplot2::vars(dist), scales = "free") +
-  ggplot2::theme(strip.background = ggplot2::element_blank())
+  scale_x_continuous(name = "Parameter 1 Difference (|true - estimated|)") +
+  scale_y_continuous(name = "Parameter 2 Difference (|true - estimated|)") +
+  labs(colour = "Percentile Asym.") + 
+  theme_bw() +
+  scale_color_viridis_c() +
+  facet_wrap(facets = vars(dist), scales = "free") +
+  theme(strip.background = element_blank())
 ```
 
 The magnitude of the error is larger for parameter 1 (see axis breaks) which is either
@@ -240,7 +241,7 @@ for (params_idx in seq_len(nrow(parameters_range))) {
   
   # message about stochastic optimisation suppressed
   estim_params[[params_idx]] <- suppressMessages(
-    expr =  epiparameter::extract_param(
+    expr =  extract_param(
       type = "range",
       values = true_values,
       distribution = dist,
@@ -270,21 +271,21 @@ Plot results:
 ```{r, plot-results-med-range, fig.cap="Parameter extraction bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
 
 # plot differences by distribution
-ggplot2::ggplot(data = results) +
-  ggplot2::geom_point(
-    mapping = ggplot2::aes(
+ggplot(data = results) +
+  geom_point(
+    mapping = aes(
       x = diff_param_1, 
       y = diff_param_2, 
       colour = n_samples
     )
   ) +
-  ggplot2::scale_x_continuous(name = "Parameter 1 Difference (|true - estimated|)") +
-  ggplot2::scale_y_continuous(name = "Parameter 2 Difference (|true - estimated|)") +
-  ggplot2::labs(colour = "No. Samples") + 
-  ggplot2::theme_bw() +
-  ggplot2::scale_color_viridis_c() + 
-  ggplot2::facet_wrap(facets = ggplot2::vars(dist), scales = "free") +
-  ggplot2::theme(strip.background = ggplot2::element_blank())
+  scale_x_continuous(name = "Parameter 1 Difference (|true - estimated|)") +
+  scale_y_continuous(name = "Parameter 2 Difference (|true - estimated|)") +
+  labs(colour = "No. Samples") + 
+  theme_bw() +
+  scale_color_viridis_c() + 
+  facet_wrap(facets = vars(dist), scales = "free") +
+  theme(strip.background = element_blank())
 
 ```
 
@@ -333,7 +334,7 @@ for (params_idx in seq_len(nrow(parameters_perc))) {
     estim <- suppressMessages(
       replicate(
         n = 5,
-        expr =  epiparameter::extract_param(
+        expr =  extract_param(
           type = "percentiles",
           values = true_values,
           distribution = dist,
@@ -355,19 +356,19 @@ colnames(results) <- c(
 ```
 
 ```{r, plot-results, fig.cap="Parameter extraction stability, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
-ggplot2::ggplot(data = results) +
-  ggplot2::geom_point(mapping = ggplot2::aes(
+ggplot(data = results) +
+  geom_point(mapping = aes(
     x = estim_param_1_var, 
     y = estim_param_2_var, 
     colour = deg_asym
   )) + 
-  ggplot2::scale_x_continuous(name = "Parameter 1 Variance") +
-  ggplot2::scale_y_continuous(name = "Parameter 2 Variance") +
-  ggplot2::labs(colour = "Percentile Asym.") + 
-  ggplot2::theme_bw() +
-  ggplot2::scale_color_viridis_c() + 
-  ggplot2::facet_wrap(facets = ggplot2::vars(dist), scales = "free") +
-  ggplot2::theme(strip.background = ggplot2::element_blank())
+  scale_x_continuous(name = "Parameter 1 Variance") +
+  scale_y_continuous(name = "Parameter 2 Variance") +
+  labs(colour = "Percentile Asym.") + 
+  theme_bw() +
+  scale_color_viridis_c() + 
+  facet_wrap(facets = vars(dist), scales = "free") +
+  theme(strip.background = element_blank())
 ```
 
 
@@ -426,7 +427,7 @@ for (params_idx in seq_len(nrow(parameters_range))) {
   estim <- suppressMessages(
     replicate(
       n = 5,
-      expr =  epiparameter::extract_param(
+      expr =  extract_param(
         type = "range",
         values = true_values,
         distribution = dist,
@@ -448,18 +449,18 @@ colnames(results) <- c(
 ```
 
 ```{r, plot-estim-var-range, fig.cap="Parameter extraction stability, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
-ggplot2::ggplot(data = results) +
-  ggplot2::geom_point(mapping = ggplot2::aes(
+ggplot(data = results) +
+  geom_point(mapping = aes(
     x = estim_param_1_var, 
     y = estim_param_2_var, 
     colour = n_samples
   )) + 
-  ggplot2::scale_x_continuous(name = "Parameter 1 Variance") +
-  ggplot2::scale_y_continuous(name = "Parameter 2 Variance") +
-  ggplot2::labs(colour = "No. Samples") + 
-  ggplot2::theme_bw() +
-  ggplot2::scale_color_viridis_c() + 
-  ggplot2::facet_wrap(facets = ggplot2::vars(dist), scales = "free") +
-  ggplot2::theme(strip.background = ggplot2::element_blank())
+  scale_x_continuous(name = "Parameter 1 Variance") +
+  scale_y_continuous(name = "Parameter 2 Variance") +
+  labs(colour = "No. Samples") + 
+  theme_bw() +
+  scale_color_viridis_c() + 
+  facet_wrap(facets = vars(dist), scales = "free") +
+  theme(strip.background = element_blank())
 ```
 

--- a/vignettes/extract-bias.Rmd
+++ b/vignettes/extract-bias.Rmd
@@ -96,7 +96,7 @@ set.seed(1)
 ```
 
 ```{r, run-extraction-percentile}
-estim_params <- list()
+estim_params <- vector("list", nrow(parameters_perc))
 # Loop through parameter space estimating parameters
 for (params_idx in seq_len(nrow(parameters_perc))) {
   
@@ -197,7 +197,7 @@ parameters_range <- expand.grid(
 ```
 
 ```{r run-extraction-med-range}
-estim_params <- list()
+estim_params <- vector("list", nrow(parameters_range))
 # Loop through parameter space estimating parameters
 for (params_idx in seq_len(nrow(parameters_range))) {
   
@@ -308,7 +308,7 @@ We use the same parameter space for percentiles as defined above
 compute the variance of parameter estimates over those replicates.
 
 ```{r, run-extraction-stability-percentile}
-estim_param_var <- list()
+estim_param_var <- vector("list", nrow(parameters_perc))
 # Loop through parameter space estimating parameters
 for (params_idx in seq_len(nrow(parameters_perc))) {
   
@@ -382,7 +382,7 @@ The same test of estimation consistency can be performed for the extraction from
 
 
 ```{r, run-extraction-stability-range}
-estim_param_var <- list()
+estim_param_var <- vector("list", nrow(parameters_range))
 # Loop through parameter space estimating parameters
 for (params_idx in seq_len(nrow(parameters_range))) {
   

--- a/vignettes/extract-bias.Rmd
+++ b/vignettes/extract-bias.Rmd
@@ -19,10 +19,10 @@ knitr::opts_chunk$set(
 )
 ```
 
-```{r setup}
-library(epiparameter)
-library(ggplot2)
-```
+::: {.alert .alert-warning}
+If you are unfamiliar with the parameter extraction functionality in {epiparameter} 
+the Conversion and Extraction vignette is a great place to start.
+:::
 
 The {epiparameter} R package contains a set of functions to extract parameters
 of probability distributions given a set of summary statistics. These summary statistics can
@@ -36,7 +36,20 @@ of the different distributions to understand potential erroneous inferences. Thi
 vignette aims to explore this inference bias for the three distribution currently 
 supported in {epiparameter} for parameter extraction: gamma, lognormal and weibull.
 
-## Extraction by percentiles
+::: {.alert .alert-warning}
+This is not an in depth analysis of the estimation methods implemented in {epiparameter}, 
+but rather a supplementary article exploring the bias and consistency of the functions.
+It is specific to the case of {epiparameter} and should not be taken as a generalised results.
+:::
+
+```{r setup}
+library(epiparameter)
+library(ggplot2)
+```
+
+## Extraction Bias
+
+### Extraction by percentiles
 
 First we explore extraction from percentiles.
 
@@ -291,6 +304,8 @@ ggplot(data = results) +
 
 ## Extraction stability
 
+### Extraction by percentiles
+
 The two analyses above used a single extraction (replicate), however, it may be that
 the estimation of the parameters is unstable for a given set of percentiles or median 
 range. Therefore, we finish with a test of whether repeated extraction of parameters 
@@ -371,6 +386,7 @@ ggplot(data = results) +
   theme(strip.background = element_blank())
 ```
 
+### Extraction by median and range
 
 The same test of estimation consistency can be performed for the extraction from median and range.
 

--- a/vignettes/extract-bias.Rmd
+++ b/vignettes/extract-bias.Rmd
@@ -465,3 +465,17 @@ ggplot(data = results) +
   facet_wrap(facets = vars(dist), scales = "free") +
   theme(strip.background = element_blank())
 ```
+
+::: {.alert .alert-primary}
+From the plots in this vignette, the bias is low and precision is high
+when extracting parameters from the gamma, lognormal and Weibull distributions 
+from both percentiles of the distribution and from median and range of a data
+set.
+
+The asymmetry of percentiles and sample size of the data does not noticeably 
+influence the bias in parameter extraction.
+
+However, this does not ensure reliable extract for all use cases of the 
+`extract_param()` function and we recommend checking the output for spurious
+results.
+:::

--- a/vignettes/extract-bias.Rmd
+++ b/vignettes/extract-bias.Rmd
@@ -3,6 +3,8 @@ title: "{epiparameter} Extraction Bias Analysis"
 output: 
   bookdown::html_vignette2:
     fig_caption: yes
+  pkgdown:
+    as_is: true
 vignette: >
   %\VignetteIndexEntry{{epiparameter} Extraction Bias Analysis}
   %\VignetteEngine{knitr::rmarkdown}
@@ -13,9 +15,7 @@ vignette: >
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  fig.width = 6,
-  fig.height = 5,
-  fig.align = 'center'
+  fig.width = 8
 )
 ```
 
@@ -33,8 +33,8 @@ optimisation using least-squares.
 
 The precision and bias of this approach needs to be explored across the parameter space
 of the different distributions to understand potential erroneous inferences. This
-vignette aims to explore this inference bias for the three distribution currently 
-supported in {epiparameter} for parameter extraction: gamma, lognormal and weibull.
+vignette aims to explore this inference bias for the three distributions currently 
+supported in {epiparameter} for parameter extraction: gamma, lognormal and Weibull.
 
 ::: {.alert .alert-warning}
 This is not an in depth analysis of the estimation methods implemented in {epiparameter}, 
@@ -55,7 +55,7 @@ First we explore extraction from percentiles.
 
 If a study reports the percentiles of a distribution, they are usually symmetrical
 (e.g. 5th and 95th, or 2.5th and 97.5th). However, in a few instances, only asymmetrical
-percentiles are available. We test whether asymetry to varying degrees influences the
+percentiles are available. We test whether asymmetry to varying degrees influences the
 precision of parameter extraction for all distributions.
 
 We set up the parameter space to explore:
@@ -129,8 +129,7 @@ for (params_idx in seq_len(nrow(parameters_perc))) {
       type = "percentiles",
       values = true_values,
       distribution = dist,
-      percentiles = percen,
-      control = list(tolerance = 10)
+      percentiles = percen
     )
   )
 }
@@ -151,16 +150,16 @@ results <- cbind(
 )
 ```
 
-In the above code chunk the `extract_param()` function re-runs the optimisation
-until convergence to a set tolerance is achieved to more reliably return the global 
-optimum. For this analysis we set the tolerance to be arbitrarily large (i.e. 10) 
-to meet the convergence criteria immediately in order to save computation time. Therefore
-these results may be more biased than if the function were run with the default tolerance
-(`1e-5`).
+The `extract_param()` function re-runs the optimisation
+until convergence to a set tolerance is achieved (or a maximum number of 
+iterations is reached) to more reliably return the global 
+optimum. In theory, this should help to minimise bias and instability in the 
+parameter estimation. See the function documentation (`?extract_param()`) or 
+the extraction and conversion vignette for more details.
 
 The extraction precision/bias can be explored:
 
-```{r, plot-results-percentiles, fig.cap="Parameter estimation bias facetted by distribution. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
+```{r, plot-results-percentiles, fig.cap="Parameter estimation bias facetted by distribution. Parameter 1 is either the shape parameter, for gamma and Weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and Weibull distributions, or sdlog for the lognormal distribution."}
 # plot differences by distribution
 ggplot(data = results) +
   geom_point(mapping = aes(
@@ -180,7 +179,7 @@ ggplot(data = results) +
 ### Extraction by median and range
 
 The same analysis as above can be repeated, this time using the other summary
-statistic possibly reported in studies: an inferred distribution's median and range.
+statistic possibly reported in studies: median and range of data.
 For this extraction the number of samples used to infer the distribution is required
 as this can impact the possible range exhibited by the data.
 
@@ -250,8 +249,7 @@ for (params_idx in seq_len(nrow(parameters_range))) {
       type = "range",
       values = true_values,
       distribution = dist,
-      samples = n_samples,
-      control = list(tolerance = 10)
+      samples = n_samples
     )
   )
 }
@@ -273,7 +271,7 @@ results <- cbind(
 
 Plot results:
 
-```{r, plot-results-med-range, fig.cap="Parameter extraction bias. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
+```{r, plot-results-med-range, fig.cap="Parameter extraction bias. Parameter 1 is either the shape parameter, for gamma and Weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and Weibull distributions, or sdlog for the lognormal distribution."}
 # plot differences by distribution
 ggplot(data = results) +
   geom_point(
@@ -343,8 +341,7 @@ for (params_idx in seq_len(nrow(parameters_perc))) {
         type = "percentiles",
         values = true_values,
         distribution = dist,
-        percentiles = percen,
-        control = list(tolerance = 10)
+        percentiles = percen
       )
     )
   )
@@ -360,7 +357,7 @@ colnames(results) <- c(
 )  
 ```
 
-```{r, plot-results, fig.cap="Parameter extraction stability, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
+```{r, plot-results, fig.cap="Parameter extraction stability, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and Weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and Weibull distributions, or sdlog for the lognormal distribution."}
 ggplot(data = results) +
   geom_point(mapping = aes(
     x = estim_param_1_var, 
@@ -437,8 +434,7 @@ for (params_idx in seq_len(nrow(parameters_range))) {
         type = "range",
         values = true_values,
         distribution = dist,
-        samples = n_samples,
-        control = list(tolerance = 10)
+        samples = n_samples
       )
     )
   )
@@ -454,7 +450,7 @@ colnames(results) <- c(
 )  
 ```
 
-```{r, plot-estim-var-range, fig.cap="Parameter extraction stability, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and weibull distributions, or sdlog for the lognormal distribution."}
+```{r, plot-estim-var-range, fig.cap="Parameter extraction stability, facetted by distribution. Parameter 1 is either the shape parameter, for gamma and Weibull distributions, or meanlog for the lognormal distribution. Parameter 2 is either the scale parameter for gamma and Weibull distributions, or sdlog for the lognormal distribution."}
 ggplot(data = results) +
   geom_point(mapping = aes(
     x = estim_param_1_var, 

--- a/vignettes/extract-bias.Rmd
+++ b/vignettes/extract-bias.Rmd
@@ -21,7 +21,7 @@ knitr::opts_chunk$set(
 
 ::: {.alert .alert-info}
 If you are unfamiliar with the parameter extraction functionality in {epiparameter} 
-the Conversion and Extraction vignette is a great place to start.
+the [Conversion and Extraction vignette](extract_convert.html) is a great place to start.
 :::
 
 The {epiparameter} R package contains a set of functions to extract parameters


### PR DESCRIPTION
{epiparameter} contains functions to extract parameters of distributions from either the percentiles of a distribution, or the median and range of a data set. This is all implemented in the `extract_param()` function. There have been several questions around the formulation of the extraction functions and the bias and precision of the extraction process.

This PR addresses:
- #1 
- #102 

The vignette includes two sections:
1. Parameter extraction bias
2. Parameter extraction stability/precision

This vignette contributes to the ongoing work on package documentation as part of #75.