### PR TITLE
Remove covr from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,6 @@ Imports:
     stats,
     utils
 Suggests: 
-    covr,
     knitr,
     bookdown,
     rmarkdown,


### PR DESCRIPTION
This PR removes {covr} from the Suggests in the DESCRIPTION as mentioned in PR #151.