### PR TITLE
Update package style and documentation

### DIFF
--- a/R/accessors.R
+++ b/R/accessors.R
@@ -18,7 +18,6 @@ get_parameters <- function(x, ...) {
 
 #' @export
 get_parameters.epidist <- function(x, ...) {
-
   # extract parameters depending on prob distribution class
   if (inherits(x$prob_dist, "distcrete")) {
     params <- unlist(x$prob_dist$parameters)
@@ -83,21 +82,22 @@ get_citation.epidist <- function(x, ...) {
 
 #' @export
 get_citation.epiparam <- function(x, ...) {
-  citation_list <- apply(x, MARGIN = 1, FUN = function(y) {
-    # suppressing message as users do not need reminding of citation when
-    # retrieving citation
-    suppressMessages(
-      create_epidist_citation(
-        author = y$author,
-        year = y$year,
-        title = y$title,
-        journal = y$journal,
-        DOI = y$DOI,
-        PMID = y$PMID
+  citation_list <- apply(x,
+    MARGIN = 1, FUN = function(y) {
+      # suppressing message as users do not need reminding of citation when
+      # retrieving citation
+      suppressMessages(
+        create_epidist_citation(
+          author = y$author,
+          year = y$year,
+          title = y$title,
+          journal = y$journal,
+          DOI = y$DOI,
+          PMID = y$PMID
+        )
       )
-    )
-  },
-  simplify = FALSE
+    },
+    simplify = FALSE
   )
 
   # remove names from list

--- a/R/accessors.R
+++ b/R/accessors.R
@@ -1,16 +1,16 @@
-#' Parameters method for `epidist` object
+#' Get parameters from an `<epidist>` object
 #'
-#' Extracts the parameters of the distribution stored in an `epidist` object.
+#' Extract the parameters of the distribution stored in an `<epidist>` object.
 #'
-#' @details The <epidist> object can be unparameterised in which it lacks
+#' @details The `<epidist>` object can be unparameterised in which it lacks
 #' a probability distribution or parameters of a probability distribution.
 #' In this can the `parameters.epidist()` method with return `NA`.
 #'
-#' @param x An `epidist` object
+#' @inheritParams print.epidist
 #' @param ... Extra arguments to be passed to the method.
 #'
 #' @return A named vector of parameters or `NA` when the `<epidist>` object is
-#' unparameterised
+#' unparameterised.
 #' @export
 get_parameters <- function(x, ...) {
   UseMethod("get_parameters")
@@ -45,14 +45,13 @@ get_parameters.epidist <- function(x, ...) {
   params
 }
 
-#' Method for extracting citation information from `<epidist>` or
-#' `<epiparam>` objects.
+#' Extract citation information from `<epidist>` or `<epiparam>` objects
 #'
-#' @param x An `epidist` or `epiparam` object.
+#' @param x An `<epidist>` or `<epiparam>` object.
 #' @param ... Extra arguments to be passed to the method.
 #'
 #' @return A single character string or list of character string citations.
-#' Length of list output is equal to number of rows in the `epiparam` object
+#' Length of list output is equal to number of rows in the `<epiparam>` object
 #' passed to the function.
 #' @export
 #'

--- a/R/bind_epiparam.R
+++ b/R/bind_epiparam.R
@@ -35,7 +35,6 @@
 #' )
 #' bind_epiparam(eparam, edist)
 bind_epiparam <- function(epiparam, epi_obj) {
-
   # check input
   validate_epiparam(epiparam)
   if (is_epidist(epi_obj)) {
@@ -63,7 +62,7 @@ bind_epiparam <- function(epiparam, epi_obj) {
 
   # convert epidist to epiparam object
   if (is_epidist(epi_obj) || inherits(epi_obj, "list") ||
-      is_vb_epidist(epi_obj)) {
+    is_vb_epidist(epi_obj)) {
     epi_obj <- as_epiparam(x = epi_obj)
   }
 

--- a/R/bind_epiparam.R
+++ b/R/bind_epiparam.R
@@ -1,28 +1,28 @@
-#' Bind an epi object to an [`epiparam`] object
+#' Bind an epi object to an `<epiparam>` object
 #'
-#' Binds any epi data class in \pkg{epiparameter} ([`epidist`],
-#' [`vb_epidist`], [`epiparam`]) or data frame to an [`epiparam`] object.
+#' Bind any epi data class in \pkg{epiparameter} (`<epidist>`,
+#' `<vb_epidist>`, `<epiparam>`) or data frame to an `<epiparam>` object.
 #'
-#' @details The [`epiparam`] class holds the library of epidemiological
+#' @details The `<epiparam>` class holds the library of epidemiological
 #' parameters that is stored in the \pkg{epiparameter} R package and can be
 #' manipulated. The [bind_epiparam()] function allows users to add entries to
-#' the library by binding them to the bottom of an existing [`epiparam`] object
+#' the library by binding them to the bottom of an existing `<epiparam>` object
 #' loaded in R.
 #'
-#' The `<epiparam>` returned by `bind_epiparam()` contains the matching columns
-#' of the input objects. Therefore, if one of the input objects contains extra
-#' columns which are not present in the other input object these will be missing
-#' from the returned object. This also applies whether binding other
-#' `<epiparam>` objects or `<data.frames>`. When binding `<epidist>` objects
-#' missing data fields are given a default value before
+#' The `<epiparam>` returned by [bind_epiparam()] contains the matching
+#' columns of the input objects. Therefore, if one of the input objects
+#' contains extra columns which are not present in the other input object
+#' these will be missing from the returned object. This also applies whether
+#' binding other `<epiparam>` or `<data.frame>` objects. When binding
+#' `<epidist>` objects missing data fields are given a default value before
 #' binding.
 #'
-#' @param epiparam An `<epiparam>` object
+#' @inheritParams validate_epiparam
 #' @param epi_obj Either an `<epidist>`, `<vb_epidist>`, `<epiparam>` or list
 #' of `<epidist>` objects. It can also be a data frame as long as the columns
 #' conform to the columns of an `<epiparam>` object.
 #'
-#' @return An `<epiparam>` object
+#' @inherit epiparam return
 #' @export
 #'
 #' @examples

--- a/R/calc_dist_params.R
+++ b/R/calc_dist_params.R
@@ -1,22 +1,21 @@
-#' Calculates the parameters of a probability distribution from a list of
-#' available summary statistics
+#' Calculate the parameters of a probability distribution from a list of
+#' summary statistics
 #'
-#' @description When the parameters of a probability distribution are not
+#' @description If parameters of a probability distribution are not
 #' provided (e.g. when describing the distribution in the literature) and
 #' instead summary statistics of a distribution are provided, the parameters
-#' can usually be calculated from the summary statistics. The
-#' `calc_dist_params()` function computes the parameters for the gamma,
-#' lognormal and Weibull distributions.
+#' can usually be calculated from the summary statistics.
 #'
-#' This function can provide a convenient wrapper around the conversion and
-#' extraction functions when it is not known which summary statistics can be
-#' used to calculate the parameters of a distribution.
+#' This function can provide a convenient wrapper around
+#' [convert_summary_stats_to_params()] and [extract_param()]
+#' when it is not known which summary statistics can be used to
+#' calculate the parameters of a distribution.
 #'
 #' @details The hierarchy of methods is:
 #'
 #' 1. Conversion is prioritised if the mean and standard deviation are
 #' available as these are mostly analytical conversions (except for one of the
-#' Weibull conversions)
+#' Weibull conversions).
 #' 2. Next method if possible is extraction from percentiles. This method
 #' requires a lower percentile (between(0-50]) and an upper percentile
 #' (between (50-100)). If multiple percentiles in each of these ranges is
@@ -28,7 +27,7 @@
 #' @param sample_size The sample size of the data. Only needed when falling back
 #' on using the median-range extraction calculation.
 #'
-#' @return A named vector with parameters
+#' @return A named `numeric` vector with parameters.
 #' @keywords internal
 #' @examples
 #' \dontrun{

--- a/R/calc_dist_params.R
+++ b/R/calc_dist_params.R
@@ -51,7 +51,6 @@
 calc_dist_params <- function(prob_dist,
                              summary_stats,
                              sample_size = NA) {
-
   # extract mean and sd to see if conversion is possible
   mean_sd <- c(
     mean = summary_stats$centre_spread$mean,
@@ -86,7 +85,8 @@ calc_dist_params <- function(prob_dist,
     # create flat list structure to be passed to ... in conversion
     args <- unlist(list(prob_dist, as.list(summary_stats_)), recursive = FALSE)
     prob_dist_params <- unlist(do.call(
-      convert_summary_stats_to_params, args = args
+      convert_summary_stats_to_params,
+      args = args
     ))
   } else if (!anyNA(percentiles)) {
     # calculate the parameters from the percentiles

--- a/R/check_epidist.R
+++ b/R/check_epidist.R
@@ -14,7 +14,6 @@
 #'   prob_dist_params = c(shape = 1, scale = 1)
 #' )
 check_epidist_params <- function(prob_dist, prob_dist_params) {
-
   # check parameters if provided
   checkmate::assert_numeric(prob_dist_params, names = "unique")
 
@@ -56,16 +55,15 @@ check_epidist_params <- function(prob_dist, prob_dist_params) {
 #'   )
 #' )
 check_epidist_uncertainty <- function(prob_dist_params, uncertainty) {
-
   # check whether ci has been provided for each parameter
   # check that the parameters and uncertainty names match
   stopifnot(
     "uncertainty must be provided for each parameter" =
       anyNA(uncertainty) ||
-      length(prob_dist_params) == length(uncertainty),
+        length(prob_dist_params) == length(uncertainty),
     "parameters and uncertainty must be named and match" =
       anyNA(uncertainty) ||
-      identical(names(prob_dist_params), names(uncertainty))
+        identical(names(prob_dist_params), names(uncertainty))
   )
 
   invisible(uncertainty)

--- a/R/check_epidist.R
+++ b/R/check_epidist.R
@@ -1,5 +1,4 @@
-#' Checks the probability distribution name and parameters to be used in an
-#' `epidist` object
+#' Check the probability distribution name and parameters for `<epidist>` object
 #'
 #' @inheritParams new_epidist
 #'
@@ -27,7 +26,7 @@ check_epidist_params <- function(prob_dist, prob_dist_params) {
   invisible(prob_dist_params)
 }
 
-#' Checks the parameter uncertainty list in an `epidist` object
+#' Check the parameter uncertainty in an `<epidist>` object
 #'
 #' @inheritParams new_epidist
 #' @inheritParams epidist

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -1,16 +1,15 @@
-#' Checks whether <epidist> or <epiparam> object contains a distribution and
-#' parameters for that distribution.
+#' Check if `<epidist>` or `<epiparam>` object contain a distribution and
+#' distribution parameters
 #'
-#' @description If the <epidist> object or a row in the <epiparam> data frame
-#' is missing either a probability distribution or parameters for the
-#' probability distribution, `is_parameterised` returns `FALSE`, otherwise
-#' it returns `TRUE`.
 #'
-#' @param x An `epidist` or `epiparam` object.
-#' @param ... [`dots`] not used, extra arguments supplied will cause a warning.
+#' @param x An `<epidist>` or `<epiparam>` object.
+#' @param ... [dots] not used, extra arguments supplied will cause a warning.
 #'
-#' @return A boolean logical for <epidist> or vector of boolean for each entry
-#' in the <epiparam>.
+#' @return A single boolean `logical` for `<epidist>` or vector of boolean
+#' `logical`s with length equal to the number of rows in the `<epiparam>`.
+#' If the `<epidist>` object or a row in the `<epiparam>` is missing either
+#' a probability distribution or parameters for the probability distribution
+#' returns `FALSE`, otherwise it returns `TRUE`.
 #' @export
 #'
 #' @examples

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -35,7 +35,6 @@ is_parameterised <- function(x, ...) {
 
 #' @export
 is_parameterised.epiparam <- function(x, ...) {
-
   chkDots(...)
 
   has_params <- vapply(
@@ -72,7 +71,6 @@ is_parameterised.epiparam <- function(x, ...) {
 
 #' @export
 is_parameterised.epidist <- function(x, ...) {
-
   chkDots(...)
 
   # probability distribution object

--- a/R/convert_params.R
+++ b/R/convert_params.R
@@ -1,7 +1,7 @@
 #' Convert the summary statistics of a distribution to parameters
 #'
-#' @description Converts the summary statistics for a range of distributions to
-#' a distribution's parameters. Most summary statistics are calculated
+#' @description Convert the summary statistics for a range of distributions to
+#' the distribution's parameters. Most summary statistics are calculated
 #' analytically given the parameters. An exception is the Weibull distribution
 #' which uses a root finding numerical method.
 #'
@@ -21,10 +21,10 @@
 #' the parameters cannot be calculated from the given input.
 #'
 #' The distribution names and parameter names follow the style of
-#' distributions in R, for example the lognormal distribution is `lnorm`,
+#' distributions in \R, for example the lognormal distribution is `lnorm`,
 #' and its parameters are `meanlog` and `sdlog`.
 #'
-#' @param distribution A `character` specifying distribution to use.
+#' @param distribution A `character` string specifying distribution to use.
 #' Default is `lnorm`; also takes `gamma` and `weibull`, `nbinom` and `geom`.
 #' @param ... `Numeric` named summary statistics used to convert to
 #' parameter(s). An example is the meanlog and sdlog parameters of the
@@ -71,12 +71,12 @@ convert_summary_stats_to_params <- function(distribution = c( # nolint
 
 #' Convert the parameter(s) of a distribution to summary statistics
 #'
-#' @description Converts the parameters for a range of distributions to a
+#' @description Convert the parameters for a range of distributions to a
 #' number of summary statistics. All summary statistics are calculated
 #' analytically given the parameters.
 #'
 #' @details The distribution names and parameter names follow the style of
-#' distributions in R, for example the lognormal distribution is `lnorm`,
+#' distributions in \R, for example the lognormal distribution is `lnorm`,
 #' and its parameters are `meanlog` and `sdlog`.
 #'
 #' @inheritParams convert_summary_stats_to_params
@@ -228,14 +228,14 @@ convert_params_lnorm <- function(...) {
   )
 }
 
-#' Converts the summary statistics to parameters of the lognormal distribution
+#' Convert summary statistics to parameters of the lognormal distribution
 #'
-#' @description Converts the summary statistics input into the meanlog and sdlog
+#' @description Convert the summary statistics input into the meanlog and sdlog
 #' parameters of the lognormal distribution.
 #'
 #' @inheritParams convert_summary_stats_to_params
 #'
-#' @return A list of two elements, the meanlog and sdlog
+#' @return A list of two elements: meanlog and sdlog
 #' @keywords internal
 convert_summary_stats_lnorm <- function(...) {
   # capture input
@@ -271,12 +271,12 @@ convert_summary_stats_lnorm <- function(...) {
   )
 }
 
-#' Converts the parameters of the gamma distribution to summary statistics
+#' Convert parameters of the gamma distribution to summary statistics
 #'
-#' @description Converts the shape and scale parameters of the gamma
+#' @description Convert the shape and scale parameters of the gamma
 #' distribution to a number of summary statistics which can be calculated
 #' analytically given the gamma parameters. One exception is the median which
-#' is calculated using [`qgamma()`] as no analytical form is available.
+#' is calculated using [qgamma()] as no analytical form is available.
 #'
 #' @inheritParams convert_params_to_summary_stats
 #'
@@ -323,9 +323,9 @@ convert_params_gamma <- function(...) {
   )
 }
 
-#' Converts the summary statistics to parameters of the gamma distribution
+#' Convert summary statistics to parameters of the gamma distribution
 #'
-#' @description Converts the summary statistics input into the shape and scale
+#' @description Convert the summary statistics input into the shape and scale
 #' parameters of the gamma distribution.
 #'
 #' @inheritParams convert_summary_stats_to_params
@@ -355,12 +355,12 @@ convert_summary_stats_gamma <- function(...) {
   stop("Cannot calculate gamma parameters from given input")
 }
 
-#' Converts the parameters of the Weibull distribution to summary statistics
+#' Convert parameters of the Weibull distribution to summary statistics
 #'
-#' @description Converts the shape and scale parameters of the Weibull
+#' @description Convert the shape and scale parameters of the Weibull
 #' distribution to a number of summary statistics which can be calculated
 #' analytically given the Weibull parameters. Note the conversion uses the
-#' [`gamma()`] function.
+#' [gamma()] function.
 #'
 #' @inheritParams convert_params_to_summary_stats
 #'
@@ -413,14 +413,14 @@ convert_params_weibull <- function(...) {
   )
 }
 
-#' Converts the summary statistics to parameters of the Weibull distribution
+#' Convert summary statistics to parameters of the Weibull distribution
 #'
-#' @description Converts the summary statistics input into the shape and scale
+#' @description Convert summary statistics input into the shape and scale
 #' parameters of the Weibull distribution.
 #'
 #' @inheritParams convert_summary_stats_to_params
 #'
-#' @return A list of two elements, the shape and scale
+#' @return A list of two elements, the shape and scale.
 #' @keywords internal
 convert_summary_stats_weibull <- function(...) {
   # capture input
@@ -456,13 +456,13 @@ convert_summary_stats_weibull <- function(...) {
   stop("Cannot calculate Weibull parameters from given input")
 }
 
-#' Converts the parameters of the negative binomial distribution to summary
+#' Convert parameters of the negative binomial distribution to summary
 #' statistics
 #'
-#' @description Converts the probability (`prob`) and dispersion parameters of
+#' @description Convert the probability (`prob`) and dispersion parameters of
 #' the negative binomial distribution to a number of summary statistics which
 #' can be calculated analytically given the negative binomial parameters.
-#' One exception is the median which is calculated using [`qnbinom()`] as no
+#' One exception is the median which is calculated using [qnbinom()] as no
 #' analytical form is available.
 #'
 #' The parameters are `prob` and `dispersion` (which is also commonly
@@ -516,16 +516,16 @@ convert_params_nbinom <- function(...) {
   )
 }
 
-#' Converts the summary statistics to parameters of the negative binomial
+#' Convert summary statistics to parameters of the negative binomial
 #' distribution
 #'
-#' @description Converts the summary statistics of the negative binomial
+#' @description Convert summary statistics of the negative binomial
 #' distribution the parameters (`prob`) and (`dispersion`) of the negative
 #' binomial distribution.
 #'
 #' @inheritParams convert_summary_stats_to_params
 #'
-#' @return A list of two elements, the probability and dispersion parameters
+#' @return A list of two elements, the probability and dispersion parameters.
 #' @keywords internal
 convert_summary_stats_nbinom <- function(...) {
   # capture input
@@ -567,15 +567,15 @@ convert_summary_stats_nbinom <- function(...) {
   )
 }
 
-#' Converts the parameters of the geometric distribution to summary statistics
+#' Convert parameter of the geometric distribution to summary statistics
 #'
-#' @description Converts the probability (`prob`) of the geometric distribution
+#' @description Convert the probability (`prob`) of the geometric distribution
 #' to a number of summary statistics which can be calculated analytically given
 #' the geometric parameter.
 #'
 #' @details This conversion function assumes that distribution represents the
 #' number of failures before the first success (supported for zero). This is
-#' the same form as used by base R and `distributional::dist_geometric()`.
+#' the same form as used by base R and [distributional::dist_geometric()].
 #'
 #' @inheritParams convert_params_to_summary_stats
 #'
@@ -620,18 +620,18 @@ convert_params_geom <- function(...) {
   )
 }
 
-#' Converts the summary statistics to parameters of the geometric distribution
+#' Convert summary statistics to parameters of the geometric distribution
 #'
-#' @description Converts the summary statistics of the geometric
+#' @description Convert summary statistics of the geometric
 #' distribution the parameter (`prob`) of the geometric distribution.
 #'
 #' @details This conversion function assumes that distribution represents the
 #' number of failures before the first success (supported for zero). This is
-#' the same form as used by base R and `distributional::dist_geometric()`.
+#' the same form as used by base R and [distributional::dist_geometric()].
 #'
 #' @inheritParams convert_summary_stats_to_params
 #'
-#' @return A list of one element, the probability parameter
+#' @return A list of one element, the probability parameter.
 #' @keywords internal
 convert_summary_stats_geom <- function(...) {
   # capture input

--- a/R/create_prob_dist.R
+++ b/R/create_prob_dist.R
@@ -1,12 +1,15 @@
-#' Creates an distribution object depending on input parameters and distribution
-#' settings
+#' Create a distribution object from distribution name and parameters
 #'
-#' @description This function converts the probability distribution name and its
-#' parameters into an S3 class holding the distribution and parameters. The
-#' class holding the distribution depends on whether it is a continuous or
-#' discrete distribution. For continuous distributions the `{distributional}`
-#' package and classes are used, for discrete distributions the `{distcrete}`
-#' package is used. For details on the properties of the distribution classes
+#' @description Creates an S3 class holding the distribution and parameters
+#' from the probability distribution name, its parameters and distribution
+#' truncation and discretisation.
+#'
+#' The class holding the distribution depends on whether it is a discretised
+#' distribution. For continuous and discrete distributions S3 classes from the
+#' `{distributional}` package are used, for discretised continuous
+#' distributions the an S3 class from the `{distcrete}` package is used.
+#'
+#' For details on the properties of the distribution classes
 #' from each respective package see their documentation (either
 #' `?distributional` or `?distcrete`)
 #'
@@ -15,7 +18,7 @@
 #'
 #' @inheritParams new_epidist
 #'
-#' @return An S3 class containing the probability distribution
+#' @return An S3 class containing the probability distribution.
 #' @keywords internal
 #'
 #' @examples

--- a/R/create_prob_dist.R
+++ b/R/create_prob_dist.R
@@ -48,7 +48,6 @@ create_prob_dist <- function(prob_dist,
                              prob_dist_params,
                              discretise,
                              truncation) {
-
   if (discretise) {
     prob_dist <- match.arg(prob_dist, choices = c("gamma", "lnorm", "weibull"))
     # create discretised probability distribution object
@@ -63,8 +62,7 @@ create_prob_dist <- function(prob_dist,
     )
   } else {
     # create non-discretised probability distribution object
-    prob_dist <- switch(
-      prob_dist,
+    prob_dist <- switch(prob_dist,
       gamma = distributional::dist_gamma(
         shape = prob_dist_params[["shape"]],
         rate = 1 / prob_dist_params[["scale"]]

--- a/R/epidist.R
+++ b/R/epidist.R
@@ -1,6 +1,6 @@
-#' Constructor for epidist class
+#' Constructor for `<epidist>` class
 #'
-#' @description Creates an epidist object. The
+#' @description Create an `<epidist>` object. The
 #' constructor will search whether parameters of the probability distribution
 #' are supplied and if not look to see whether they can be inferred/extracted/
 #' converted from summary statistics provided. It will also convert the
@@ -9,18 +9,18 @@
 #' `{distributional}` when `discretise = FALSE`, or a `distcrete` object from
 #' `{distcrete}` when `discretise = TRUE`.
 #'
-#' @param disease A list contains the `$disease` a character string of the
-#' infectious disease specified in the study, and the `$pathogen` a character
+#' @param disease A list containing the `$disease` a `character` string of the
+#' infectious disease specified in the study, and the `$pathogen` a `character`
 #' string. If the pathogen is unknown it can be given as `NULL`.
 #' @param prob_dist A character string specifying the probability
 #' distribution. This should match the R naming convention of probability
 #' distributions (e.g. lognormal is lnorm, negative binomial is nbinom, and
-#' geometric is geom)
+#' geometric is geom).
 #' @param prob_dist_params A named vector of probability distribution
-#' parameters
+#' parameters.
 #' @inheritParams epidist
 #'
-#' @return epidist object
+#' @inherit epidist return
 #' @keywords internal
 #'
 #' @examples
@@ -117,20 +117,22 @@ new_epidist <- function(disease = list(),
   )
 }
 
-#' Create an `epidist` object
+#' Create an `<epidist>` object
 #'
-#' @description The `epidist` class is used to store epidemiological parameters
-#' for a single disease. These epidemiological parameters cover a variety of
-#' aspects including delay distributions (e.g. incubation periods and serial
-#' intervals, among others) and offspring distributions.
+#' @description The `<epidist>` class is used to store epidemiological
+#' parameters for a single disease. These epidemiological parameters cover a
+#' variety of aspects including delay distributions (e.g. incubation periods
+#' and serial intervals, among others) and offspring distributions.
 #'
-#' The `epidist` object is the functional unit provided by `{epiparameter}` to
-#' plug into epidemiological pipelines. Obtaining an `epidist` object can be
-#' achieved in two main ways. 1) The epidemiological distribution is stored in
-#' the `{epiparameter}` library and can be accessed by [`epiparam()`] and
-#' [`as_epidist()`]. 2) the alternative method is when you have information
+#' The `<epidist>` object is the functional unit provided by `{epiparameter}` to
+#' plug into epidemiological pipelines. Obtaining an `<epidist>` object can be
+#' achieved in two main ways:
+#' 1. The epidemiological distribution is stored in
+#' the `{epiparameter}` library and can be accessed by [epiparam()] and
+#' [as_epidist()].
+#' 2. The alternative method is when you have information
 #' (e.g. disease and distribution parameter estimates) and would like to input
-#' this into an `epidist` object in order to work in existing analysis
+#' this into an `<epidist>` object in order to work in existing analysis
 #' pipelines. This is where the `epidist()` function can be used to fill out
 #' each field for which information is known.
 #'
@@ -142,36 +144,36 @@ new_epidist <- function(disease = list(),
 #' - Geometric must be either 'mean' or 'prob'
 #' - Poisson must be 'mean'
 #'
-#' @param disease A character string with name of the infectious disease
-#' @param pathogen A character string with the name of the causative agent of
-#' disease, or NULL if not known
-#' @param epi_dist A character string with the name of the
-#' epidemiological distribution type
-#' @param prob_distribution A character string specifying the probability
-#' distribution. This should match the R naming convention of probability
-#' distributions (e.g. lognormal is lnorm, negative binomial is nbinom, and
-#' geometric is geom)
+#' @param disease A `character` string with name of the infectious disease.
+#' @param pathogen A `character` string with the name of the causative agent of
+#' disease, or NULL if not known.
+#' @param epi_dist A `character` string with the name of the
+#' epidemiological distribution type.
+#' @param prob_distribution A `character` string specifying the probability
+#' distribution. This should match the \R naming convention of probability
+#' distributions (e.g. lognormal is `lnorm`, negative binomial is `nbinom`, and
+#' geometric is `geom`).
 #' @param prob_distribution_params A named vector of probability distribution
-#' parameters
+#' parameters.
 #' @param uncertainty A list of named vectors with the uncertainty around
 #' the probability distribution parameters. If uncertainty around the parameter
-#' estimates is unknown use `create_epidist_uncertainty()` (which is the
+#' estimates is unknown use [create_epidist_uncertainty()] (which is the
 #' argument default) to create a list wiht the correct names with missing
 #' values.
 #' @param summary_stats A list of summary statistics, use
-#' [`create_epidist_summary_stats()`] to create list. This list can include
+#' [create_epidist_summary_stats()] to create list. This list can include
 #' summary statistics about the inferred distribution such as it's mean and
 #' standard deviation, quantiles of the distribution, or information about the
 #' data used to fit the distribution such as lower and upper range. The summary
 #' statistics can also include uncertainty around metrics such as confidence
 #' interval around mean and standard deviation.
-#' @param auto_calc_params A boolean logical determining whether to try and
+#' @param auto_calc_params A boolean `logical` determining whether to try and
 #' calculate the probability distribution parameters from summary statistics if
 #' distribution parameters are not provided. Default is `TRUE`. In the case when
 #' sufficient summary statistics are provided and the parameter(s) of the
-#' distribution are not, the [`calc_dist_params()`] function is called to
+#' distribution are not, the [calc_dist_params()] function is called to
 #' calculate the parameters and add them to the `epidist` object created.
-#' @param citation A character string with the citation of the source of the
+#' @param citation A `character` string with the citation of the source of the
 #' data or the paper that inferred the distribution parameters, use
 #' `create_epidist_citation()` to create citation.
 #' @param metadata A list of metadata, this can include: sample size, the
@@ -184,14 +186,15 @@ new_epidist <- function(disease = list(),
 #' @param method_assess A list of methodological aspects used when fitting
 #' the distribution, use `create_epidist_method_assess()` to create method
 #' assessment.
-#' @param discretise A boolean logical whether the distribution is discretised.
+#' @param discretise A boolean `logical` whether the distribution is
+#' discretised.
 #' Default is FALSE which assumes a continuous probability distribution
-#' @param truncation A numeric specifying the truncation point if the inferred
-#' distribution was truncated, NA if not or unknown.
-#' @param notes A character string with any additional information about the
+#' @param truncation A `numeric` specifying the truncation point if the inferred
+#' distribution was truncated, `NA` if not or unknown.
+#' @param notes A `character` string with any additional information about the
 #' data, inference method or disease.
 #'
-#' @return An `epidist` object
+#' @return An `<epidist>` object.
 #' @export
 #'
 #' @examples
@@ -319,14 +322,13 @@ epidist <- function(disease,
   epidist
 }
 
-#' `epidist` class validator
+#' Validator for `<epidist>` class
 #'
-#' @param epidist An `epidist` object
+#' @param epidist An `<epidist>` object
 #'
-#' @return Invisibly returns an [`epidist`]. Called for side-effects (errors
-#' when invalid `epidist` object is provided).
+#' @return Invisibly returns an `<epidist>`. Called for side-effects (errors
+#' when invalid `<epidist>` object is provided).
 #'
-#' Nothing, errors when invalid `epidist` object is provided
 #' @export
 validate_epidist <- function(epidist) {
   if (!is_epidist(epidist)) {
@@ -362,18 +364,18 @@ validate_epidist <- function(epidist) {
   invisible(epidist)
 }
 
-#' Print method for epidist class
+#' Print method for `<epidist>` class
 #'
-#' @param x epidist object
-#' @param header Boolean logical determining whether the header (first part) of
-#' the print method is printed. This is used internally for plotting the
-#' vb_epidist class
-#' @param vb A character string containing whether it is the intrinsic
+#' @param x An `<epidist>` object.
+#' @param header Boolean `logical` determining whether the header (first part)
+#' of the print method is printed. This is used internally for plotting the
+#' `<vb_epidist>` class.
+#' @param vb A `character` string containing whether it is the intrinsic
 #' (`"Intrinsic"`) or extrinsic (`"Extrinsic"`) distribution for vector-borne
-#' diseases
-#' @param ... further arguments passed to or from other methods
+#' diseases.
+#' @param ... [dots] Extra arguments passed to or from other methods.
 #'
-#' @return Invisibly returns an [`epidist`]. Called for side-effects.
+#' @return Invisibly returns an `<epidist>`. Called for side-effects.
 #' @export
 #'
 #' @examples
@@ -388,17 +390,16 @@ print.epidist <- function(x, header = TRUE, vb = NULL, ...) {
   format(x, header = header, vb = vb, ...)
 }
 
-#' Format method for epidist class
+#' Format method for `<epidist>` class
 #'
-#' @param x epidist object
+#' @inheritParams print.epidist
 #' @param header Boolean logical determining whether the header (first part) of
 #' the print method is printed. This is used internally for plotting the
 #' vb_epidist class
 #' @param vb Either NULL (default) or a character string of either "Intrinsic"
 #' or "Extrinsic" which is used internally for plotting the vb_epidist class
-#' @param ... further arguments passed to or from other methods
 #'
-#' @return Invisibly returns an [`epidist`]. Called for printing side-effects.
+#' @return Invisibly returns an `<epidist>`. Called for printing side-effects.
 #' @export
 #'
 #' @examples
@@ -461,22 +462,22 @@ format.epidist <- function(x, header = TRUE, vb = NULL, ...) {
   invisible(x)
 }
 
-#' Plots an `epidist` object
+#' Plot method for `<epidist>` class
 #'
-#' @description Plots an `epidist` object by displaying the either the
+#' @description Plot an `<epidist>` object by displaying the either the
 #' probability mass function (PMF), (in the case of discrete distributions)
 #' or probability density function (PDF) (in the case of continuous
 #' distributions) and the cumulative distribution function (CDF). Resulting in
 #' a 1x2 grid plot.
 #'
-#' @param x An `epidist` object
+#' @param x An `<epidist>` object.
 #' @param day_range A vector with the sequence of days to be plotted on the
-#' x-axis of the distribution
-#' @param ... Allow other graphical parameters
+#' x-axis of the distribution.
 #' @param vb A boolean logical determining whether the `epidist` being plotted
-#' has come from a `vb_epidist` object
+#' has come from a `vb_epidist` object.
 #' @param title Either a character string or `NULL`. If not null the character
-#' string will be printed as a title to the plot
+#' string will be printed as a title to the plot.
+#' @inheritParams base::print
 #'
 #' @author Joshua W. Lambert
 #' @export
@@ -556,12 +557,12 @@ plot.epidist <- function(x, day_range = 0:10, ..., vb = FALSE, title = NULL) {
   }
 }
 
-#' Checks whether the object is an `epidist`
+#' Check object is an `<epidist>`
 #'
-#' @param x An R object
+#' @param x An \R object.
 #'
-#' @return A boolean logical, `TRUE` if the object is an `epidist` and `FALSE`
-#' if not
+#' @return A boolean logical, `TRUE` if the object is an `<epidist>` and `FALSE`
+#' if not.
 #' @export
 #'
 #' @examples
@@ -586,25 +587,25 @@ is_epidist <- function(x) {
   inherits(x, "epidist")
 }
 
-#' PDF, CDF, PMF, quantiles and random number generation for `epidist` and
-#' `vb_epidist` objects
+#' PDF, CDF, PMF, quantiles and random number generation for `<epidist>` and
+#' `<vb_epidist>` objects
 #'
-#' @description The epidist object holds a probability distribution which can
-#' either be a continuous or discrete distribution. These are the density,
+#' @description The `<epidist>` object holds a probability distribution which
+#' can either be a continuous or discrete distribution. These are the density,
 #' cumulative distribution, quantile and random number generation functions.
-#' These operate on any distribution that can be included in an `epidist`
+#' These operate on any distribution that can be included in an `<epidist>`
 #' object.
 #'
-#' @param x An `epidist` or `vb_epidist` object
-#' @param at The quantiles to evaluate at
-#' @param q The quantiles to evaluate at
-#' @param p The probabilities to evaluate at
-#' @param times The number of random samples
-#' @param ... further arguments passed to or from other methods
+#' @param x An `<epidist>` or `<vb_epidist>` object.
+#' @param at The quantiles to evaluate at.
+#' @param q The quantiles to evaluate at.
+#' @param p The probabilities to evaluate at.
+#' @param times The number of random samples.
+#' @inheritParams print.epidist
 #'
-#' @return If an `epidist` object is given a numeric vector is returned, if an
-#' `vb_epidist` object is given a list of two elements each with a numeric
-#' vector is returned
+#' @return If an `<epidist>` object is given a numeric vector is returned, if an
+#' `<vb_epidist>` object is given a list of two elements each with a numeric
+#' vector is returned.
 #'
 #' @name epidist_distribution_functions
 #' @keywords epidist_distribution_functions
@@ -722,16 +723,15 @@ generate.epidist <- function(x, times, ...) {
   out
 }
 
-#' Discretises a continuous distribution in an `epidist` object
+#' Discretises a continuous distribution in an `<epidist>` object
 #'
-#' @details Converts the S3 distribution object in an `epidist` from continuous
-#' (using an object from the {distributional} package) to a discretised
-#' distribution (using an object from the {distcrete} package).
+#' @details Converts the S3 distribution object in an `<epidist>` from
+#' continuous (using an object from the `{distributional}` package) to a
+#' discretised distribution (using an object from the `{distcrete}` package).
 #'
-#' @param x An `epidist` object
-#' @param ... further arguments passed to or from other methods
+#' @inheritParams print.epidist
 #'
-#' @return An `epidist` object
+#' @inherit epidist return
 #' @export
 #'
 #' @examples
@@ -809,14 +809,14 @@ discretise.default <- function(x, ...) {
   stop("No discretise method defined for class ", class(x))
 }
 
-#' Family method for the `epidist` class
+#' Family method for the `<epidist>` class
 #'
-#' @description The `family()` function is used to extract the distribution
-#' names from objects from {distributional} and {distcrete}. This method
+#' @description The [family()] function is used to extract the distribution
+#' names from objects from `{distributional}` and `{distcrete}`. This method
 #' provides the same interface for `<epidist>` objects to give consistent
-#' output irrespective of the distribution class.
+#' output irrespective of the internal distribution class.
 #'
-#' @param object An `epidist` object
+#' @param object An `<epidist>` object.
 #' @inheritParams stats::family
 #'
 #' @return A character string with the name of the distribution, or `NA` when
@@ -875,17 +875,17 @@ family.epidist <- function(object, ...) {
   prob_dist
 }
 
-#' Check if distribution in `epidist` is truncated
+#' Check if distribution in `<epidist>` is truncated
 #'
 #' @details The `<epidist>` class can hold probability distribution objects
-#' from the {distributional} package or the {distcrete} package, however, only
-#' distribution objects from {distributional} can be truncated. If a
-#' `<epidist>` object has a {distcrete} object `is_truncated` will return
-#' `FALSE` by default.
+#' from the `{distributional}` package or the `{distcrete}` package,
+#' however, only distribution objects from `{distributional}` can be truncated.
+#' If a `<epidist>` object has a `<distcrete>` object `is_truncated` will
+#' return `FALSE` by default.
 #'
-#' @param x An `epidist` object.
+#' @inheritParams print.epidist
 #'
-#' @return A boolean logical.
+#' @return A boolean `logical`.
 #' @export
 #'
 #' @examples

--- a/R/epidist.R
+++ b/R/epidist.R
@@ -52,7 +52,6 @@ new_epidist <- function(disease = list(),
                         discretise = logical(),
                         truncation = numeric(),
                         notes = character()) {
-
   check_epidist_uncertainty(
     prob_dist_params = prob_dist_params,
     uncertainty = uncertainty
@@ -259,7 +258,6 @@ epidist <- function(disease,
                     discretise = FALSE,
                     truncation = NA_real_,
                     notes = NULL) {
-
   # check input
   checkmate::assert_string(disease)
   checkmate::assert_character(pathogen)
@@ -288,10 +286,10 @@ epidist <- function(disease,
   stopifnot(
     "uncertainty must be provided for each parameter" =
       anyNA(uncertainty, recursive = TRUE) ||
-      length(prob_distribution_params) == length(uncertainty),
+        length(prob_distribution_params) == length(uncertainty),
     "probability distribution params must be a named vector or NA" =
       anyNA(prob_distribution_params, recursive = TRUE) ||
-      !is.null(names(prob_distribution_params))
+        !is.null(names(prob_distribution_params))
   )
 
   # call epidist constructor
@@ -331,7 +329,6 @@ epidist <- function(disease,
 #' Nothing, errors when invalid `epidist` object is provided
 #' @export
 validate_epidist <- function(epidist) {
-
   if (!is_epidist(epidist)) {
     stop("Object should be of class epidist", call. = FALSE)
   }
@@ -339,17 +336,19 @@ validate_epidist <- function(epidist) {
   # check for class invariants
   stopifnot(
     "epidist object does not contain the correct attributes" =
-      c("disease", "epi_dist", "prob_dist", "uncertainty", "summary_stats",
-        "citation", "metadata", "method_assess", "notes") %in%
-      attributes(epidist)$names,
+      c(
+        "disease", "epi_dist", "prob_dist", "uncertainty", "summary_stats",
+        "citation", "metadata", "method_assess", "notes"
+      ) %in%
+        attributes(epidist)$names,
     "epidist must contain a disease (single character string)" =
       is.character(epidist$disease$disease) &&
-      length(epidist$disease$disease) == 1,
+        length(epidist$disease$disease) == 1,
     "epidist must contain an epidemiological distribution" =
       is.character(epidist$epi_dist) && length(epidist$epi_dist) == 1,
     "epidist must contain a <distribution> or <distcrete> distribution or NA" =
       inherits(epidist$prob_dist, c("distribution", "distcrete")) ||
-      is.na(epidist$prob_dist) || is.character(epidist$prob_dist),
+        is.na(epidist$prob_dist) || is.character(epidist$prob_dist),
     "epidisit must contain uncertainty, summary stats and metadata" =
       all(
         is.list(epidist$uncertainty),
@@ -411,7 +410,6 @@ print.epidist <- function(x, header = TRUE, vb = NULL, ...) {
 #' )
 #' format(epidist)
 format.epidist <- function(x, header = TRUE, vb = NULL, ...) {
-
   if (header) {
     writeLines(
       c(
@@ -505,7 +503,6 @@ format.epidist <- function(x, header = TRUE, vb = NULL, ...) {
 #'
 #' plot(edist, day_range = 0:10)
 plot.epidist <- function(x, day_range = 0:10, ..., vb = FALSE, title = NULL) {
-
   # check input
   validate_epidist(x)
   checkmate::assert_numeric(day_range, min.len = 2)
@@ -569,7 +566,7 @@ plot.epidist <- function(x, day_range = 0:10, ..., vb = FALSE, title = NULL) {
 #'
 #' @examples
 #' edist <- epidist(
-#' disease = "ebola",
+#'   disease = "ebola",
 #'   epi_dist = "serial_interval",
 #'   prob_distribution = "gamma",
 #'   prob_distribution_params = c(shape = 1, scale = 1)
@@ -752,20 +749,17 @@ discretise <- function(x, ...) {
 #' @rdname discretise
 #' @export
 discretise.epidist <- function(x, ...) {
-
   # check if distribution is already discretised if so return early
   if (inherits(x$prob_dist, "distcrete")) {
     message("Distribution in `epidist` is already discretised")
     return(x)
   } else {
-
     # extract prob dist and prob dist parameters from epidist
     prob_dist <- family(x)
     prob_dist_params <- get_parameters(x)
 
     # if distribution is truncated take only parameters
     if (is_truncated(x)) {
-
       warning(
         "Discretising a truncated continuous distribution, ",
         "returning non-truncated discretised distribution",
@@ -850,7 +844,6 @@ discretise.default <- function(x, ...) {
 #' )
 #' family(edist)
 family.epidist <- function(object, ...) {
-
   if (inherits(object$prob_dist, "distcrete")) {
     prob_dist <- object$prob_dist$name
   } else if (inherits(object$prob_dist, "distribution")) {
@@ -870,8 +863,7 @@ family.epidist <- function(object, ...) {
     return(NA)
   }
 
-  prob_dist <- switch(
-    prob_dist,
+  prob_dist <- switch(prob_dist,
     lognormal = "lnorm",
     negbin = "nbinom",
     geometric = "geom",
@@ -914,7 +906,6 @@ family.epidist <- function(object, ...) {
 #' )
 #' is_truncated(edist)
 is_truncated <- function(x) {
-
   stopifnot(
     "is_truncated only works for `<epidist> objects`" =
       is_epidist(x)

--- a/R/epidist_db.R
+++ b/R/epidist_db.R
@@ -1,9 +1,9 @@
-#' Create an `epidist` object(s) directly from the epiparameter library
+#' Create an `<epidist>` object(s) directly from the epiparameter library
 #' (database)
 #'
-#' @description This function can extract an `epidist` object(s) directly from
-#' the library of epidemiological parameters without having to read in an
-#' `epiparam` object and pull out an `epidist` object from one of the entries.
+#' @description Extract an `<epidist>` object(s) directly from
+#' the library of epidemiological parameters. This bypasses the need to
+#' read in an `<epiparam>` object and convert to an `<epidist>` object.
 #'
 #' If a distribution from a specific study is required, the `author` argument
 #' can be specified.
@@ -35,7 +35,7 @@
 #' The expression should be specified without using the data object name
 #' (e.g. `df$var`) and instead just `var` should be supplied. In
 #' other words, this argument works the same as the `subset` argument in
-#' [`subset()`]. It is similar to `<data-masking>` using by the `dplyr` package.
+#' [subset()]. It is similar to `<data-masking>` using by the `dplyr` package.
 #'
 #' @param single_epidist A boolean `logical` determining whether a single
 #' `<epidist>` or multiple entries from the library can be returned if
@@ -45,11 +45,11 @@
 #'
 #' **Note**: If multiple entries match the arguments supplied and
 #' `single_epidist = TRUE` then the `<epidist>` that is parameterised and
-#' has the largest sample size will be returned (see [`is_parameterised()`]).
+#' has the largest sample size will be returned (see [is_parameterised()]).
 #' If multiple entries are equal after this sorting the first entry will
 #' be returned.
 #'
-#' @return An `epidist` object or list of `epidist` objects.
+#' @return An `<epidist>` object or list of `<epidist>` objects.
 #' @export
 #'
 #' @examples

--- a/R/epidist_utils.R
+++ b/R/epidist_utils.R
@@ -33,7 +33,7 @@
 #' # lengh of list should match number of parameters
 #' list(
 #'   shape = create_epidist_uncertainty(
-#'     ci_limits = c(1,3),
+#'     ci_limits = c(1, 3),
 #'     ci = 95,
 #'     ci_type = "confidence interval"
 #'   ),
@@ -50,13 +50,14 @@
 #' # or give NA as the first argument
 #' create_epidist_uncertainty(NA)
 create_epidist_uncertainty <- function(ci_limits = NA_real_, ci, ci_type) {
-
   # when no uncertainty is given
-  if (anyNA(ci_limits)) return(list(
-    ci_limits = NA_real_,
-    ci = c(NA_real_, NA_real_),
-    ci_type = NA_character_
-  ))
+  if (anyNA(ci_limits)) {
+    return(list(
+      ci_limits = NA_real_,
+      ci = c(NA_real_, NA_real_),
+      ci_type = NA_character_
+    ))
+  }
 
   # check input
   checkmate::assert_numeric(ci_limits, any.missing = FALSE, len = 2)
@@ -147,7 +148,6 @@ create_epidist_metadata <- function(sample_size = NA_integer_,
                                     vector = NA_character_,
                                     extrinsic = FALSE,
                                     inference_method = NA_character_) {
-
   # check input
   checkmate::assert_number(
     sample_size,
@@ -200,7 +200,6 @@ create_epidist_region <- function(continent = NA_character_,
                                   country = NA_character_,
                                   region = NA_character_,
                                   city = NA_character_) {
-
   checkmate::assert_string(continent, na.ok = TRUE)
   checkmate::assert_string(country, na.ok = TRUE)
   checkmate::assert_string(region, na.ok = TRUE)
@@ -213,7 +212,6 @@ create_epidist_region <- function(continent = NA_character_,
     region = region,
     city = city
   )
-
 }
 
 #' Specify any reported summary statistics for `epidist`
@@ -285,12 +283,16 @@ create_epidist_summary_stats <- function(mean = NA_real_,
                                          sd_ci_limits = c(NA_real_, NA_real_),
                                          sd_ci = NA_real_,
                                          median = NA_real_,
-                                         median_ci_limits = c(NA_real_,
-                                                              NA_real_),
+                                         median_ci_limits = c(
+                                           NA_real_,
+                                           NA_real_
+                                         ),
                                          median_ci = NA_real_,
                                          dispersion = NA_real_,
-                                         dispersion_ci_limits = c(NA_real_,
-                                                                  NA_real_),
+                                         dispersion_ci_limits = c(
+                                           NA_real_,
+                                           NA_real_
+                                         ),
                                          dispersion_ci = NA_real_,
                                          lower_range = NA_real_,
                                          upper_range = NA_real_,
@@ -301,8 +303,8 @@ create_epidist_summary_stats <- function(mean = NA_real_,
                                            "q_50" = NA_real_,
                                            "q_75" = NA_real_,
                                            "q_95" = NA_real_,
-                                           "q_97.5" = NA_real_)) {
-
+                                           "q_97.5" = NA_real_
+                                         )) {
   # check input
   checkmate::assert_number(mean, na.ok = TRUE)
   checkmate::assert_numeric(mean_ci_limits, len = 2, any.missing = TRUE)
@@ -322,8 +324,8 @@ create_epidist_summary_stats <- function(mean = NA_real_,
 
   stopifnot(
     "quantiles vector should have names with 'q_' prefix" =
-     !is.null(names(quantiles)) &&
-      all(startsWith(x = names(quantiles), prefix = "q_"))
+      !is.null(names(quantiles)) &&
+        all(startsWith(x = names(quantiles), prefix = "q_"))
   )
 
   # return list of summary stats
@@ -530,7 +532,6 @@ clean_epidist_params <- function(prob_dist_params, ...) {
 #' @return Named vector of parameters
 #' @keywords internal
 clean_epidist_params.gamma <- function(prob_dist_params) {
-
   # if unparameterised return named vector of NAs
   if (isTRUE(is.na(prob_dist_params))) {
     prob_dist_params <- c(shape = NA_real_, scale = NA_real_)
@@ -570,7 +571,6 @@ clean_epidist_params.gamma <- function(prob_dist_params) {
 #' @return Named vector of parameters
 #' @keywords internal
 clean_epidist_params.lnorm <- function(prob_dist_params) {
-
   # if unparameterised return named vector of NAs
   if (isTRUE(is.na(prob_dist_params))) {
     prob_dist_params <- c(meanlog = NA_real_, sdlog = NA_real_)
@@ -579,7 +579,6 @@ clean_epidist_params.lnorm <- function(prob_dist_params) {
 
   # if mu and sigma are provided convert to meanlog and sdlog
   if (all(c("mu", "sigma") %in% names(prob_dist_params))) {
-
     # find index so parameters can be in any order
     mu_index <- which(names(prob_dist_params) == "mu")
     sigma_index <- which(names(prob_dist_params) == "sigma")
@@ -612,7 +611,6 @@ clean_epidist_params.lnorm <- function(prob_dist_params) {
 #' @return Named vector of parameters
 #' @keywords internal
 clean_epidist_params.weibull <- function(prob_dist_params) {
-
   # if unparameterised return named vector of NAs
   if (isTRUE(is.na(prob_dist_params))) {
     prob_dist_params <- c(shape = NA_real_, scale = NA_real_)
@@ -640,7 +638,6 @@ clean_epidist_params.weibull <- function(prob_dist_params) {
 #' @return Named vector of parameters
 #' @keywords internal
 clean_epidist_params.nbinom <- function(prob_dist_params) {
-
   # if unparameterised return named vector of NAs
   if (isTRUE(is.na(prob_dist_params))) {
     prob_dist_params <- c(mean = NA_real_, dispersion = NA_real_)
@@ -648,7 +645,6 @@ clean_epidist_params.nbinom <- function(prob_dist_params) {
   }
 
   if (all(c("n", "p") %in% names(prob_dist_params))) {
-
     # convert prob to mean
     prob_dist_params[["p"]] <- convert_params_to_summary_stats(
       distribution = "nbinom",
@@ -691,7 +687,6 @@ clean_epidist_params.nbinom <- function(prob_dist_params) {
 #' @return Named vector of parameters
 #' @keywords internal
 clean_epidist_params.geom <- function(prob_dist_params) {
-
   # if unparameterised return named NA
   if (isTRUE(is.na(prob_dist_params))) {
     prob_dist_params <- c(prob = NA_real_)
@@ -713,7 +708,6 @@ clean_epidist_params.geom <- function(prob_dist_params) {
 
     # return prob_dist_params
     return(prob_dist_params)
-
   } else if ("p" %in% names(prob_dist_params)) {
     names(prob_dist_params) <- gsub(
       pattern = "^p$",
@@ -747,7 +741,6 @@ clean_epidist_params.geom <- function(prob_dist_params) {
 #' @return Named vector of parameters
 #' @keywords internal
 clean_epidist_params.pois <- function(prob_dist_params) {
-
   # if unparameterised return named NA
   if (isTRUE(is.na(prob_dist_params))) {
     prob_dist_params <- c(mean = NA_real_)
@@ -768,7 +761,6 @@ clean_epidist_params.pois <- function(prob_dist_params) {
       call. = FALSE
     )
   }
-
 }
 
 #' Default method if class of parameters is not recognised

--- a/R/epidist_utils.R
+++ b/R/epidist_utils.R
@@ -1,22 +1,22 @@
 #' Specify distribution parameter uncertainty
 #'
 #' @description A helper function when creating uncertainty for the parameters
-#' of the distribution for the `epidist` object
+#' of the distribution for the `<epidist>` object.
 #'
 #' @param ci_limits A numeric vector of length two with the lower and upper
-#' bound of the confidence interval or credible interval
+#' bound of the confidence interval or credible interval.
 #' @param ci A numeric specifying the interval for the ci, e.g. 95 is
-#' 95% ci
-#' @param ci_type A character string, either "confidence interval" or "credible
-#' interval"
+#' 95% ci.
+#' @param ci_type A character string, either `"confidence interval"` or
+#' `"credible interval"`.
 #'
 #' @return List of three elements:
 #'
 #' 1. `$ci_limits` is the upper and lower bounds
 #' of the CI (either confidence interval or credible interval) (i.e. a two
-#' element numeric vector)
+#' element numeric vector).
 #' 2. `$ci` the interval (e.g. 95 is 95% CI) given by a
-#' single numeric
+#' single numeric.
 #' 3. `$ci_type` a character string specifying the type of
 #' uncertainty (can be either `"confidence interval"` or `"credible interval"`).
 #' @export
@@ -79,9 +79,9 @@ create_epidist_uncertainty <- function(ci_limits = NA_real_, ci, ci_type) {
 
 #' Specify metadata associated with data set
 #'
-#' @description A helper function when creating an epidist object to create a
-#' metadata list with sensible defaults, type checking and arguments to help
-#' remember metadata list structure (element names)
+#' @description A helper function when creating an `<epidist>` object to
+#' create a metadata list with sensible defaults, type checking and arguments
+#' to help remember metadata list structure (element names).
 #'
 #' @details In vector-borne diseases the transmissibility of a disease is
 #' dependent on both the time taken for a host (i.e. human) to become
@@ -186,12 +186,12 @@ create_epidist_metadata <- function(sample_size = NA_integer_,
 #' region at either continent, country, region or city level. By specifying
 #' the level of the geography the other fields may be deduced.
 #'
-#' @param continent A character string specifying the continent
-#' @param country A character string specifying the country
-#' @param region A character string specifying the region
-#' @param city A character string specifying the city
+#' @param continent A `character` string specifying the continent.
+#' @param country A `character` string specifying the country.
+#' @param region A `character` string specifying the region.
+#' @param city A `character` string specifying the city.
 #'
-#' @return A named list
+#' @return A named list.
 #' @export
 #'
 #' @examples
@@ -214,38 +214,40 @@ create_epidist_region <- function(continent = NA_character_,
   )
 }
 
-#' Specify any reported summary statistics for `epidist`
+#' Specify reported summary statistics
 #'
-#' @description A helper function when creating an epidist object to create a
-#' summary statistics list with sensible defaults, type checking and arguments
-#' to help remember which summary statistics can be accepted in the list.
+#' @description A helper function when creating an `<epidist>` object to
+#' create a summary statistics list with sensible defaults, type checking
+#' and arguments to help remember which summary statistics can be accepted in
+#' the list.
 #'
-#' @param mean A numeric of the mean (expectation) of the probability
-#' distribution
-#' @param mean_ci_limits A numeric vector of length two of the confidence
-#' interval around the mean
-#' @param mean_ci A numeric specifying the confidence interval width,
+#' @param mean A `numeric` of the mean (expectation) of the probability
+#' distribution.
+#' @param mean_ci_limits A `numeric` vector of length two of the confidence
+#' interval around the mean.
+#' @param mean_ci A `numeric` specifying the confidence interval width,
 #' e.g. 95 would be the 95% CI
-#' @param sd A numeric of the standard deviation of the probability distribution
-#' @param sd_ci_limits A numeric vector of length 2 of the confidence interval
-#' around the standard deviation
-#' @param sd_ci A numeric specifying the confidence interval width,
-#' e.g. 95 would be 95% confidence interval
-#' @param median A numeric of the median of the probability distribution
-#' @param median_ci_limits A numeric vector of length two of the confidence
-#' interval around the median
-#' @param median_ci A numeric specifying the confidence interval width
-#' of the median
-#' @param dispersion A numeric of the dispersion parameter of a distribution
-#' @param dispersion_ci_limits A numeric vector of length two of the confidence
-#' interval around the dispersion
-#' @param dispersion_ci A numeric specifying the confidence interval
-#' width of the dispersion parameter
+#' @param sd A `numeric` of the standard deviation of the probability
+#' distribution.
+#' @param sd_ci_limits A `numeric` vector of length 2 of the confidence interval
+#' around the standard deviation.
+#' @param sd_ci A `numeric` specifying the confidence interval width,
+#' e.g. 95 would be 95% confidence interval.
+#' @param median A `numeric` of the median of the probability distribution.
+#' @param median_ci_limits A `numeric` vector of length two of the confidence
+#' interval around the median.
+#' @param median_ci A `numeric` specifying the confidence interval width
+#' of the median.
+#' @param dispersion A `numeric` of the dispersion parameter of a distribution.
+#' @param dispersion_ci_limits A `numeric` vector of length two of the
+#' confidence interval around the dispersion.
+#' @param dispersion_ci A `numeric` specifying the confidence interval
+#' width of the dispersion parameter.
 #' @param lower_range The lower range of the data, used to infer the parameters
-#' of the distribution when not provided
+#' of the distribution when not provided.
 #' @param upper_range The upper range of the data, used to infer the parameters
-#' of the distribution when not provided
-#' @param quantiles A numeric vector of the quantiles for the distribution.
+#' of the distribution when not provided.
+#' @param quantiles A `numeric` vector of the quantiles for the distribution.
 #' If quantiles are not provided a default empty vector with the 2.5th, 5th,
 #' 25th, 75th, 95th, 97.5th quantiles are supplied.
 #'
@@ -351,19 +353,19 @@ create_epidist_summary_stats <- function(mean = NA_real_,
   )
 }
 
-#' Create a citation for an epidist object
+#' Create a citation for an `<epidist>` object
 #'
-#' @description A helper function when creating an epidist object to create a
-#' citation list with sensible defaults, type checking and arguments to help
+#' @description A helper function when creating an `<epidist>` object to create
+#' a citation list with sensible defaults, type checking and arguments to help
 #' remember which citation information is accepted in the list.
 #'
-#' @details This function acts as a wrapper around [`bibentry()`] to create
+#' @details This function acts as a wrapper around [bibentry()] to create
 #' citations for sources reporting epidemiological parameters.
 #'
 #' @param author A `character` string of the surname of the first author. This
 #' can be underscore separated from a second author, or underscore separated
 #' from "etal" if there are more than two authors.
-#' @param year A `numeric` of the year of publication
+#' @param year A `numeric` of the year of publication.
 #' @param title A `character` string with the title of the article that
 #' published the epidemiological parameters.
 #' @param journal A `character` string with the name of the journal that
@@ -374,7 +376,7 @@ create_epidist_summary_stats <- function(mean = NA_real_,
 #' @param DOI A `character` string of the Digital Object Identifier (DOI)
 #' assigned to papers which are unique to each paper.
 #'
-#' @return A `bibentry` object of the citation
+#' @return A `<bibentry>` object of the citation
 #' @export
 #'
 #' @examples
@@ -431,12 +433,12 @@ create_epidist_citation <- function(author = NA_character_,
   citation
 }
 
-#' Specify whether certain methodological aspects have been used when fitting
-#' the distribution
+#' Specify methodological aspects of distribution fitting
 #'
-#' @description A helper function when creating an epidist object to create a
-#' method assessment list with sensible defaults, type checking and arguments
-#' to help remember which method assessments can be accepted in the list
+#' @description A helper function when creating an `<epidist>` object to
+#' create a method assessment list with sensible defaults, type checking and
+#' arguments to help remember which method assessments can be accepted in
+#' the list.
 #'
 #' @details Currently, the method assessment focuses on common methodological
 #' aspects of delay distributions (e.g. incubation period, serial interval,
@@ -444,11 +446,11 @@ create_epidist_citation <- function(author = NA_character_,
 #' may be important when fitting offspring distributions to data on disease
 #' (super)spreading.
 #'
-#' @param censored A boolean logical whether the study used single or double
+#' @param censored A boolean `logical` whether the study used single or double
 #' interval censoring in the methods to infer the delay distribution
-#' @param right_truncated A boolean logical whether the study used right-
+#' @param right_truncated A boolean `logical` whether the study used right-
 #' truncation in the methods to infer the delay distribution
-#' @param phase_bias_adjusted A boolean logical whether the study adjusted for
+#' @param phase_bias_adjusted A boolean `logical` whether the study adjusted for
 #' phase bias in the methods to infer the delay distribution
 #'
 #' @return A named list with three elements
@@ -476,13 +478,12 @@ create_epidist_method_assess <- function(censored = NA,
   )
 }
 
-#' A helper function to check whether the vector of parameters for the
-#' probability distribution are in the set of possible parameters used in
-#' the `epiparameter` package
+#' Check whether the vector of parameters for the probability distribution
+#' are in the set of possible parameters used in the epiparameter package
 #'
 #' @inheritParams new_epidist
 #'
-#' @return A logical boolean
+#' @return A boolean `logical`.
 #' @export
 #'
 #' @examples
@@ -525,11 +526,11 @@ clean_epidist_params <- function(prob_dist_params, ...) {
   UseMethod("clean_epidist_params")
 }
 
-#' Standardises parameters for a gamma distribution
+#' Standardise parameters for a gamma distribution
 #'
 #' @inheritParams new_epidist
 #'
-#' @return Named vector of parameters
+#' @return Named `numeric` vector of parameters.
 #' @keywords internal
 clean_epidist_params.gamma <- function(prob_dist_params) {
   # if unparameterised return named vector of NAs
@@ -564,11 +565,11 @@ clean_epidist_params.gamma <- function(prob_dist_params) {
   }
 }
 
-#' Standardises parameters for a lognormal distribution
+#' Standardise parameters for a lognormal distribution
 #'
 #' @inheritParams new_epidist
 #'
-#' @return Named vector of parameters
+#' @return Named `numeric` vector of parameters.
 #' @keywords internal
 clean_epidist_params.lnorm <- function(prob_dist_params) {
   # if unparameterised return named vector of NAs
@@ -604,11 +605,11 @@ clean_epidist_params.lnorm <- function(prob_dist_params) {
   }
 }
 
-#' Standardises parameters for a Weibull distribution
+#' Standardise parameters for a Weibull distribution
 #'
 #' @inheritParams new_epidist
 #'
-#' @return Named vector of parameters
+#' @return Named `numeric` vector of parameters.
 #' @keywords internal
 clean_epidist_params.weibull <- function(prob_dist_params) {
   # if unparameterised return named vector of NAs
@@ -631,11 +632,11 @@ clean_epidist_params.weibull <- function(prob_dist_params) {
   }
 }
 
-#' Standardises parameters for a negative binomial distribution
+#' Standardise parameters for a negative binomial distribution
 #'
 #' @inheritParams new_epidist
 #'
-#' @return Named vector of parameters
+#' @return Named `numeric` vector of parameters.
 #' @keywords internal
 clean_epidist_params.nbinom <- function(prob_dist_params) {
   # if unparameterised return named vector of NAs
@@ -680,11 +681,11 @@ clean_epidist_params.nbinom <- function(prob_dist_params) {
   }
 }
 
-#' Standardises parameters for a geometric distribution
+#' Standardise parameters for a geometric distribution
 #'
 #' @inheritParams new_epidist
 #'
-#' @return Named vector of parameters
+#' @return Named `numeric` vector of parameters.
 #' @keywords internal
 clean_epidist_params.geom <- function(prob_dist_params) {
   # if unparameterised return named NA
@@ -734,11 +735,11 @@ clean_epidist_params.geom <- function(prob_dist_params) {
   }
 }
 
-#' Standardises parameters for a poisson distribution
+#' Standardise parameters for a poisson distribution
 #'
 #' @inheritParams new_epidist
 #'
-#' @return Named vector of parameters
+#' @return Named `numeric` vector of parameters.
 #' @keywords internal
 clean_epidist_params.pois <- function(prob_dist_params) {
   # if unparameterised return named NA
@@ -767,7 +768,7 @@ clean_epidist_params.pois <- function(prob_dist_params) {
 #'
 #' @inheritParams new_epidist
 #'
-#' @return Named vector of parameters
+#' @return Named `numeric` vector of parameters.
 #' @keywords internal
 clean_epidist_params.default <- function(prob_dist_params) {
   # print message that cleaning function not dispatched
@@ -780,11 +781,11 @@ clean_epidist_params.default <- function(prob_dist_params) {
   prob_dist_params
 }
 
-#' Standardises the names of epidemiological distributions
+#' Standardise the names of epidemiological distributions
 #'
-#' @param epi_dist A character string with the name of the distribution
+#' @param epi_dist A `character` string with the name of the distribution.
 #'
-#' @return Character string
+#' @return A `character` vector of equal length to the input.
 #' @export
 #'
 #' @examples
@@ -794,11 +795,11 @@ clean_epidist_name <- function(epi_dist) {
   tolower(out)
 }
 
-#' Standardises the names of diseases
+#' Standardise the names of diseases
 #'
-#' @param x A character string specifying a disease.
+#' @param x A `character` string specifying a disease.
 #'
-#' @return A character string of equal length to the input
+#' @return A `character` vector of equal length to the input.
 #' @export
 clean_disease <- function(x) {
   checkmate::assert_character(x)

--- a/R/epiparam.R
+++ b/R/epiparam.R
@@ -9,7 +9,6 @@
 #' @examples
 #' eparam <- epiparameter:::new_epiparam("all")
 new_epiparam <- function(epi_dist) {
-
   # check input
   checkmate::assert_string(epi_dist)
 
@@ -24,15 +23,18 @@ new_epiparam <- function(epi_dist) {
   # ensure type correctness
   numeric_col <- epiparam_num_fields(params)
   params[numeric_col] <- vapply(
-    params[numeric_col], FUN = as.numeric, FUN.VALUE = numeric(nrow(params))
+    params[numeric_col],
+    FUN = as.numeric, FUN.VALUE = numeric(nrow(params))
   )
   char_col <- epiparam_char_fields(params)
   params[char_col] <- vapply(
-    params[char_col], FUN = as.character, FUN.VALUE = character(nrow(params))
+    params[char_col],
+    FUN = as.character, FUN.VALUE = character(nrow(params))
   )
   logic_col <- epiparam_logic_fields(params)
   params[logic_col] <- vapply(
-    params[logic_col], FUN = as.logical, FUN.VALUE = logical(nrow(params))
+    params[logic_col],
+    FUN = as.logical, FUN.VALUE = logical(nrow(params))
   )
 
   # convert intervals from strings to numeric vectors
@@ -62,7 +64,6 @@ new_epiparam <- function(epi_dist) {
   rownames(params) <- NULL
 
   structure(params, class = c("epiparam", "data.frame"))
-
 }
 
 #' Create an `epiparam` object
@@ -104,14 +105,15 @@ new_epiparam <- function(epi_dist) {
 #'
 #' # subset by disease
 #' influenza_dists <- eparam[eparam$disease == "influenza", ]
-epiparam <- function(epi_dist = c("all",
-                                  "incubation_period",
-                                  "onset_to_hospitalisation",
-                                  "onset_to_death",
-                                  "serial_interval",
-                                  "generation_time",
-                                  "offspring_distribution")) {
-
+epiparam <- function(epi_dist = c(
+                       "all",
+                       "incubation_period",
+                       "onset_to_hospitalisation",
+                       "onset_to_death",
+                       "serial_interval",
+                       "generation_time",
+                       "offspring_distribution"
+                     )) {
   # check input
   epi_dist <- match.arg(arg = epi_dist, several.ok = FALSE)
 
@@ -137,7 +139,6 @@ epiparam <- function(epi_dist = c("all",
 #' @return Invisibly returns an [`epiparam`]. Called for side-effects
 #' (errors when invalid `epiparam` object is provided).
 validate_epiparam <- function(epiparam, reconstruct = FALSE) {
-
   if (!is_epiparam(epiparam) && isFALSE(reconstruct)) {
     stop("Object should be of class epiparam", call. = FALSE)
   }
@@ -157,12 +158,13 @@ validate_epiparam <- function(epiparam, reconstruct = FALSE) {
       all(epiparam$year > 0 | is.na(epiparam$year))
   )
 
-  check_limits <- apply(epiparam, MARGIN = 2, FUN = function(x) { # nolint
-    vapply(x, function(y) {
-      length(y) == 2 && is.numeric(y)
-    }, FUN.VALUE = logical(1))
-  },
-  simplify = FALSE
+  check_limits <- apply(epiparam,
+    MARGIN = 2, FUN = function(x) { # nolint
+      vapply(x, function(y) {
+        length(y) == 2 && is.numeric(y)
+      }, FUN.VALUE = logical(1))
+    },
+    simplify = FALSE
   )
 
   check_limits <- all(unlist(
@@ -262,7 +264,8 @@ summary.epiparam <- function(object, ...) {
   num_delay_dist <- sum(
     object$epi_distribution %in% c(
       "incubation_period", "generation_time",
-      "serial_interval", "onset_to_death")
+      "serial_interval", "onset_to_death"
+    )
   )
   num_offspring_dist <- sum(
     object$epi_distribution %in% "offspring_distribution"
@@ -272,14 +275,15 @@ summary.epiparam <- function(object, ...) {
   num_disc_dist <- sum(object$discetised)
   num_vector_borne <- sum(object$extrinsic)
   # return epiparam summary
-  list(num_entries = num_entries,
-       num_diseases = num_diseases,
-       num_delay_dist = num_delay_dist,
-       num_offspring_dist = num_offspring_dist,
-       num_studies = num_studies,
-       num_continuous_distributions = num_cont_dist,
-       num_discrete_distributions = num_disc_dist,
-       num_vector_borne_diseases = num_vector_borne
+  list(
+    num_entries = num_entries,
+    num_diseases = num_diseases,
+    num_delay_dist = num_delay_dist,
+    num_offspring_dist = num_offspring_dist,
+    num_studies = num_studies,
+    num_continuous_distributions = num_cont_dist,
+    num_discrete_distributions = num_disc_dist,
+    num_vector_borne_diseases = num_vector_borne
   )
 }
 
@@ -298,7 +302,7 @@ summary.epiparam <- function(object, ...) {
 #' head(epiparam())
 #' tail(epiparam())
 head.epiparam <- function(x, ...) {
- utils::head(as.data.frame(x), ...)
+  utils::head(as.data.frame(x), ...)
 }
 
 #' @rdname head.epiparam
@@ -313,7 +317,8 @@ tail.epiparam <- function(x, ...) {
 #' @keywords internal
 #' @noRd
 epiparam_fields <- function() {
-  c("disease", "pathogen", "epi_distribution", "author", "title", "journal",
+  c(
+    "disease", "pathogen", "epi_distribution", "author", "title", "journal",
     "year", "sample_size", "region", "transmission_mode", "vector",
     "extrinsic", "prob_distribution", "inference_method", "mean",
     "mean_ci_limits", "mean_ci", "sd", "sd_ci_limits", "sd_ci", "quantile_2.5",
@@ -325,7 +330,8 @@ epiparam_fields <- function() {
     "dispersion_ci_limits", "dispersion_ci", "precision",
     "precision_ci_limits", "precision_ci", "truncation", "discretised",
     "censored", "right_truncated", "phase_bias_adjusted", "notes", "PMID",
-    "DOI")
+    "DOI"
+  )
 }
 
 #' Character fields (columns) of an `<epiparam>` object

--- a/R/epiparam.R
+++ b/R/epiparam.R
@@ -1,9 +1,11 @@
-#' epiparam constructor
+#' Constructor for `<epiparam>` class
 #'
 #' @description The constructor reads the data stored internally in the package
-#' and subsets by epidemiological distribution (epi_dist)
+#' and subsets by epidemiological distribution (`epi_dist`).
 #'
-#' @return epiparam object
+#' @inheritParams epidist
+#'
+#' @inherit epiparam return
 #' @keywords internal
 #'
 #' @examples
@@ -66,34 +68,34 @@ new_epiparam <- function(epi_dist) {
   structure(params, class = c("epiparam", "data.frame"))
 }
 
-#' Create an `epiparam` object
+#' Create an `<epiparam>` object
 #'
-#' @description The `epiparam` class holds information on epidemiological
+#' @description The `<epiparam>` class holds information on epidemiological
 #' distribution and their estimated parameters as well as other information and
 #' metadata. This library of epidemiological parameters is compiled from
-#' primary literature sources. An `epiparam` object can be used to compare the
+#' primary literature sources. An `<epiparam>` object can be used to compare the
 #' availability of distribution for a certain disease or pathogen, or refine
-#' by, for example, region or sample size. Additionally, the `epiparam` class
-#' can be subset and converted into `epidist` or `vb_epidist` objects to the be
-#' used in epidemiological analysis in which a delay distribution or offspring
-#' distribution is required.
+#' by, for example, region or sample size. Additionally, the `<epiparam>` class
+#' can be subset and converted into `<epidist>` or `<vb_epidist>` objects to
+#' the be used in epidemiological analysis in which a delay distribution or
+#' offspring distribution is required.
 #'
-#' The `epiparam()` function reads the library of epidemiological parameters
-#' from `{epiparameter}` into memory and stores it as an `epiparam` object.
+#' The [epiparam()] function reads the library of epidemiological parameters
+#' from `{epiparameter}` into memory and stores it as an `<epiparam>` object.
 #'
-#' @details The `epiparam` object has certain protected fields, and thus if
+#' @details The `<epiparam>` object has certain protected fields, and thus if
 #' one of these protected fields is removed when subsetting columns an error
 #' will be returned. The subsetting checks are carried out by
-#' [`validate_epiparam()`].
+#' [validate_epiparam()].
 #'
-#' `epiparam` objects can be added to by using [`bind_epiparam()`] to add either
-#' `epidist`s, `vb_epdist`s, `epiparam`s, lists of `epdist` objects, or data
-#' frames with the correct columns to an existing `epiparam` object.
+#' Data can be added to `<epiparam>` objects by using [bind_epiparam()], this
+#' can add information from `<epidist>`, `<vb_epdist>`, `<epiparam>`, lists
+#' of `<epdist>` objects, or data frames with the correct columns to an
+#' existing `<epiparam>` object.
 #'
-#' @param epi_dist A character string of which epidemiological distributions
-#' to select
+#' @inheritParams epidist
 #'
-#' @return `epiparam` object
+#' @return An `<epiparam>` object.
 #' @export
 #'
 #' @examples
@@ -127,17 +129,17 @@ epiparam <- function(epi_dist = c(
   epiparam
 }
 
-#' `epiparam` class validator
+#' Validator for `<epiparam>` class
 #'
-#' @param epiparam An `epiparam` object
-#' @param reconstruct A boolean logical determining whether the validation
+#' @param epiparam An `<epiparam>` object.
+#' @param reconstruct A boolean `logical` determining whether the validation
 #' should be class specific. When `TRUE` the input object must be of type
-#' `epiparam` (default), when `FALSE` the input object can be of another class,
-#' e.g. `data.frame`. This argument is used in reconstruction operations see
-#' [`epiparam_reconstruct()`].
+#' `<epiparam>` (default), when `FALSE` the input object can be of another
+#' class, e.g. data frame. This argument is used in reconstruction operations
+#' see [`epiparam_reconstruct()`].
 #'
-#' @return Invisibly returns an [`epiparam`]. Called for side-effects
-#' (errors when invalid `epiparam` object is provided).
+#' @return Invisibly returns an `<epiparam>`. Called for side-effects
+#' (errors when invalid `<epiparam>` object is provided).
 validate_epiparam <- function(epiparam, reconstruct = FALSE) {
   if (!is_epiparam(epiparam) && isFALSE(reconstruct)) {
     stop("Object should be of class epiparam", call. = FALSE)
@@ -178,12 +180,12 @@ validate_epiparam <- function(epiparam, reconstruct = FALSE) {
   invisible(epiparam)
 }
 
-#' Print method for epiparam class
+#' Print method for `<epiparam>` class
 #'
-#' @param x epiparam object
-#' @param ... further arguments passed to or from other methods
+#' @param x An `<epiparam>` object.
+#' @inheritParams print.epidist
 #'
-#' @return Nothing (prints output)
+#' @return Invisibly returns an `<epiparam>`. Called for side-effects.
 #' @export
 #'
 #' @examples
@@ -193,12 +195,11 @@ print.epiparam <- function(x, ...) {
   format(x, ...)
 }
 
-#' Format method for epiparam class
+#' Format method for `<epiparam>` class
 #'
-#' @param x epiparam object
-#' @param ... further arguments passed to or from other methods
+#' @inheritParams print.epiparam
 #'
-#' @return Invisibly returns an [`epiparam`]. Called for printing side-effects.
+#' @return Invisibly returns an `<epiparam>`. Called for printing side-effects.
 #' @export
 #'
 #' @examples
@@ -231,12 +232,12 @@ format.epiparam <- function(x, ...) {
   invisible(x)
 }
 
-#' Checks whether the object is an `epiparam`
+#' Check object is an `<epiparam>`
 #'
-#' @param x An R object
+#' @inheritParams is_epidist
 #'
-#' @return A boolean logical, `TRUE` if the object is an `epiparam` and `FALSE`
-#' if not
+#' @return A boolean `logical`, `TRUE` if the object is an `<epiparam>` and
+#' `FALSE` if not.
 #' @export
 #'
 #' @examples
@@ -247,10 +248,10 @@ is_epiparam <- function(x) {
   inherits(x, "epiparam")
 }
 
-#' Summary method for epiparam class
+#' Summary method for `<epiparam>` class
 #'
-#' @param object epiparam object
-#' @param ... further arguments passed to or from other methods
+#' @param object An `<epiparam>` object.
+#' @inheritParams is_parameterised
 #'
 #' @return data frame of information
 #' @export
@@ -259,6 +260,7 @@ is_epiparam <- function(x) {
 #' x <- epiparam()
 #' summary(x)
 summary.epiparam <- function(object, ...) {
+  chkDots(...)
   num_entries <- nrow(object)
   num_diseases <- length(unique(object$disease))
   num_delay_dist <- sum(
@@ -287,10 +289,9 @@ summary.epiparam <- function(object, ...) {
   )
 }
 
-#' `head` and `tail` methods for [`epiparam`] class
+#' [head()] and [tail()] methods for `<epiparam>` class
 #'
-#' @param x An [`epiparam`] object
-#' @param ... further arguments passed to or from other methods
+#' @inheritParams print.epiparam
 #'
 #' @return Data frame
 #' @export
@@ -311,9 +312,9 @@ tail.epiparam <- function(x, ...) {
   utils::tail(as.data.frame(x), ...)
 }
 
-#' Fields (columns) of an `<epiparam>` object
+#' State column names of an `<epiparam>` object
 #'
-#' @return Character vector
+#' @return `Character` vector.
 #' @keywords internal
 #' @noRd
 epiparam_fields <- function() {
@@ -334,9 +335,9 @@ epiparam_fields <- function() {
   )
 }
 
-#' Character fields (columns) of an `<epiparam>` object
+#' State columns of `<epiparam>` object containing `character`s
 #'
-#' @return Numeric vector
+#' @return `Numeric` vector.
 #' @keywords internal
 #' @noRd
 epiparam_char_fields <- function(epiparam) {
@@ -349,9 +350,9 @@ epiparam_char_fields <- function(epiparam) {
   )
 }
 
-#' Numeric fields (columns) of an `<epiparam>` object
+#' State columns of `<epiparam>` object containing `numeric`s
 #'
-#' @return Numeric vector
+#' @return `Numeric` vector.
 #' @keywords internal
 #' @noRd
 epiparam_num_fields <- function(epiparam) {
@@ -367,6 +368,11 @@ epiparam_num_fields <- function(epiparam) {
   )
 }
 
+#' State columns of `<epiparam>` object containing `logical`s
+#'
+#' @return `Numeric` vector.
+#' @keywords internal
+#' @noRd
 epiparam_logic_fields <- function(epiparam) {
   which(
     colnames(epiparam) %in% c(

--- a/R/epiparam_utils.R
+++ b/R/epiparam_utils.R
@@ -13,11 +13,10 @@
 #'
 #' @examples
 #' \donttest{
-#'   eparam <- epiparam()
-#'   as_epidist(eparam[1, ])
+#' eparam <- epiparam()
+#' as_epidist(eparam[1, ])
 #' }
 as_epidist <- function(x) {
-
   # check input
   validate_epiparam(x)
 
@@ -45,7 +44,6 @@ as_epidist <- function(x) {
 #' @return An `epidist` object
 #' @keywords internal
 make_epidist <- function(x) {
-
   # determine parameters
   if (x$prob_distribution %in% c("gamma", "weibull")) {
     parameters <- c(shape = x$shape, scale = x$scale)
@@ -53,7 +51,7 @@ make_epidist <- function(x) {
       shape = create_epidist_uncertainty(
         ci_limits = x$shape_ci_limits,
         ci = x$shape_ci,
-        ci_type =  ifelse(
+        ci_type = ifelse(
           test = x$inference_method == "mle",
           yes = "confidence interval",
           no = "credible interval"
@@ -75,7 +73,7 @@ make_epidist <- function(x) {
       meanlog = create_epidist_uncertainty(
         ci_limits = x$meanlog_ci_limits,
         ci = x$meanlog_ci,
-        ci_type =  ifelse(
+        ci_type = ifelse(
           test = x$inference_method == "mle",
           yes = "confidence interval",
           no = "credible interval"
@@ -97,7 +95,7 @@ make_epidist <- function(x) {
       mean = create_epidist_uncertainty(
         ci_limits = x$mean_ci_limits,
         ci = x$mean_ci,
-        ci_type =  ifelse(
+        ci_type = ifelse(
           test = x$inference_method == "mle",
           yes = "confidence interval",
           no = "credible interval"
@@ -119,7 +117,7 @@ make_epidist <- function(x) {
       mean = create_epidist_uncertainty(
         ci_limits = x$mean_ci_limits,
         ci = x$mean_ci,
-        ci_type =  ifelse(
+        ci_type = ifelse(
           test = x$inference_method == "mle",
           yes = "confidence interval",
           no = "credible interval"
@@ -206,7 +204,6 @@ make_epidist <- function(x) {
 #' )
 #' as_epiparam(edist)
 as_epiparam <- function(x) {
-
   # for vb_epidist or list of epidists call as_epiparam recursively
   if (!is_epidist(x)) {
     eparam <- as.data.frame(matrix(nrow = length(x), ncol = 58))
@@ -245,7 +242,8 @@ as_epiparam <- function(x) {
       x$uncertainty,
       function(x) {
         list(ci_limits = NA_real_, ci = NA_real_, ci_type = NA_character_)
-      })
+      }
+    )
   }
 
   author <- ifelse(
@@ -362,7 +360,7 @@ as_epiparam <- function(x) {
     ),
     DOI = ifelse(
       test = is.null(x$citation$doi),
-      yes =  NA_character_,
+      yes = NA_character_,
       no = x$citation$doi
     )
   )
@@ -390,7 +388,6 @@ as_epiparam <- function(x) {
 #' @keywords internal
 #' @noRd
 add_ci_limits <- function(eparam, x) {
-
   if (is.null(x$uncertainty[["shape"]])) {
     eparam$shape_ci_limits <- I(list(c(NA_real_, NA_real_)))
   } else {
@@ -512,10 +509,11 @@ epiparam_reconstruct <- function(x, to) {
 #' @return A boolean logical (`TRUE` or `FALSE`)
 #' @keywords internal
 epiparam_can_reconstruct <- function(x) {
-
   # check whether input is valid, ignoring its class
   out <- tryCatch(
-    { validate_epiparam(x, reconstruct = TRUE) },
+    {
+      validate_epiparam(x, reconstruct = TRUE)
+    },
     error = function(cnd) FALSE
   )
 

--- a/R/epiparam_utils.R
+++ b/R/epiparam_utils.R
@@ -1,14 +1,16 @@
-#' Converts rows of an epiparam object into an epidist object
+#' Convert `<epiparam>` to `<epidist>`
 #'
-#' @description Can convert the entries (rows) of an epiparam object to one or
-#' list of several epidist objects. This allows subsetting of epiparam records
-#' into a class that can then be used to to calculate the cdf, random number
-#' generation and other methods of the epidist class
-#' (see `?epidist_distribution_functions`).
+#' @description Convert the entries (rows) of an `<epiparam>` object to one or
+#' list of several `<epidist>` objects.
 #'
-#' @param x A epiparam object
+#' Epidemiological distributions and parameters can be converted from database
+#' entries (i.e. rows in `<epiparam>`) into `<epidist>` objects in order
+#' use the distribution functions (see `?epidist_distribution_functions`) and
+#' and other methods of the `<epidist>` class.
 #'
-#' @return An epidist object or a list of epidist objects
+#' @param x A `<epiparam>` object.
+#'
+#' @return An `<epidist>` object or a list of `<epidist>` objects.
 #' @export
 #'
 #' @examples
@@ -33,15 +35,16 @@ as_epidist <- function(x) {
   out
 }
 
-#' Creates an `epidist` object from a list of input from an `epiparam` object
+#' Create an `<epidist>` object from a list of input from an
+#' `<epiparam>` object
 #'
-#' @description Unpacks list of inputs from an epiparam object into the epidist
-#' helper, including the parameters and uncertainty from the correct type of
-#' probability distribution
+#' @description Unpacks list of inputs from an `<epiparam>` object into
+#' the `<epidist>` helper, including the parameters and uncertainty from
+#' the correct type of probability distribution.
 #'
-#' @param x List of data to be used to construct an epidist object
+#' @param x List of data to be used to construct an `<epidist>` object.
 #'
-#' @return An `epidist` object
+#' @inherit epidist return
 #' @keywords internal
 make_epidist <- function(x) {
   # determine parameters
@@ -188,11 +191,11 @@ make_epidist <- function(x) {
   )
 }
 
-#' Converts an `epidist` object to an `epiparam` object
+#' Convert an `<epidist>` object to an `<epiparam>` object
 #'
-#' @param x An `epidist` object
+#' @inheritParams print.epidist
 #'
-#' @return An `epiparam` object
+#' @return An `<epiparam>` object.
 #' @export
 #'
 #' @examples
@@ -382,7 +385,7 @@ as_epiparam <- function(x) {
 #' data frame
 #'
 #' @param eparam A data frame with `<epiparam>` data
-#' @param x An `<epidist>` object
+#' @inheritParams print.epidist
 #'
 #' @return A data frame containing `<epiparam>` data
 #' @keywords internal
@@ -428,15 +431,15 @@ add_ci_limits <- function(eparam, x) {
   eparam
 }
 
-#' Subsetting method for `epiparam`
+#' Subset method for `<epiparam>` class
 #'
-#' @description If the subsetting invalidates the `epiparam` object (defined by
-#' its invariants, and encoded in [`validate_epiparam()`]) the subsetting will
-#' return a data frame with a message to console stating the class of the object
-#' has been converted to `data.frame` with the other attributes of the class
-#' preserved.
+#' @description If the subsetting invalidates the `<epiparam>` object (defined
+#' by its invariants, and encoded in [validate_epiparam()]) the subsetting
+#' will return a data frame with a message to console stating the class of the
+#' object has been converted to `data.frame` with the other attributes of the
+#' class preserved.
 #'
-#' @param epiparam An `epiparam` object
+#' @inheritParams validate_epiparam
 #' @inheritParams base::subset
 #'
 #' @return An `epiparam` object or a `data.frame`
@@ -446,12 +449,12 @@ add_ci_limits <- function(eparam, x) {
   epiparam_reconstruct(out, epiparam)
 }
 
-#' Set names on `epiparam` class
+#' Set names for `<epiparam>` class
 #'
-#' @description If the modifying the names invalidates the `epiparam` object
-#' (defined by its invariants, and encoded in [`validate_epiparam()`]) the
+#' @description If the modifying the names invalidates the `<epiparam>` object
+#' (defined by its invariants, and encoded in [validate_epiparam()]) the
 #' subsetting will return a data frame with a message to console stating the
-#' class of the object has been converted to `data.frame` with the other
+#' class of the object has been converted to data frame with the other
 #' attributes of the class preserved.
 #'
 #' @inheritParams base::names
@@ -475,17 +478,17 @@ add_ci_limits <- function(eparam, x) {
   epiparam_reconstruct(out, x)
 }
 
-#' Decides whether `epiparam` object can be reconstructed from input
+#' Decide whether `<epiparam>` object can be reconstructed from input
 #'
-#' @description Uses [`epiparam_can_reconstruct()`] to determine whether the
-#' data input can be reconstructed in a valid `epiparam` object. If it can not,
-#' it is returned as a `data.frame`.
+#' @description Uses [epiparam_can_reconstruct()] to determine whether the
+#' data input can be reconstructed in a valid `<epiparam>` object. If it can
+#' not, it is returned as a data frame.
 #'
-#' @param x A `data.frame` or subclass of `data.frame` (e.g. `tibble` or
-#' `epiparam`)
-#' @param to The reference object, in this case an `epiparam` object
+#' @param x A `data.frame` or subclass of `data.frame` (e.g. `<tibble>` or
+#' `<epiparam>`).
+#' @param to The reference object, in this case an `<epiparam>` object.
 #'
-#' @return An `epiparam` object (if the input is valid) or a `data.frame`
+#' @return An `<epiparam>` object (if the input is valid) or a `data.frame`.
 #' @keywords internal
 epiparam_reconstruct <- function(x, to) {
   if (epiparam_can_reconstruct(x)) {
@@ -497,16 +500,16 @@ epiparam_reconstruct <- function(x, to) {
   }
 }
 
-#' Checks whether the `epiparam` object is valid
+#' Check whether the `<epiparam>` object is valid
 #'
-#' @description This is a wrapper for [`validate_epiparam`] in a [`tryCatch()`]
+#' @description This is a wrapper for [validate_epiparam()] in a [tryCatch()]
 #' in order to not error if the input object is invalid and returns `TRUE` or
 #' `FALSE` on if the object is valid. If the object is valid it can be
 #' "reconstructed" and not downgraded to a `data.frame`.
 #'
 #' @inheritParams epiparam_reconstruct
 #'
-#' @return A boolean logical (`TRUE` or `FALSE`)
+#' @return A boolean `logical`.
 #' @keywords internal
 epiparam_can_reconstruct <- function(x) {
   # check whether input is valid, ignoring its class
@@ -521,11 +524,11 @@ epiparam_can_reconstruct <- function(x) {
   !isFALSE(out)
 }
 
-#' Transplants the attributes of one input (`to`) to the other input (`x`)
+#' Transplant the attributes of one input (`to`) to the other input (`x`)
 #'
 #' @inheritParams epiparam_reconstruct
 #'
-#' @return An `epiparam` object
+#' @inherit epiparam return
 #' @keywords internal
 df_reconstruct <- function(x, to) {
   attrs <- attributes(to)

--- a/R/extract_param.R
+++ b/R/extract_param.R
@@ -17,9 +17,9 @@
 #' distribution negative values are allowed.
 #'
 #' @param type A `character` defining whether summary statistics based
-#' around `percentiles` (default) or `range`
+#' around `percentiles` (default) or `range`.
 #' @param values A `vector`. If `type = percentiles`: `c(percentile_1,
-#' percentile_2)`; and if `type = range`: `c(median, min, max)`
+#' percentile_2)`; and if `type = range`: `c(median, min, max)`.
 #' @param distribution A `character` specifying distribution to use.
 #' Default is `lnorm`; also takes `gamma`, `weibull` and `norm`.
 #' @param percentiles A `vector` with two elements specifying the
@@ -33,9 +33,9 @@
 #' the parameter extraction will run optimisation before returning result early.
 #' This prevents overly long optimisation loops if optimisation is unstable and
 #' does not converge over multiple iterations. Default is 1000 iterations. List
-#' element `$tolerance` is passed to [`check_optim_conv()`] for tolerance on
+#' element `$tolerance` is passed to [check_optim_conv()] for tolerance on
 #' parameter convergence over iterations of optimisation. Elements of in the
-#' control list are not passed to [`optim()`].
+#' control list are not passed to [optim()].
 #'
 #' @return A named `numeric` vector with the parameter values of the
 #' distribution. If the `distribution = lnorm` then the parameters returned are
@@ -186,7 +186,7 @@ extract_param <- function(type = c("percentiles", "range"),
 #'
 #' @inheritParams extract_param
 #'
-#' @return A list with output from [`stats::optim()`].
+#' @return A list with output from [stats::optim()].
 #' @keywords internal
 .extract_param <- function(values,
                            distribution,
@@ -240,7 +240,7 @@ extract_param <- function(type = c("percentiles", "range"),
   optim_params
 }
 
-#' Checks whether the optimisation of distribution parameters has converged to
+#' Check whether the optimisation of distribution parameters has converged to
 #' stable value for the parameters and function output for multiple iterations
 #'
 #' @description This function is to try and prevent optimisation to a local
@@ -248,8 +248,8 @@ extract_param <- function(type = c("percentiles", "range"),
 #' consistently finding parameter values to within a set tolerance.
 #'
 #' @param optim_params_list A list, where each element is the output of
-#' stats::optim. See ?optim for more details
-#' @param optim_params A list given by the output of stats::optim
+#' [stats::optim()]. See `?optim` for more details.
+#' @param optim_params A list given by the output of [stats::optim()].
 #' @param tolerance A `numeric` specifying within which disparity convergence
 #' of parameter estimates and function minimisation is accepted.
 #'
@@ -287,12 +287,12 @@ check_optim_conv <- function(optim_params_list,
 #' distribution (lognormal, gamma, Weibull, normal) via optimisation from
 #' either the percentiles or the median and ranges.
 #'
-#' @param param Named numeric vector of the distribution parameters to be
-#' optimised
-#' @param val Numeric vector, in the case of using percentiles it contains the
-#' values at the percentiles and the percentiles, in the case of median and
+#' @param param Named `numeric` vector of the distribution parameters to be
+#' optimised.
+#' @param val `Numeric` vector, in the case of using percentiles it contains
+#' the values at the percentiles and the percentiles, in the case of median and
 #' range it contains the median, lower range, upper range and the number of
-#' sample points to evaluate the function at
+#' sample points to evaluate the function at.
 #' @param dist A `character` string with the name of the distribution for
 #' fitting. Naming follows the base R distribution names (e.g. `lnorm` for
 #' lognormal).

--- a/R/get_percentiles.R
+++ b/R/get_percentiles.R
@@ -23,13 +23,12 @@
 #'
 #' @examples
 #' \dontrun{
-#'   # 90th interval
-#'   get_percentiles(c(q_5 = 1, q_95 = 10))
-#'   # 95th interval
-#'   get_percentiles(c(q_2.5 = 1, q_97.5 = 10))
+#' # 90th interval
+#' get_percentiles(c(q_5 = 1, q_95 = 10))
+#' # 95th interval
+#' get_percentiles(c(q_2.5 = 1, q_97.5 = 10))
 #' }
 get_percentiles <- function(percentiles) {
-
   # check input
   checkmate::assert_numeric(percentiles, names = "unique")
 
@@ -64,7 +63,6 @@ get_percentiles <- function(percentiles) {
 #' and upper (second element) percentiles
 #' @keywords internal
 get_sym_percentiles <- function(percentiles) {
-
   # make a copy of percentiles
   percentiles_ <- percentiles
 
@@ -80,7 +78,7 @@ get_sym_percentiles <- function(percentiles) {
 
   # if upper or lower percentiles are not available return percentiles
   if (identical(length(lower_intervals), 0L) ||
-      identical(length(upper_intervals), 0L)) {
+    identical(length(upper_intervals), 0L)) {
     return(NA)
   }
 

--- a/R/get_percentiles.R
+++ b/R/get_percentiles.R
@@ -1,9 +1,9 @@
-#' Converts a vector of named percentiles into correct format and selects two
+#' Convert a vector of named percentiles into correct format and selects two
 #' values for parameter extraction
 #'
 #' @description Parameters of a probability distribution can be extracted using
 #' the values given at percentiles of the distribution and the percentiles using
-#' [`extract_param()`]. `get_percentiles()` takes a named vector of percentiles
+#' [extract_param()]. [get_percentiles()] takes a named vector of percentiles
 #' (names) and values at those percentiles (elements in the vector) and selects
 #' two values as lower and upper percentiles to be used in extraction. If a
 #' lower and upper percentile are not available `NA` is returned.
@@ -18,7 +18,7 @@
 #' @param percentiles A named vector of values at percentiles with the names the
 #' percentiles. See Details for the accepted vector name format.
 #'
-#' @return A named vector of percentiles
+#' @return A named `numeric` vector of percentiles.
 #' @keywords internal
 #'
 #' @examples
@@ -59,8 +59,8 @@ get_percentiles <- function(percentiles) {
 #' @param percentiles A named vector of percentiles. The names are in the
 #' correct format to be converted to their numeric value using `as.numeric()`.
 #'
-#' @return A named numeric vector of two elements with the lower (first element)
-#' and upper (second element) percentiles
+#' @return A named `numeric` vector of two elements with the lower
+#' (first element) and upper (second element) percentiles.
 #' @keywords internal
 get_sym_percentiles <- function(percentiles) {
   # make a copy of percentiles

--- a/R/list_distributions.R
+++ b/R/list_distributions.R
@@ -9,7 +9,7 @@
 #' and the year of publication as well as the sample size of the study. If the
 #' all columns of the database are required set `subset_db = FALSE`.
 #'
-#' @param epiparam An `epiparam` object
+#' @inheritParams validate_epiparam
 #' @param epi_dist A character defining parameter to be listed:
 #' `"incubation"`, `"onset_to_hospitalisation"`, `"onset_to_death"`, or
 #' `"serial_interval"`. `"incubation_period"` is the default `epi_dist` so if no

--- a/R/utils.R
+++ b/R/utils.R
@@ -4,14 +4,14 @@
 #' @description This function can be used in cases where the data on a fitted
 #' distribution is not openly available and the summary statistics of the
 #' distribution are not reported so the data are scraped from the plot and
-#' the quantiles are needed in order use the `extract_param()` function
+#' the quantiles are needed in order use the [extract_param()] function.
 #'
-#' @param prob A numeric vector of probabilities
-#' @param days A numeric vector of days
-#' @param quantile A single numeric or vector of numerics specifying which
-#' quantiles to extract from the distribution
+#' @param prob A `numeric` vector of probabilities.
+#' @param days A `numeric` vector of days.
+#' @param quantile A single `numeric` or vector of `numerics` specifying which
+#' quantiles to extract from the distribution.
 #'
-#' @return A named vector of quantiles
+#' @return A named vector of quantiles.
 #' @export
 #'
 #' @examples

--- a/R/vb_epidist.R
+++ b/R/vb_epidist.R
@@ -1,15 +1,16 @@
-#' Constructor for `vb_epidist` class
+#' Constructor for `<vb_epidist>` class
 #'
-#' @description Create an `vb_epidist` object by binding two `epidist` objects
-#' and assigning the `vb_epidist` class. Not extra checks are made as these
-#' take place in the `epidist` helper function.
+#' @description Create an `<vb_epidist>` object by binding two
+#' `<epidist>` objects and assigning the `<vb_epidist>` class.
 #'
 #' @inheritParams vb_epidist
 #'
-#' @return `vb_epidist` object
+#' @return `<vb_epidist>` object
 #' @keywords internal
 new_vb_epidist <- function(intrinsic_epidist,
                            extrinsic_epidist) {
+  # input checking is done in epidist()
+
   # return vb_epidist object
   structure(
     list(
@@ -20,28 +21,28 @@ new_vb_epidist <- function(intrinsic_epidist,
   )
 }
 
-#' Create a `vb_epidist` object
+#' Create a `<vb_epidist>` object
 #'
-#' @param intrinsic_epidist An `epidist` object
-#' @param extrinsic_epidist An `epidist` object
+#' @param intrinsic_epidist An `<epidist>` object.
+#' @param extrinsic_epidist An `<epidist>` object.
 #'
-#' @description The `vb_epidist` class is an extension of the `epidist` class
-#' (although not a subclass of `epidist`). It is is used to store
-#' epidemiological parameters for vector-borne diseases. It has the same
-#' methods (`print()`, `format()`, `plot()`, `generate()`, `cdf()`, `density()`,
-#' `quantile()`) as the `epidist` class and therefore there are used
-#' identically.
+#' @description The `<vb_epidist>` class is an extension of the
+#' `<epidist>` class (although not a subclass of `<epidist>`). It is is
+#' used to store epidemiological parameters for vector-borne diseases.
+#' It has the same methods (`print()`, `format()`, `plot()`, `generate()`,
+#' `cdf()`, `density()`, `quantile()`) as the `<epidist>` class and
+#' therefore they are used identically.
 #'
-#' @details The `epidist` objects should contain metadata (`epidist$metadata`)
-#' indicating it is a vector-borne disease
-#' (`epidist$metadata$transmission_mode == "vector_borne"`) and the extrinsic
+#' @details The `<epidist>` objects should contain metadata
+#' (`epidist$metadata`) indicating it is a vector-borne disease
+#' (`epidist$metadata$transmission_mode = "vector_borne"`) and the extrinsic
 #' distribution should indicate in the metadata that it is the extrinsic
-#' distribution (`epidist$metadata$extrinsic` is TRUE). If these two aspects
+#' distribution (`epidist$metadata$extrinsic = TRUE`). If these two aspects
 #' are not given the construction of the class will throw a warning.
 #'
-#' @seealso [`epidist()`]
+#' @seealso [epidist()]
 #'
-#' @return `vb_epidist` object
+#' @return `<vb_epidist>` object
 #' @export
 #'
 #' @examples
@@ -88,12 +89,12 @@ vb_epidist <- function(intrinsic_epidist,
   vb_epidist
 }
 
-#' `vb_epidist` class validator
+#' Validator for `<vb_epidist>` class
 #'
-#' @param vb_epidist A `vb_epidist` object
+#' @param vb_epidist A `<vb_epidist>` object
 #'
-#' @return Invisibly returns a [`vb_epidist`]. Called for side-effects (errors
-#' when invalid `vb_epidist` object is provided).
+#' @return Invisibly returns a `<vb_epidist>`. Called for side-effects (errors
+#' when invalid `<vb_epidist>` object is provided).
 #' @export
 validate_vb_epidist <- function(vb_epidist) {
   if (!is_vb_epidist(vb_epidist)) {
@@ -149,12 +150,12 @@ validate_vb_epidist <- function(vb_epidist) {
   invisible(vb_epidist)
 }
 
-#' Print method for vb_epidist class
+#' Print method for `<vb_epidist>` class
 #'
-#' @param x vb_epidist object
-#' @param ... further arguments passed to or from other methods
+#' @param x A `<vb_epidist>` object.
+#' @inheritParams print.epidist
 #'
-#' @return Invisibly returns a [`vb_epidist`]. Called for printing
+#' @return Invisibly returns a `<vb_epidist>`. Called for printing
 #' side-effects.
 #' @export
 #'
@@ -178,13 +179,11 @@ print.vb_epidist <- function(x, ...) {
   format(x, ...)
 }
 
-#' Format method for vb_epidist class
+#' Format method for `<vb_epidist>` class
 #'
-#' @param x vb_epidist object
-#' @param ... further arguments passed to or from other methods
+#' @inheritParams print.vb_epidist
 #'
-#' @return Invisibly returns a [`vb_epidist`] object. Usually called for
-#' printing side-effects.
+#' @inherit print.vb_epidist return
 #' @export
 #'
 #' @examples
@@ -211,12 +210,12 @@ format.vb_epidist <- function(x, ...) {
   invisible(x)
 }
 
-#' Checks whether the object is a `vb_epidist`
+#' Check object is a `<vb_epidist>`
 #'
-#' @param x An R object
+#' @inheritParams is_epidist
 #'
-#' @return A boolean logical, `TRUE` if the object is an `vb_epidist` and
-#' `FALSE` if not
+#' @return A boolean `logical`, `TRUE` if the object is a `<vb_epidist>` and
+#' `FALSE` if not.
 #' @export
 #'
 #' @examples
@@ -245,18 +244,16 @@ is_vb_epidist <- function(x) {
   inherits(x, "vb_epidist")
 }
 
-#' Plots an `vb_epidist` object,
+#' Plot method for `<vb_epidist>` class
 #'
-#' @description Plots a `vb_epidist` object by displaying the either the
+#' @description Plot a `<vb_epidist>` object by displaying the either the
 #' probability mass function (PMF), (in the case of discrete distributions)
 #' or probability density function (PDF) (in the case of continuous
 #' distributions) and the cumulative distribution function (CDF), for both the
 #' intrinsic and extrinsic distributions. This resulting in a 2x2 grid plot.
 #'
-#' @param x An `epidist` object
-#' @param day_range A vector with the sequence of days to be plotted on the
-#' x-axis of the distribution
-#' @param ... Allow other graphical parameters
+#' @param x A `<vb_epidist>` object.
+#' @inheritParams plot.epidist
 #'
 #' @author Joshua W. Lambert
 #' @export

--- a/R/vb_epidist.R
+++ b/R/vb_epidist.R
@@ -10,12 +10,12 @@
 #' @keywords internal
 new_vb_epidist <- function(intrinsic_epidist,
                            extrinsic_epidist) {
-
   # return vb_epidist object
   structure(
     list(
       intrinsic = intrinsic_epidist,
-      extrinsic = extrinsic_epidist),
+      extrinsic = extrinsic_epidist
+    ),
     class = "vb_epidist"
   )
 }
@@ -57,7 +57,7 @@ new_vb_epidist <- function(intrinsic_epidist,
 #'       extrinsic = FALSE
 #'     )
 #'   ),
-#'   extrinsic_epidist =  epidist(
+#'   extrinsic_epidist = epidist(
 #'     disease = "dengue",
 #'     pathogen = "dengue_virus",
 #'     epi_dist = "incubation_period",
@@ -71,7 +71,6 @@ new_vb_epidist <- function(intrinsic_epidist,
 #' )
 vb_epidist <- function(intrinsic_epidist,
                        extrinsic_epidist) {
-
   # check input
   validate_epidist(intrinsic_epidist)
   validate_epidist(extrinsic_epidist)
@@ -97,7 +96,6 @@ vb_epidist <- function(intrinsic_epidist,
 #' when invalid `vb_epidist` object is provided).
 #' @export
 validate_vb_epidist <- function(vb_epidist) {
-
   if (!is_vb_epidist(vb_epidist)) {
     stop("Object should be of class vb_epidist", call. = FALSE)
   }
@@ -206,7 +204,6 @@ print.vb_epidist <- function(x, ...) {
 #' )
 #' format(vb_epidist)
 format.vb_epidist <- function(x, ...) {
-
   # use epidist printing function
   print(x$intrinsic, header = TRUE, vb = "\n <Intrinsic Distribution> \n", ...)
   print(x$extrinsic, header = FALSE, vb = "\n <Extrinsic Distribution> \n", ...)
@@ -291,7 +288,6 @@ is_vb_epidist <- function(x) {
 #'
 #' plot(dengue_dist, day_range = 0:10)
 plot.vb_epidist <- function(x, day_range = 0:10, ...) {
-
   # check input
   validate_vb_epidist(x)
   checkmate::assert_numeric(day_range, min.len = 2)

--- a/README.Rmd
+++ b/README.Rmd
@@ -9,8 +9,8 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   fig.path = "man/figures/README-",
-  out.width="75%", 
-  fig.align="center"
+  out.width = "75%",
+  fig.align = "center"
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -155,20 +155,18 @@ By contributing to this project, you agree to abide by its terms.
 
 ``` r
 citation("epiparameter")
-#> To cite package 'epiparameter' in publications use:
+#> To cite epiparameter in publications use:
 #> 
-#>   Lambert J, Kucharski A (2023). _epiparameter: Library of
-#>   Epidemiological Parameters_.
-#>   https://github.com/epiverse-trace/epiparameter,
-#>   https://epiverse-trace.github.io/epiparameter/.
+#>   Joshua W. Lambert and Adam Kucharski (2023). epiparameter: Library of
+#>   Epidemiological Parameters, website:
+#>   https://github.com/epiverse-trace/epiparameter/
 #> 
 #> A BibTeX entry for LaTeX users is
 #> 
 #>   @Manual{,
-#>     title = {epiparameter: Library of Epidemiological Parameters},
+#>     title = {Library of Epidemiological Parameters},
 #>     author = {Joshua W. Lambert and Adam Kucharski},
 #>     year = {2023},
-#>     note = {https://github.com/epiverse-trace/epiparameter,
-#> https://epiverse-trace.github.io/epiparameter/},
+#>     url = {https://github.com/epiverse-trace/epiparameter},
 #>   }
 ```

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -62,7 +62,7 @@ reference:
     - extract_param
 
   - title: Parameter conversion
-    desc: Converts distribution parameter to summary statistics and vice versa
+    desc: Convert distribution parameter to summary statistics and vice versa
     contents:
     - starts_with("convert_")
 
@@ -93,7 +93,7 @@ reference:
     - bind_epiparam
 
   - title: Cleaning
-    desc: Standardises name of disease or epidist object
+    desc: Standardise name of disease or epidist object
     contents:
     - clean_disease
     - clean_epidist_name

--- a/man/as_epidist.Rd
+++ b/man/as_epidist.Rd
@@ -2,22 +2,24 @@
 % Please edit documentation in R/epiparam_utils.R
 \name{as_epidist}
 \alias{as_epidist}
-\title{Converts rows of an epiparam object into an epidist object}
+\title{Convert \verb{<epiparam>} to \verb{<epidist>}}
 \usage{
 as_epidist(x)
 }
 \arguments{
-\item{x}{A epiparam object}
+\item{x}{A \verb{<epiparam>} object.}
 }
 \value{
-An epidist object or a list of epidist objects
+An \verb{<epidist>} object or a list of \verb{<epidist>} objects.
 }
 \description{
-Can convert the entries (rows) of an epiparam object to one or
-list of several epidist objects. This allows subsetting of epiparam records
-into a class that can then be used to to calculate the cdf, random number
-generation and other methods of the epidist class
-(see \code{?epidist_distribution_functions}).
+Convert the entries (rows) of an \verb{<epiparam>} object to one or
+list of several \verb{<epidist>} objects.
+
+Epidemiological distributions and parameters can be converted from database
+entries (i.e. rows in \verb{<epiparam>}) into \verb{<epidist>} objects in order
+use the distribution functions (see \code{?epidist_distribution_functions}) and
+and other methods of the \verb{<epidist>} class.
 }
 \examples{
 \donttest{

--- a/man/as_epidist.Rd
+++ b/man/as_epidist.Rd
@@ -21,7 +21,7 @@ generation and other methods of the epidist class
 }
 \examples{
 \donttest{
-  eparam <- epiparam()
-  as_epidist(eparam[1, ])
+eparam <- epiparam()
+as_epidist(eparam[1, ])
 }
 }

--- a/man/as_epiparam.Rd
+++ b/man/as_epiparam.Rd
@@ -2,18 +2,18 @@
 % Please edit documentation in R/epiparam_utils.R
 \name{as_epiparam}
 \alias{as_epiparam}
-\title{Converts an \code{epidist} object to an \code{epiparam} object}
+\title{Convert an \verb{<epidist>} object to an \verb{<epiparam>} object}
 \usage{
 as_epiparam(x)
 }
 \arguments{
-\item{x}{An \code{epidist} object}
+\item{x}{An \verb{<epidist>} object.}
 }
 \value{
-An \code{epiparam} object
+An \verb{<epiparam>} object.
 }
 \description{
-Converts an \code{epidist} object to an \code{epiparam} object
+Convert an \verb{<epidist>} object to an \verb{<epiparam>} object
 }
 \examples{
 edist <- epidist(

--- a/man/bind_epiparam.Rd
+++ b/man/bind_epiparam.Rd
@@ -2,37 +2,37 @@
 % Please edit documentation in R/bind_epiparam.R
 \name{bind_epiparam}
 \alias{bind_epiparam}
-\title{Bind an epi object to an \code{\link{epiparam}} object}
+\title{Bind an epi object to an \verb{<epiparam>} object}
 \usage{
 bind_epiparam(epiparam, epi_obj)
 }
 \arguments{
-\item{epiparam}{An \verb{<epiparam>} object}
+\item{epiparam}{An \verb{<epiparam>} object.}
 
 \item{epi_obj}{Either an \verb{<epidist>}, \verb{<vb_epidist>}, \verb{<epiparam>} or list
 of \verb{<epidist>} objects. It can also be a data frame as long as the columns
 conform to the columns of an \verb{<epiparam>} object.}
 }
 \value{
-An \verb{<epiparam>} object
+An \verb{<epiparam>} object.
 }
 \description{
-Binds any epi data class in \pkg{epiparameter} (\code{\link{epidist}},
-\code{\link{vb_epidist}}, \code{\link{epiparam}}) or data frame to an \code{\link{epiparam}} object.
+Bind any epi data class in \pkg{epiparameter} (\verb{<epidist>},
+\verb{<vb_epidist>}, \verb{<epiparam>}) or data frame to an \verb{<epiparam>} object.
 }
 \details{
-The \code{\link{epiparam}} class holds the library of epidemiological
+The \verb{<epiparam>} class holds the library of epidemiological
 parameters that is stored in the \pkg{epiparameter} R package and can be
 manipulated. The \code{\link[=bind_epiparam]{bind_epiparam()}} function allows users to add entries to
-the library by binding them to the bottom of an existing \code{\link{epiparam}} object
+the library by binding them to the bottom of an existing \verb{<epiparam>} object
 loaded in R.
 
-The \verb{<epiparam>} returned by \code{bind_epiparam()} contains the matching columns
-of the input objects. Therefore, if one of the input objects contains extra
-columns which are not present in the other input object these will be missing
-from the returned object. This also applies whether binding other
-\verb{<epiparam>} objects or \verb{<data.frames>}. When binding \verb{<epidist>} objects
-missing data fields are given a default value before
+The \verb{<epiparam>} returned by \code{\link[=bind_epiparam]{bind_epiparam()}} contains the matching
+columns of the input objects. Therefore, if one of the input objects
+contains extra columns which are not present in the other input object
+these will be missing from the returned object. This also applies whether
+binding other \verb{<epiparam>} or \verb{<data.frame>} objects. When binding
+\verb{<epidist>} objects missing data fields are given a default value before
 binding.
 }
 \examples{

--- a/man/calc_disc_dist_quantile.Rd
+++ b/man/calc_disc_dist_quantile.Rd
@@ -8,21 +8,21 @@ of probabilities and time data (e.g. time since infection)}
 calc_disc_dist_quantile(prob, days, quantile)
 }
 \arguments{
-\item{prob}{A numeric vector of probabilities}
+\item{prob}{A \code{numeric} vector of probabilities.}
 
-\item{days}{A numeric vector of days}
+\item{days}{A \code{numeric} vector of days.}
 
-\item{quantile}{A single numeric or vector of numerics specifying which
-quantiles to extract from the distribution}
+\item{quantile}{A single \code{numeric} or vector of \code{numerics} specifying which
+quantiles to extract from the distribution.}
 }
 \value{
-A named vector of quantiles
+A named vector of quantiles.
 }
 \description{
 This function can be used in cases where the data on a fitted
 distribution is not openly available and the summary statistics of the
 distribution are not reported so the data are scraped from the plot and
-the quantiles are needed in order use the \code{extract_param()} function
+the quantiles are needed in order use the \code{\link[=extract_param]{extract_param()}} function.
 }
 \examples{
 prob <- dgamma(seq(0, 10, length.out = 21), shape = 2, scale = 2)

--- a/man/calc_dist_params.Rd
+++ b/man/calc_dist_params.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/calc_dist_params.R
 \name{calc_dist_params}
 \alias{calc_dist_params}
-\title{Calculates the parameters of a probability distribution from a list of
-available summary statistics}
+\title{Calculate the parameters of a probability distribution from a list of
+summary statistics}
 \usage{
 calc_dist_params(prob_dist, summary_stats, sample_size = NA)
 }
@@ -11,7 +11,7 @@ calc_dist_params(prob_dist, summary_stats, sample_size = NA)
 \item{prob_dist}{A character string specifying the probability
 distribution. This should match the R naming convention of probability
 distributions (e.g. lognormal is lnorm, negative binomial is nbinom, and
-geometric is geom)}
+geometric is geom).}
 
 \item{summary_stats}{A list of summary statistics, use
 \code{\link[=create_epidist_summary_stats]{create_epidist_summary_stats()}} to create list. This list can include
@@ -25,26 +25,25 @@ interval around mean and standard deviation.}
 on using the median-range extraction calculation.}
 }
 \value{
-A named vector with parameters
+A named \code{numeric} vector with parameters.
 }
 \description{
-When the parameters of a probability distribution are not
+If parameters of a probability distribution are not
 provided (e.g. when describing the distribution in the literature) and
 instead summary statistics of a distribution are provided, the parameters
-can usually be calculated from the summary statistics. The
-\code{calc_dist_params()} function computes the parameters for the gamma,
-lognormal and Weibull distributions.
+can usually be calculated from the summary statistics.
 
-This function can provide a convenient wrapper around the conversion and
-extraction functions when it is not known which summary statistics can be
-used to calculate the parameters of a distribution.
+This function can provide a convenient wrapper around
+\code{\link[=convert_summary_stats_to_params]{convert_summary_stats_to_params()}} and \code{\link[=extract_param]{extract_param()}}
+when it is not known which summary statistics can be used to
+calculate the parameters of a distribution.
 }
 \details{
 The hierarchy of methods is:
 \enumerate{
 \item Conversion is prioritised if the mean and standard deviation are
 available as these are mostly analytical conversions (except for one of the
-Weibull conversions)
+Weibull conversions).
 \item Next method if possible is extraction from percentiles. This method
 requires a lower percentile (between(0-50]) and an upper percentile
 (between (50-100)). If multiple percentiles in each of these ranges is

--- a/man/check_optim_conv.Rd
+++ b/man/check_optim_conv.Rd
@@ -2,16 +2,16 @@
 % Please edit documentation in R/extract_param.R
 \name{check_optim_conv}
 \alias{check_optim_conv}
-\title{Checks whether the optimisation of distribution parameters has converged to
+\title{Check whether the optimisation of distribution parameters has converged to
 stable value for the parameters and function output for multiple iterations}
 \usage{
 check_optim_conv(optim_params_list, optim_params, tolerance)
 }
 \arguments{
 \item{optim_params_list}{A list, where each element is the output of
-stats::optim. See ?optim for more details}
+\code{\link[stats:optim]{stats::optim()}}. See \code{?optim} for more details.}
 
-\item{optim_params}{A list given by the output of stats::optim}
+\item{optim_params}{A list given by the output of \code{\link[stats:optim]{stats::optim()}}.}
 
 \item{tolerance}{A \code{numeric} specifying within which disparity convergence
 of parameter estimates and function minimisation is accepted.}

--- a/man/clean_disease.Rd
+++ b/man/clean_disease.Rd
@@ -2,16 +2,16 @@
 % Please edit documentation in R/epidist_utils.R
 \name{clean_disease}
 \alias{clean_disease}
-\title{Standardises the names of diseases}
+\title{Standardise the names of diseases}
 \usage{
 clean_disease(x)
 }
 \arguments{
-\item{x}{A character string specifying a disease.}
+\item{x}{A \code{character} string specifying a disease.}
 }
 \value{
-A character string of equal length to the input
+A \code{character} vector of equal length to the input.
 }
 \description{
-Standardises the names of diseases
+Standardise the names of diseases
 }

--- a/man/clean_epidist_name.Rd
+++ b/man/clean_epidist_name.Rd
@@ -2,18 +2,18 @@
 % Please edit documentation in R/epidist_utils.R
 \name{clean_epidist_name}
 \alias{clean_epidist_name}
-\title{Standardises the names of epidemiological distributions}
+\title{Standardise the names of epidemiological distributions}
 \usage{
 clean_epidist_name(epi_dist)
 }
 \arguments{
-\item{epi_dist}{A character string with the name of the distribution}
+\item{epi_dist}{A \code{character} string with the name of the distribution.}
 }
 \value{
-Character string
+A \code{character} vector of equal length to the input.
 }
 \description{
-Standardises the names of epidemiological distributions
+Standardise the names of epidemiological distributions
 }
 \examples{
 clean_epidist_name("Incubation_period")

--- a/man/clean_epidist_params.default.Rd
+++ b/man/clean_epidist_params.default.Rd
@@ -8,10 +8,10 @@
 }
 \arguments{
 \item{prob_dist_params}{A named vector of probability distribution
-parameters}
+parameters.}
 }
 \value{
-Named vector of parameters
+Named \code{numeric} vector of parameters.
 }
 \description{
 Default method if class of parameters is not recognised

--- a/man/clean_epidist_params.gamma.Rd
+++ b/man/clean_epidist_params.gamma.Rd
@@ -2,18 +2,18 @@
 % Please edit documentation in R/epidist_utils.R
 \name{clean_epidist_params.gamma}
 \alias{clean_epidist_params.gamma}
-\title{Standardises parameters for a gamma distribution}
+\title{Standardise parameters for a gamma distribution}
 \usage{
 \method{clean_epidist_params}{gamma}(prob_dist_params)
 }
 \arguments{
 \item{prob_dist_params}{A named vector of probability distribution
-parameters}
+parameters.}
 }
 \value{
-Named vector of parameters
+Named \code{numeric} vector of parameters.
 }
 \description{
-Standardises parameters for a gamma distribution
+Standardise parameters for a gamma distribution
 }
 \keyword{internal}

--- a/man/clean_epidist_params.geom.Rd
+++ b/man/clean_epidist_params.geom.Rd
@@ -2,18 +2,18 @@
 % Please edit documentation in R/epidist_utils.R
 \name{clean_epidist_params.geom}
 \alias{clean_epidist_params.geom}
-\title{Standardises parameters for a geometric distribution}
+\title{Standardise parameters for a geometric distribution}
 \usage{
 \method{clean_epidist_params}{geom}(prob_dist_params)
 }
 \arguments{
 \item{prob_dist_params}{A named vector of probability distribution
-parameters}
+parameters.}
 }
 \value{
-Named vector of parameters
+Named \code{numeric} vector of parameters.
 }
 \description{
-Standardises parameters for a geometric distribution
+Standardise parameters for a geometric distribution
 }
 \keyword{internal}

--- a/man/clean_epidist_params.lnorm.Rd
+++ b/man/clean_epidist_params.lnorm.Rd
@@ -2,18 +2,18 @@
 % Please edit documentation in R/epidist_utils.R
 \name{clean_epidist_params.lnorm}
 \alias{clean_epidist_params.lnorm}
-\title{Standardises parameters for a lognormal distribution}
+\title{Standardise parameters for a lognormal distribution}
 \usage{
 \method{clean_epidist_params}{lnorm}(prob_dist_params)
 }
 \arguments{
 \item{prob_dist_params}{A named vector of probability distribution
-parameters}
+parameters.}
 }
 \value{
-Named vector of parameters
+Named \code{numeric} vector of parameters.
 }
 \description{
-Standardises parameters for a lognormal distribution
+Standardise parameters for a lognormal distribution
 }
 \keyword{internal}

--- a/man/clean_epidist_params.nbinom.Rd
+++ b/man/clean_epidist_params.nbinom.Rd
@@ -2,18 +2,18 @@
 % Please edit documentation in R/epidist_utils.R
 \name{clean_epidist_params.nbinom}
 \alias{clean_epidist_params.nbinom}
-\title{Standardises parameters for a negative binomial distribution}
+\title{Standardise parameters for a negative binomial distribution}
 \usage{
 \method{clean_epidist_params}{nbinom}(prob_dist_params)
 }
 \arguments{
 \item{prob_dist_params}{A named vector of probability distribution
-parameters}
+parameters.}
 }
 \value{
-Named vector of parameters
+Named \code{numeric} vector of parameters.
 }
 \description{
-Standardises parameters for a negative binomial distribution
+Standardise parameters for a negative binomial distribution
 }
 \keyword{internal}

--- a/man/clean_epidist_params.pois.Rd
+++ b/man/clean_epidist_params.pois.Rd
@@ -2,18 +2,18 @@
 % Please edit documentation in R/epidist_utils.R
 \name{clean_epidist_params.pois}
 \alias{clean_epidist_params.pois}
-\title{Standardises parameters for a poisson distribution}
+\title{Standardise parameters for a poisson distribution}
 \usage{
 \method{clean_epidist_params}{pois}(prob_dist_params)
 }
 \arguments{
 \item{prob_dist_params}{A named vector of probability distribution
-parameters}
+parameters.}
 }
 \value{
-Named vector of parameters
+Named \code{numeric} vector of parameters.
 }
 \description{
-Standardises parameters for a poisson distribution
+Standardise parameters for a poisson distribution
 }
 \keyword{internal}

--- a/man/clean_epidist_params.weibull.Rd
+++ b/man/clean_epidist_params.weibull.Rd
@@ -2,18 +2,18 @@
 % Please edit documentation in R/epidist_utils.R
 \name{clean_epidist_params.weibull}
 \alias{clean_epidist_params.weibull}
-\title{Standardises parameters for a Weibull distribution}
+\title{Standardise parameters for a Weibull distribution}
 \usage{
 \method{clean_epidist_params}{weibull}(prob_dist_params)
 }
 \arguments{
 \item{prob_dist_params}{A named vector of probability distribution
-parameters}
+parameters.}
 }
 \value{
-Named vector of parameters
+Named \code{numeric} vector of parameters.
 }
 \description{
-Standardises parameters for a Weibull distribution
+Standardise parameters for a Weibull distribution
 }
 \keyword{internal}

--- a/man/convert_params_gamma.Rd
+++ b/man/convert_params_gamma.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/convert_params.R
 \name{convert_params_gamma}
 \alias{convert_params_gamma}
-\title{Converts the parameters of the gamma distribution to summary statistics}
+\title{Convert parameters of the gamma distribution to summary statistics}
 \usage{
 convert_params_gamma(...)
 }
@@ -17,7 +17,7 @@ variance (\code{var}), standard deviation (\code{sd}), coefficient of variation 
 skewness, and excess kurtosis (\code{ex_kurtosis}).
 }
 \description{
-Converts the shape and scale parameters of the gamma
+Convert the shape and scale parameters of the gamma
 distribution to a number of summary statistics which can be calculated
 analytically given the gamma parameters. One exception is the median which
 is calculated using \code{\link[=qgamma]{qgamma()}} as no analytical form is available.

--- a/man/convert_params_geom.Rd
+++ b/man/convert_params_geom.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/convert_params.R
 \name{convert_params_geom}
 \alias{convert_params_geom}
-\title{Converts the parameters of the geometric distribution to summary statistics}
+\title{Convert parameter of the geometric distribution to summary statistics}
 \usage{
 convert_params_geom(...)
 }
@@ -17,13 +17,13 @@ variance (\code{var}), standard deviation (\code{sd}), coefficient of variation 
 skewness, and excess kurtosis (\code{ex_kurtosis}).
 }
 \description{
-Converts the probability (\code{prob}) of the geometric distribution
+Convert the probability (\code{prob}) of the geometric distribution
 to a number of summary statistics which can be calculated analytically given
 the geometric parameter.
 }
 \details{
 This conversion function assumes that distribution represents the
 number of failures before the first success (supported for zero). This is
-the same form as used by base R and \code{distributional::dist_geometric()}.
+the same form as used by base R and \code{\link[distributional:dist_geometric]{distributional::dist_geometric()}}.
 }
 \keyword{internal}

--- a/man/convert_params_nbinom.Rd
+++ b/man/convert_params_nbinom.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/convert_params.R
 \name{convert_params_nbinom}
 \alias{convert_params_nbinom}
-\title{Converts the parameters of the negative binomial distribution to summary
+\title{Convert parameters of the negative binomial distribution to summary
 statistics}
 \usage{
 convert_params_nbinom(...)
@@ -18,7 +18,7 @@ variance (\code{var}), standard deviation (\code{sd}), coefficient of variation 
 skewness, and ex_kurtosis.
 }
 \description{
-Converts the probability (\code{prob}) and dispersion parameters of
+Convert the probability (\code{prob}) and dispersion parameters of
 the negative binomial distribution to a number of summary statistics which
 can be calculated analytically given the negative binomial parameters.
 One exception is the median which is calculated using \code{\link[=qnbinom]{qnbinom()}} as no

--- a/man/convert_params_to_summary_stats.Rd
+++ b/man/convert_params_to_summary_stats.Rd
@@ -10,7 +10,7 @@ convert_params_to_summary_stats(
 )
 }
 \arguments{
-\item{distribution}{A \code{character} specifying distribution to use.
+\item{distribution}{A \code{character} string specifying distribution to use.
 Default is \code{lnorm}; also takes \code{gamma} and \code{weibull}, \code{nbinom} and \code{geom}.}
 
 \item{...}{\code{Numeric} named parameter(s) used to convert to summary
@@ -23,13 +23,13 @@ variance (\code{var}), standard deviation (\code{sd}), coefficient of variation 
 skewness, and excess kurtosis (\code{ex_kurtosis}).
 }
 \description{
-Converts the parameters for a range of distributions to a
+Convert the parameters for a range of distributions to a
 number of summary statistics. All summary statistics are calculated
 analytically given the parameters.
 }
 \details{
 The distribution names and parameter names follow the style of
-distributions in R, for example the lognormal distribution is \code{lnorm},
+distributions in \R, for example the lognormal distribution is \code{lnorm},
 and its parameters are \code{meanlog} and \code{sdlog}.
 }
 \examples{

--- a/man/convert_params_weibull.Rd
+++ b/man/convert_params_weibull.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/convert_params.R
 \name{convert_params_weibull}
 \alias{convert_params_weibull}
-\title{Converts the parameters of the Weibull distribution to summary statistics}
+\title{Convert parameters of the Weibull distribution to summary statistics}
 \usage{
 convert_params_weibull(...)
 }
@@ -17,7 +17,7 @@ variance (\code{var}), standard deviation (\code{sd}), coefficient of variation 
 skewness, and excess kurtosis (\code{ex_kurtosis}).
 }
 \description{
-Converts the shape and scale parameters of the Weibull
+Convert the shape and scale parameters of the Weibull
 distribution to a number of summary statistics which can be calculated
 analytically given the Weibull parameters. Note the conversion uses the
 \code{\link[=gamma]{gamma()}} function.

--- a/man/convert_summary_stats_gamma.Rd
+++ b/man/convert_summary_stats_gamma.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/convert_params.R
 \name{convert_summary_stats_gamma}
 \alias{convert_summary_stats_gamma}
-\title{Converts the summary statistics to parameters of the gamma distribution}
+\title{Convert summary statistics to parameters of the gamma distribution}
 \usage{
 convert_summary_stats_gamma(...)
 }
@@ -15,7 +15,7 @@ lognormal (\code{lnorm}) distribution.}
 A list of two elements, the shape and scale
 }
 \description{
-Converts the summary statistics input into the shape and scale
+Convert the summary statistics input into the shape and scale
 parameters of the gamma distribution.
 }
 \keyword{internal}

--- a/man/convert_summary_stats_geom.Rd
+++ b/man/convert_summary_stats_geom.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/convert_params.R
 \name{convert_summary_stats_geom}
 \alias{convert_summary_stats_geom}
-\title{Converts the summary statistics to parameters of the geometric distribution}
+\title{Convert summary statistics to parameters of the geometric distribution}
 \usage{
 convert_summary_stats_geom(...)
 }
@@ -12,15 +12,15 @@ parameter(s). An example is the meanlog and sdlog parameters of the
 lognormal (\code{lnorm}) distribution.}
 }
 \value{
-A list of one element, the probability parameter
+A list of one element, the probability parameter.
 }
 \description{
-Converts the summary statistics of the geometric
+Convert summary statistics of the geometric
 distribution the parameter (\code{prob}) of the geometric distribution.
 }
 \details{
 This conversion function assumes that distribution represents the
 number of failures before the first success (supported for zero). This is
-the same form as used by base R and \code{distributional::dist_geometric()}.
+the same form as used by base R and \code{\link[distributional:dist_geometric]{distributional::dist_geometric()}}.
 }
 \keyword{internal}

--- a/man/convert_summary_stats_lnorm.Rd
+++ b/man/convert_summary_stats_lnorm.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/convert_params.R
 \name{convert_summary_stats_lnorm}
 \alias{convert_summary_stats_lnorm}
-\title{Converts the summary statistics to parameters of the lognormal distribution}
+\title{Convert summary statistics to parameters of the lognormal distribution}
 \usage{
 convert_summary_stats_lnorm(...)
 }
@@ -12,10 +12,10 @@ parameter(s). An example is the meanlog and sdlog parameters of the
 lognormal (\code{lnorm}) distribution.}
 }
 \value{
-A list of two elements, the meanlog and sdlog
+A list of two elements: meanlog and sdlog
 }
 \description{
-Converts the summary statistics input into the meanlog and sdlog
+Convert the summary statistics input into the meanlog and sdlog
 parameters of the lognormal distribution.
 }
 \keyword{internal}

--- a/man/convert_summary_stats_nbinom.Rd
+++ b/man/convert_summary_stats_nbinom.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/convert_params.R
 \name{convert_summary_stats_nbinom}
 \alias{convert_summary_stats_nbinom}
-\title{Converts the summary statistics to parameters of the negative binomial
+\title{Convert summary statistics to parameters of the negative binomial
 distribution}
 \usage{
 convert_summary_stats_nbinom(...)
@@ -13,10 +13,10 @@ parameter(s). An example is the meanlog and sdlog parameters of the
 lognormal (\code{lnorm}) distribution.}
 }
 \value{
-A list of two elements, the probability and dispersion parameters
+A list of two elements, the probability and dispersion parameters.
 }
 \description{
-Converts the summary statistics of the negative binomial
+Convert summary statistics of the negative binomial
 distribution the parameters (\code{prob}) and (\code{dispersion}) of the negative
 binomial distribution.
 }

--- a/man/convert_summary_stats_to_params.Rd
+++ b/man/convert_summary_stats_to_params.Rd
@@ -10,7 +10,7 @@ convert_summary_stats_to_params(
 )
 }
 \arguments{
-\item{distribution}{A \code{character} specifying distribution to use.
+\item{distribution}{A \code{character} string specifying distribution to use.
 Default is \code{lnorm}; also takes \code{gamma} and \code{weibull}, \code{nbinom} and \code{geom}.}
 
 \item{...}{\code{Numeric} named summary statistics used to convert to
@@ -22,8 +22,8 @@ A list of either one or two elements (depending on how many
 parameters the distribution has).
 }
 \description{
-Converts the summary statistics for a range of distributions to
-a distribution's parameters. Most summary statistics are calculated
+Convert the summary statistics for a range of distributions to
+the distribution's parameters. Most summary statistics are calculated
 analytically given the parameters. An exception is the Weibull distribution
 which uses a root finding numerical method.
 }
@@ -45,7 +45,7 @@ distribution parameters. In this case the function will error stating that
 the parameters cannot be calculated from the given input.
 
 The distribution names and parameter names follow the style of
-distributions in R, for example the lognormal distribution is \code{lnorm},
+distributions in \R, for example the lognormal distribution is \code{lnorm},
 and its parameters are \code{meanlog} and \code{sdlog}.
 }
 \examples{

--- a/man/convert_summary_stats_weibull.Rd
+++ b/man/convert_summary_stats_weibull.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/convert_params.R
 \name{convert_summary_stats_weibull}
 \alias{convert_summary_stats_weibull}
-\title{Converts the summary statistics to parameters of the Weibull distribution}
+\title{Convert summary statistics to parameters of the Weibull distribution}
 \usage{
 convert_summary_stats_weibull(...)
 }
@@ -12,10 +12,10 @@ parameter(s). An example is the meanlog and sdlog parameters of the
 lognormal (\code{lnorm}) distribution.}
 }
 \value{
-A list of two elements, the shape and scale
+A list of two elements, the shape and scale.
 }
 \description{
-Converts the summary statistics input into the shape and scale
+Convert summary statistics input into the shape and scale
 parameters of the Weibull distribution.
 }
 \keyword{internal}

--- a/man/create_epidist_citation.Rd
+++ b/man/create_epidist_citation.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/epidist_utils.R
 \name{create_epidist_citation}
 \alias{create_epidist_citation}
-\title{Create a citation for an epidist object}
+\title{Create a citation for an \verb{<epidist>} object}
 \usage{
 create_epidist_citation(
   author = NA_character_,
@@ -18,7 +18,7 @@ create_epidist_citation(
 can be underscore separated from a second author, or underscore separated
 from "etal" if there are more than two authors.}
 
-\item{year}{A \code{numeric} of the year of publication}
+\item{year}{A \code{numeric} of the year of publication.}
 
 \item{title}{A \code{character} string with the title of the article that
 published the epidemiological parameters.}
@@ -34,11 +34,11 @@ assigned to papers which are unique to each paper.}
 assigned to papers to give them a unique identifier within PubMed.}
 }
 \value{
-A \code{bibentry} object of the citation
+A \verb{<bibentry>} object of the citation
 }
 \description{
-A helper function when creating an epidist object to create a
-citation list with sensible defaults, type checking and arguments to help
+A helper function when creating an \verb{<epidist>} object to create
+a citation list with sensible defaults, type checking and arguments to help
 remember which citation information is accepted in the list.
 }
 \details{

--- a/man/create_epidist_metadata.Rd
+++ b/man/create_epidist_metadata.Rd
@@ -60,9 +60,9 @@ intrinsic or extrinsic distribution as well as method of distribution
 parameter estimation.
 }
 \description{
-A helper function when creating an epidist object to create a
-metadata list with sensible defaults, type checking and arguments to help
-remember metadata list structure (element names)
+A helper function when creating an \verb{<epidist>} object to
+create a metadata list with sensible defaults, type checking and arguments
+to help remember metadata list structure (element names).
 }
 \details{
 In vector-borne diseases the transmissibility of a disease is

--- a/man/create_epidist_method_assess.Rd
+++ b/man/create_epidist_method_assess.Rd
@@ -2,8 +2,7 @@
 % Please edit documentation in R/epidist_utils.R
 \name{create_epidist_method_assess}
 \alias{create_epidist_method_assess}
-\title{Specify whether certain methodological aspects have been used when fitting
-the distribution}
+\title{Specify methodological aspects of distribution fitting}
 \usage{
 create_epidist_method_assess(
   censored = NA,
@@ -12,22 +11,23 @@ create_epidist_method_assess(
 )
 }
 \arguments{
-\item{censored}{A boolean logical whether the study used single or double
+\item{censored}{A boolean \code{logical} whether the study used single or double
 interval censoring in the methods to infer the delay distribution}
 
-\item{right_truncated}{A boolean logical whether the study used right-
+\item{right_truncated}{A boolean \code{logical} whether the study used right-
 truncation in the methods to infer the delay distribution}
 
-\item{phase_bias_adjusted}{A boolean logical whether the study adjusted for
+\item{phase_bias_adjusted}{A boolean \code{logical} whether the study adjusted for
 phase bias in the methods to infer the delay distribution}
 }
 \value{
 A named list with three elements
 }
 \description{
-A helper function when creating an epidist object to create a
-method assessment list with sensible defaults, type checking and arguments
-to help remember which method assessments can be accepted in the list
+A helper function when creating an \verb{<epidist>} object to
+create a method assessment list with sensible defaults, type checking and
+arguments to help remember which method assessments can be accepted in
+the list.
 }
 \details{
 Currently, the method assessment focuses on common methodological

--- a/man/create_epidist_region.Rd
+++ b/man/create_epidist_region.Rd
@@ -12,16 +12,16 @@ create_epidist_region(
 )
 }
 \arguments{
-\item{continent}{A character string specifying the continent}
+\item{continent}{A \code{character} string specifying the continent.}
 
-\item{country}{A character string specifying the country}
+\item{country}{A \code{character} string specifying the country.}
 
-\item{region}{A character string specifying the region}
+\item{region}{A \code{character} string specifying the region.}
 
-\item{city}{A character string specifying the city}
+\item{city}{A \code{character} string specifying the city.}
 }
 \value{
-A named list
+A named list.
 }
 \description{
 The geography of the data set can be a single geographical

--- a/man/create_epidist_summary_stats.Rd
+++ b/man/create_epidist_summary_stats.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/epidist_utils.R
 \name{create_epidist_summary_stats}
 \alias{create_epidist_summary_stats}
-\title{Specify any reported summary statistics for \code{epidist}}
+\title{Specify reported summary statistics}
 \usage{
 create_epidist_summary_stats(
   mean = NA_real_,
@@ -24,46 +24,47 @@ create_epidist_summary_stats(
 )
 }
 \arguments{
-\item{mean}{A numeric of the mean (expectation) of the probability
-distribution}
+\item{mean}{A \code{numeric} of the mean (expectation) of the probability
+distribution.}
 
-\item{mean_ci_limits}{A numeric vector of length two of the confidence
-interval around the mean}
+\item{mean_ci_limits}{A \code{numeric} vector of length two of the confidence
+interval around the mean.}
 
-\item{mean_ci}{A numeric specifying the confidence interval width,
+\item{mean_ci}{A \code{numeric} specifying the confidence interval width,
 e.g. 95 would be the 95\% CI}
 
-\item{sd}{A numeric of the standard deviation of the probability distribution}
+\item{sd}{A \code{numeric} of the standard deviation of the probability
+distribution.}
 
-\item{sd_ci_limits}{A numeric vector of length 2 of the confidence interval
-around the standard deviation}
+\item{sd_ci_limits}{A \code{numeric} vector of length 2 of the confidence interval
+around the standard deviation.}
 
-\item{sd_ci}{A numeric specifying the confidence interval width,
-e.g. 95 would be 95\% confidence interval}
+\item{sd_ci}{A \code{numeric} specifying the confidence interval width,
+e.g. 95 would be 95\% confidence interval.}
 
-\item{median}{A numeric of the median of the probability distribution}
+\item{median}{A \code{numeric} of the median of the probability distribution.}
 
-\item{median_ci_limits}{A numeric vector of length two of the confidence
-interval around the median}
+\item{median_ci_limits}{A \code{numeric} vector of length two of the confidence
+interval around the median.}
 
-\item{median_ci}{A numeric specifying the confidence interval width
-of the median}
+\item{median_ci}{A \code{numeric} specifying the confidence interval width
+of the median.}
 
-\item{dispersion}{A numeric of the dispersion parameter of a distribution}
+\item{dispersion}{A \code{numeric} of the dispersion parameter of a distribution.}
 
-\item{dispersion_ci_limits}{A numeric vector of length two of the confidence
-interval around the dispersion}
+\item{dispersion_ci_limits}{A \code{numeric} vector of length two of the
+confidence interval around the dispersion.}
 
-\item{dispersion_ci}{A numeric specifying the confidence interval
-width of the dispersion parameter}
+\item{dispersion_ci}{A \code{numeric} specifying the confidence interval
+width of the dispersion parameter.}
 
 \item{lower_range}{The lower range of the data, used to infer the parameters
-of the distribution when not provided}
+of the distribution when not provided.}
 
 \item{upper_range}{The upper range of the data, used to infer the parameters
-of the distribution when not provided}
+of the distribution when not provided.}
 
-\item{quantiles}{A numeric vector of the quantiles for the distribution.
+\item{quantiles}{A \code{numeric} vector of the quantiles for the distribution.
 If quantiles are not provided a default empty vector with the 2.5th, 5th,
 25th, 75th, 95th, 97.5th quantiles are supplied.}
 }
@@ -77,9 +78,10 @@ A nested list of summary statistics. The highest level are
 }
 }
 \description{
-A helper function when creating an epidist object to create a
-summary statistics list with sensible defaults, type checking and arguments
-to help remember which summary statistics can be accepted in the list.
+A helper function when creating an \verb{<epidist>} object to
+create a summary statistics list with sensible defaults, type checking
+and arguments to help remember which summary statistics can be accepted in
+the list.
 }
 \examples{
 # mean and standard deviation

--- a/man/create_epidist_uncertainty.Rd
+++ b/man/create_epidist_uncertainty.Rd
@@ -8,29 +8,29 @@ create_epidist_uncertainty(ci_limits = NA_real_, ci, ci_type)
 }
 \arguments{
 \item{ci_limits}{A numeric vector of length two with the lower and upper
-bound of the confidence interval or credible interval}
+bound of the confidence interval or credible interval.}
 
 \item{ci}{A numeric specifying the interval for the ci, e.g. 95 is
-95\% ci}
+95\% ci.}
 
-\item{ci_type}{A character string, either "confidence interval" or "credible
-interval"}
+\item{ci_type}{A character string, either \code{"confidence interval"} or
+\code{"credible interval"}.}
 }
 \value{
 List of three elements:
 \enumerate{
 \item \verb{$ci_limits} is the upper and lower bounds
 of the CI (either confidence interval or credible interval) (i.e. a two
-element numeric vector)
+element numeric vector).
 \item \verb{$ci} the interval (e.g. 95 is 95\% CI) given by a
-single numeric
+single numeric.
 \item \verb{$ci_type} a character string specifying the type of
 uncertainty (can be either \code{"confidence interval"} or \code{"credible interval"}).
 }
 }
 \description{
 A helper function when creating uncertainty for the parameters
-of the distribution for the \code{epidist} object
+of the distribution for the \verb{<epidist>} object.
 }
 \examples{
 # example with uncertainty for a single parameter

--- a/man/create_epidist_uncertainty.Rd
+++ b/man/create_epidist_uncertainty.Rd
@@ -44,7 +44,7 @@ create_epidist_uncertainty(
 # lengh of list should match number of parameters
 list(
   shape = create_epidist_uncertainty(
-    ci_limits = c(1,3),
+    ci_limits = c(1, 3),
     ci = 95,
     ci_type = "confidence interval"
   ),

--- a/man/create_prob_dist.Rd
+++ b/man/create_prob_dist.Rd
@@ -2,8 +2,7 @@
 % Please edit documentation in R/create_prob_dist.R
 \name{create_prob_dist}
 \alias{create_prob_dist}
-\title{Creates an distribution object depending on input parameters and distribution
-settings}
+\title{Create a distribution object from distribution name and parameters}
 \usage{
 create_prob_dist(prob_dist, prob_dist_params, discretise, truncation)
 }
@@ -11,27 +10,32 @@ create_prob_dist(prob_dist, prob_dist_params, discretise, truncation)
 \item{prob_dist}{A character string specifying the probability
 distribution. This should match the R naming convention of probability
 distributions (e.g. lognormal is lnorm, negative binomial is nbinom, and
-geometric is geom)}
+geometric is geom).}
 
 \item{prob_dist_params}{A named vector of probability distribution
-parameters}
+parameters.}
 
-\item{discretise}{A boolean logical whether the distribution is discretised.
+\item{discretise}{A boolean \code{logical} whether the distribution is
+discretised.
 Default is FALSE which assumes a continuous probability distribution}
 
-\item{truncation}{A numeric specifying the truncation point if the inferred
-distribution was truncated, NA if not or unknown.}
+\item{truncation}{A \code{numeric} specifying the truncation point if the inferred
+distribution was truncated, \code{NA} if not or unknown.}
 }
 \value{
-An S3 class containing the probability distribution
+An S3 class containing the probability distribution.
 }
 \description{
-This function converts the probability distribution name and its
-parameters into an S3 class holding the distribution and parameters. The
-class holding the distribution depends on whether it is a continuous or
-discrete distribution. For continuous distributions the \code{{distributional}}
-package and classes are used, for discrete distributions the \code{{distcrete}}
-package is used. For details on the properties of the distribution classes
+Creates an S3 class holding the distribution and parameters
+from the probability distribution name, its parameters and distribution
+truncation and discretisation.
+
+The class holding the distribution depends on whether it is a discretised
+distribution. For continuous and discrete distributions S3 classes from the
+\code{{distributional}} package are used, for discretised continuous
+distributions the an S3 class from the \code{{distcrete}} package is used.
+
+For details on the properties of the distribution classes
 from each respective package see their documentation (either
 \code{?distributional} or \code{?distcrete})
 }

--- a/man/df_reconstruct.Rd
+++ b/man/df_reconstruct.Rd
@@ -2,20 +2,20 @@
 % Please edit documentation in R/epiparam_utils.R
 \name{df_reconstruct}
 \alias{df_reconstruct}
-\title{Transplants the attributes of one input (\code{to}) to the other input (\code{x})}
+\title{Transplant the attributes of one input (\code{to}) to the other input (\code{x})}
 \usage{
 df_reconstruct(x, to)
 }
 \arguments{
-\item{x}{A \code{data.frame} or subclass of \code{data.frame} (e.g. \code{tibble} or
-\code{epiparam})}
+\item{x}{A \code{data.frame} or subclass of \code{data.frame} (e.g. \verb{<tibble>} or
+\verb{<epiparam>}).}
 
-\item{to}{The reference object, in this case an \code{epiparam} object}
+\item{to}{The reference object, in this case an \verb{<epiparam>} object.}
 }
 \value{
-An \code{epiparam} object
+An \verb{<epiparam>} object.
 }
 \description{
-Transplants the attributes of one input (\code{to}) to the other input (\code{x})
+Transplant the attributes of one input (\code{to}) to the other input (\code{x})
 }
 \keyword{internal}

--- a/man/discretise.Rd
+++ b/man/discretise.Rd
@@ -4,7 +4,7 @@
 \alias{discretise}
 \alias{discretise.epidist}
 \alias{discretise.default}
-\title{Discretises a continuous distribution in an \code{epidist} object}
+\title{Discretises a continuous distribution in an \verb{<epidist>} object}
 \usage{
 discretise(x, ...)
 
@@ -13,20 +13,20 @@ discretise(x, ...)
 \method{discretise}{default}(x, ...)
 }
 \arguments{
-\item{x}{An \code{epidist} object}
+\item{x}{An \verb{<epidist>} object.}
 
-\item{...}{further arguments passed to or from other methods}
+\item{...}{\link{dots} Extra arguments passed to or from other methods.}
 }
 \value{
-An \code{epidist} object
+An \verb{<epidist>} object.
 }
 \description{
-Discretises a continuous distribution in an \code{epidist} object
+Discretises a continuous distribution in an \verb{<epidist>} object
 }
 \details{
-Converts the S3 distribution object in an \code{epidist} from continuous
-(using an object from the {distributional} package) to a discretised
-distribution (using an object from the {distcrete} package).
+Converts the S3 distribution object in an \verb{<epidist>} from
+continuous (using an object from the \code{{distributional}} package) to a
+discretised distribution (using an object from the \code{{distcrete}} package).
 }
 \examples{
 ebola_incubation <- epidist(

--- a/man/dot-extract_param.Rd
+++ b/man/dot-extract_param.Rd
@@ -9,7 +9,7 @@ median and range of a sample and the number of samples.}
 .extract_param(values, distribution, percentiles, samples)
 }
 \arguments{
-\item{values}{A \code{vector}. If \code{type = percentiles}: \code{c(percentile_1, percentile_2)}; and if \code{type = range}: \code{c(median, min, max)}}
+\item{values}{A \code{vector}. If \code{type = percentiles}: \code{c(percentile_1, percentile_2)}; and if \code{type = range}: \code{c(median, min, max)}.}
 
 \item{distribution}{A \code{character} specifying distribution to use.
 Default is \code{lnorm}; also takes \code{gamma}, \code{weibull} and \code{norm}.}

--- a/man/epidist.Rd
+++ b/man/epidist.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/epidist.R
 \name{epidist}
 \alias{epidist}
-\title{Create an \code{epidist} object}
+\title{Create an \verb{<epidist>} object}
 \usage{
 epidist(
   disease,
@@ -22,25 +22,25 @@ epidist(
 )
 }
 \arguments{
-\item{disease}{A character string with name of the infectious disease}
+\item{disease}{A \code{character} string with name of the infectious disease.}
 
-\item{pathogen}{A character string with the name of the causative agent of
-disease, or NULL if not known}
+\item{pathogen}{A \code{character} string with the name of the causative agent of
+disease, or NULL if not known.}
 
-\item{epi_dist}{A character string with the name of the
-epidemiological distribution type}
+\item{epi_dist}{A \code{character} string with the name of the
+epidemiological distribution type.}
 
-\item{prob_distribution}{A character string specifying the probability
-distribution. This should match the R naming convention of probability
-distributions (e.g. lognormal is lnorm, negative binomial is nbinom, and
-geometric is geom)}
+\item{prob_distribution}{A \code{character} string specifying the probability
+distribution. This should match the \R naming convention of probability
+distributions (e.g. lognormal is \code{lnorm}, negative binomial is \code{nbinom}, and
+geometric is \code{geom}).}
 
 \item{prob_distribution_params}{A named vector of probability distribution
-parameters}
+parameters.}
 
 \item{uncertainty}{A list of named vectors with the uncertainty around
 the probability distribution parameters. If uncertainty around the parameter
-estimates is unknown use \code{create_epidist_uncertainty()} (which is the
+estimates is unknown use \code{\link[=create_epidist_uncertainty]{create_epidist_uncertainty()}} (which is the
 argument default) to create a list wiht the correct names with missing
 values.}
 
@@ -52,14 +52,14 @@ data used to fit the distribution such as lower and upper range. The summary
 statistics can also include uncertainty around metrics such as confidence
 interval around mean and standard deviation.}
 
-\item{auto_calc_params}{A boolean logical determining whether to try and
+\item{auto_calc_params}{A boolean \code{logical} determining whether to try and
 calculate the probability distribution parameters from summary statistics if
 distribution parameters are not provided. Default is \code{TRUE}. In the case when
 sufficient summary statistics are provided and the parameter(s) of the
 distribution are not, the \code{\link[=calc_dist_params]{calc_dist_params()}} function is called to
 calculate the parameters and add them to the \code{epidist} object created.}
 
-\item{citation}{A character string with the citation of the source of the
+\item{citation}{A \code{character} string with the citation of the source of the
 data or the paper that inferred the distribution parameters, use
 \code{create_epidist_citation()} to create citation.}
 
@@ -75,33 +75,38 @@ delay distribution such as extrinsic incubation period) unless
 the distribution, use \code{create_epidist_method_assess()} to create method
 assessment.}
 
-\item{discretise}{A boolean logical whether the distribution is discretised.
+\item{discretise}{A boolean \code{logical} whether the distribution is
+discretised.
 Default is FALSE which assumes a continuous probability distribution}
 
-\item{truncation}{A numeric specifying the truncation point if the inferred
-distribution was truncated, NA if not or unknown.}
+\item{truncation}{A \code{numeric} specifying the truncation point if the inferred
+distribution was truncated, \code{NA} if not or unknown.}
 
-\item{notes}{A character string with any additional information about the
+\item{notes}{A \code{character} string with any additional information about the
 data, inference method or disease.}
 }
 \value{
-An \code{epidist} object
+An \verb{<epidist>} object.
 }
 \description{
-The \code{epidist} class is used to store epidemiological parameters
-for a single disease. These epidemiological parameters cover a variety of
-aspects including delay distributions (e.g. incubation periods and serial
-intervals, among others) and offspring distributions.
+The \verb{<epidist>} class is used to store epidemiological
+parameters for a single disease. These epidemiological parameters cover a
+variety of aspects including delay distributions (e.g. incubation periods
+and serial intervals, among others) and offspring distributions.
 
-The \code{epidist} object is the functional unit provided by \code{{epiparameter}} to
-plug into epidemiological pipelines. Obtaining an \code{epidist} object can be
-achieved in two main ways. 1) The epidemiological distribution is stored in
+The \verb{<epidist>} object is the functional unit provided by \code{{epiparameter}} to
+plug into epidemiological pipelines. Obtaining an \verb{<epidist>} object can be
+achieved in two main ways:
+\enumerate{
+\item The epidemiological distribution is stored in
 the \code{{epiparameter}} library and can be accessed by \code{\link[=epiparam]{epiparam()}} and
-\code{\link[=as_epidist]{as_epidist()}}. 2) the alternative method is when you have information
+\code{\link[=as_epidist]{as_epidist()}}.
+\item The alternative method is when you have information
 (e.g. disease and distribution parameter estimates) and would like to input
-this into an \code{epidist} object in order to work in existing analysis
+this into an \verb{<epidist>} object in order to work in existing analysis
 pipelines. This is where the \code{epidist()} function can be used to fill out
 each field for which information is known.
+}
 }
 \details{
 Accepted \verb{<epidist>} distribution parameterisations are:

--- a/man/epidist_db.Rd
+++ b/man/epidist_db.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/epidist_db.R
 \name{epidist_db}
 \alias{epidist_db}
-\title{Create an \code{epidist} object(s) directly from the epiparameter library
+\title{Create an \verb{<epidist>} object(s) directly from the epiparameter library
 (database)}
 \usage{
 epidist_db(
@@ -50,12 +50,12 @@ If multiple entries are equal after this sorting the first entry will
 be returned.}
 }
 \value{
-An \code{epidist} object or list of \code{epidist} objects.
+An \verb{<epidist>} object or list of \verb{<epidist>} objects.
 }
 \description{
-This function can extract an \code{epidist} object(s) directly from
-the library of epidemiological parameters without having to read in an
-\code{epiparam} object and pull out an \code{epidist} object from one of the entries.
+Extract an \verb{<epidist>} object(s) directly from
+the library of epidemiological parameters. This bypasses the need to
+read in an \verb{<epiparam>} object and convert to an \verb{<epidist>} object.
 
 If a distribution from a specific study is required, the \code{author} argument
 can be specified.

--- a/man/epidist_distribution_functions.Rd
+++ b/man/epidist_distribution_functions.Rd
@@ -10,8 +10,8 @@
 \alias{cdf.vb_epidist}
 \alias{quantile.vb_epidist}
 \alias{generate.vb_epidist}
-\title{PDF, CDF, PMF, quantiles and random number generation for \code{epidist} and
-\code{vb_epidist} objects}
+\title{PDF, CDF, PMF, quantiles and random number generation for \verb{<epidist>} and
+\verb{<vb_epidist>} objects}
 \usage{
 \method{density}{epidist}(x, at, ...)
 
@@ -30,28 +30,28 @@
 \method{generate}{vb_epidist}(x, times, ...)
 }
 \arguments{
-\item{x}{An \code{epidist} or \code{vb_epidist} object}
+\item{x}{An \verb{<epidist>} or \verb{<vb_epidist>} object.}
 
-\item{at}{The quantiles to evaluate at}
+\item{at}{The quantiles to evaluate at.}
 
-\item{...}{further arguments passed to or from other methods}
+\item{...}{\link{dots} Extra arguments passed to or from other methods.}
 
-\item{q}{The quantiles to evaluate at}
+\item{q}{The quantiles to evaluate at.}
 
-\item{p}{The probabilities to evaluate at}
+\item{p}{The probabilities to evaluate at.}
 
-\item{times}{The number of random samples}
+\item{times}{The number of random samples.}
 }
 \value{
-If an \code{epidist} object is given a numeric vector is returned, if an
-\code{vb_epidist} object is given a list of two elements each with a numeric
-vector is returned
+If an \verb{<epidist>} object is given a numeric vector is returned, if an
+\verb{<vb_epidist>} object is given a list of two elements each with a numeric
+vector is returned.
 }
 \description{
-The epidist object holds a probability distribution which can
-either be a continuous or discrete distribution. These are the density,
+The \verb{<epidist>} object holds a probability distribution which
+can either be a continuous or discrete distribution. These are the density,
 cumulative distribution, quantile and random number generation functions.
-These operate on any distribution that can be included in an \code{epidist}
+These operate on any distribution that can be included in an \verb{<epidist>}
 object.
 }
 \examples{

--- a/man/epiparam.Rd
+++ b/man/epiparam.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/epiparam.R
 \name{epiparam}
 \alias{epiparam}
-\title{Create an \code{epiparam} object}
+\title{Create an \verb{<epiparam>} object}
 \usage{
 epiparam(
   epi_dist = c("all", "incubation_period", "onset_to_hospitalisation", "onset_to_death",
@@ -10,35 +10,36 @@ epiparam(
 )
 }
 \arguments{
-\item{epi_dist}{A character string of which epidemiological distributions
-to select}
+\item{epi_dist}{A \code{character} string with the name of the
+epidemiological distribution type.}
 }
 \value{
-\code{epiparam} object
+An \verb{<epiparam>} object.
 }
 \description{
-The \code{epiparam} class holds information on epidemiological
+The \verb{<epiparam>} class holds information on epidemiological
 distribution and their estimated parameters as well as other information and
 metadata. This library of epidemiological parameters is compiled from
-primary literature sources. An \code{epiparam} object can be used to compare the
+primary literature sources. An \verb{<epiparam>} object can be used to compare the
 availability of distribution for a certain disease or pathogen, or refine
-by, for example, region or sample size. Additionally, the \code{epiparam} class
-can be subset and converted into \code{epidist} or \code{vb_epidist} objects to the be
-used in epidemiological analysis in which a delay distribution or offspring
-distribution is required.
+by, for example, region or sample size. Additionally, the \verb{<epiparam>} class
+can be subset and converted into \verb{<epidist>} or \verb{<vb_epidist>} objects to
+the be used in epidemiological analysis in which a delay distribution or
+offspring distribution is required.
 
-The \code{epiparam()} function reads the library of epidemiological parameters
-from \code{{epiparameter}} into memory and stores it as an \code{epiparam} object.
+The \code{\link[=epiparam]{epiparam()}} function reads the library of epidemiological parameters
+from \code{{epiparameter}} into memory and stores it as an \verb{<epiparam>} object.
 }
 \details{
-The \code{epiparam} object has certain protected fields, and thus if
+The \verb{<epiparam>} object has certain protected fields, and thus if
 one of these protected fields is removed when subsetting columns an error
 will be returned. The subsetting checks are carried out by
 \code{\link[=validate_epiparam]{validate_epiparam()}}.
 
-\code{epiparam} objects can be added to by using \code{\link[=bind_epiparam]{bind_epiparam()}} to add either
-\code{epidist}s, \code{vb_epdist}s, \code{epiparam}s, lists of \code{epdist} objects, or data
-frames with the correct columns to an existing \code{epiparam} object.
+Data can be added to \verb{<epiparam>} objects by using \code{\link[=bind_epiparam]{bind_epiparam()}}, this
+can add information from \verb{<epidist>}, \verb{<vb_epdist>}, \verb{<epiparam>}, lists
+of \verb{<epdist>} objects, or data frames with the correct columns to an
+existing \verb{<epiparam>} object.
 }
 \examples{
 # the object can be made without arguments

--- a/man/epiparam_can_reconstruct.Rd
+++ b/man/epiparam_can_reconstruct.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/epiparam_utils.R
 \name{epiparam_can_reconstruct}
 \alias{epiparam_can_reconstruct}
-\title{Checks whether the \code{epiparam} object is valid}
+\title{Check whether the \verb{<epiparam>} object is valid}
 \usage{
 epiparam_can_reconstruct(x)
 }
 \arguments{
-\item{x}{A \code{data.frame} or subclass of \code{data.frame} (e.g. \code{tibble} or
-\code{epiparam})}
+\item{x}{A \code{data.frame} or subclass of \code{data.frame} (e.g. \verb{<tibble>} or
+\verb{<epiparam>}).}
 }
 \value{
-A boolean logical (\code{TRUE} or \code{FALSE})
+A boolean \code{logical}.
 }
 \description{
-This is a wrapper for \code{\link{validate_epiparam}} in a \code{\link[=tryCatch]{tryCatch()}}
+This is a wrapper for \code{\link[=validate_epiparam]{validate_epiparam()}} in a \code{\link[=tryCatch]{tryCatch()}}
 in order to not error if the input object is invalid and returns \code{TRUE} or
 \code{FALSE} on if the object is valid. If the object is valid it can be
 "reconstructed" and not downgraded to a \code{data.frame}.

--- a/man/epiparam_reconstruct.Rd
+++ b/man/epiparam_reconstruct.Rd
@@ -2,22 +2,22 @@
 % Please edit documentation in R/epiparam_utils.R
 \name{epiparam_reconstruct}
 \alias{epiparam_reconstruct}
-\title{Decides whether \code{epiparam} object can be reconstructed from input}
+\title{Decide whether \verb{<epiparam>} object can be reconstructed from input}
 \usage{
 epiparam_reconstruct(x, to)
 }
 \arguments{
-\item{x}{A \code{data.frame} or subclass of \code{data.frame} (e.g. \code{tibble} or
-\code{epiparam})}
+\item{x}{A \code{data.frame} or subclass of \code{data.frame} (e.g. \verb{<tibble>} or
+\verb{<epiparam>}).}
 
-\item{to}{The reference object, in this case an \code{epiparam} object}
+\item{to}{The reference object, in this case an \verb{<epiparam>} object.}
 }
 \value{
-An \code{epiparam} object (if the input is valid) or a \code{data.frame}
+An \verb{<epiparam>} object (if the input is valid) or a \code{data.frame}.
 }
 \description{
 Uses \code{\link[=epiparam_can_reconstruct]{epiparam_can_reconstruct()}} to determine whether the
-data input can be reconstructed in a valid \code{epiparam} object. If it can not,
-it is returned as a \code{data.frame}.
+data input can be reconstructed in a valid \verb{<epiparam>} object. If it can
+not, it is returned as a data frame.
 }
 \keyword{internal}

--- a/man/extract_param.Rd
+++ b/man/extract_param.Rd
@@ -16,9 +16,9 @@ extract_param(
 }
 \arguments{
 \item{type}{A \code{character} defining whether summary statistics based
-around \code{percentiles} (default) or \code{range}}
+around \code{percentiles} (default) or \code{range}.}
 
-\item{values}{A \code{vector}. If \code{type = percentiles}: \code{c(percentile_1, percentile_2)}; and if \code{type = range}: \code{c(median, min, max)}}
+\item{values}{A \code{vector}. If \code{type = percentiles}: \code{c(percentile_1, percentile_2)}; and if \code{type = range}: \code{c(median, min, max)}.}
 
 \item{distribution}{A \code{character} specifying distribution to use.
 Default is \code{lnorm}; also takes \code{gamma}, \code{weibull} and \code{norm}.}

--- a/man/extraction_functions.Rd
+++ b/man/extraction_functions.Rd
@@ -11,13 +11,13 @@ fit_range(param, val, dist = c("lnorm", "gamma", "weibull", "norm"))
 fit_percentiles(param, val, dist = c("lnorm", "gamma", "weibull", "norm"))
 }
 \arguments{
-\item{param}{Named numeric vector of the distribution parameters to be
-optimised}
+\item{param}{Named \code{numeric} vector of the distribution parameters to be
+optimised.}
 
-\item{val}{Numeric vector, in the case of using percentiles it contains the
-values at the percentiles and the percentiles, in the case of median and
+\item{val}{\code{Numeric} vector, in the case of using percentiles it contains
+the values at the percentiles and the percentiles, in the case of median and
 range it contains the median, lower range, upper range and the number of
-sample points to evaluate the function at}
+sample points to evaluate the function at.}
 
 \item{dist}{A \code{character} string with the name of the distribution for
 fitting. Naming follows the base R distribution names (e.g. \code{lnorm} for

--- a/man/family.epidist.Rd
+++ b/man/family.epidist.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/epidist.R
 \name{family.epidist}
 \alias{family.epidist}
-\title{Family method for the \code{epidist} class}
+\title{Family method for the \verb{<epidist>} class}
 \usage{
 \method{family}{epidist}(object, ...)
 }
 \arguments{
-\item{object}{An \code{epidist} object}
+\item{object}{An \verb{<epidist>} object.}
 
 \item{...}{further arguments passed to methods.}
 }
@@ -16,10 +16,10 @@ A character string with the name of the distribution, or \code{NA} when
 the \verb{<epidist>} object is unparameterised.
 }
 \description{
-The \code{family()} function is used to extract the distribution
-names from objects from {distributional} and {distcrete}. This method
+The \code{\link[=family]{family()}} function is used to extract the distribution
+names from objects from \code{{distributional}} and \code{{distcrete}}. This method
 provides the same interface for \verb{<epidist>} objects to give consistent
-output irrespective of the distribution class.
+output irrespective of the internal distribution class.
 }
 \examples{
 # example with continuous distribution

--- a/man/format.epidist.Rd
+++ b/man/format.epidist.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/epidist.R
 \name{format.epidist}
 \alias{format.epidist}
-\title{Format method for epidist class}
+\title{Format method for \verb{<epidist>} class}
 \usage{
 \method{format}{epidist}(x, header = TRUE, vb = NULL, ...)
 }
 \arguments{
-\item{x}{epidist object}
+\item{x}{An \verb{<epidist>} object.}
 
 \item{header}{Boolean logical determining whether the header (first part) of
 the print method is printed. This is used internally for plotting the
@@ -16,13 +16,13 @@ vb_epidist class}
 \item{vb}{Either NULL (default) or a character string of either "Intrinsic"
 or "Extrinsic" which is used internally for plotting the vb_epidist class}
 
-\item{...}{further arguments passed to or from other methods}
+\item{...}{\link{dots} Extra arguments passed to or from other methods.}
 }
 \value{
-Invisibly returns an \code{\link{epidist}}. Called for printing side-effects.
+Invisibly returns an \verb{<epidist>}. Called for printing side-effects.
 }
 \description{
-Format method for epidist class
+Format method for \verb{<epidist>} class
 }
 \examples{
 epidist <- epidist(

--- a/man/format.epiparam.Rd
+++ b/man/format.epiparam.Rd
@@ -2,20 +2,20 @@
 % Please edit documentation in R/epiparam.R
 \name{format.epiparam}
 \alias{format.epiparam}
-\title{Format method for epiparam class}
+\title{Format method for \verb{<epiparam>} class}
 \usage{
 \method{format}{epiparam}(x, ...)
 }
 \arguments{
-\item{x}{epiparam object}
+\item{x}{An \verb{<epiparam>} object.}
 
-\item{...}{further arguments passed to or from other methods}
+\item{...}{\link{dots} Extra arguments passed to or from other methods.}
 }
 \value{
-Invisibly returns an \code{\link{epiparam}}. Called for printing side-effects.
+Invisibly returns an \verb{<epiparam>}. Called for printing side-effects.
 }
 \description{
-Format method for epiparam class
+Format method for \verb{<epiparam>} class
 }
 \examples{
 x <- epiparam()

--- a/man/format.vb_epidist.Rd
+++ b/man/format.vb_epidist.Rd
@@ -2,21 +2,21 @@
 % Please edit documentation in R/vb_epidist.R
 \name{format.vb_epidist}
 \alias{format.vb_epidist}
-\title{Format method for vb_epidist class}
+\title{Format method for \verb{<vb_epidist>} class}
 \usage{
 \method{format}{vb_epidist}(x, ...)
 }
 \arguments{
-\item{x}{vb_epidist object}
+\item{x}{A \verb{<vb_epidist>} object.}
 
-\item{...}{further arguments passed to or from other methods}
+\item{...}{\link{dots} Extra arguments passed to or from other methods.}
 }
 \value{
-Invisibly returns a \code{\link{vb_epidist}} object. Usually called for
-printing side-effects.
+Invisibly returns a \verb{<vb_epidist>}. Called for printing
+side-effects.
 }
 \description{
-Format method for vb_epidist class
+Format method for \verb{<vb_epidist>} class
 }
 \examples{
 vb_epidist <- vb_epidist(

--- a/man/get_citation.Rd
+++ b/man/get_citation.Rd
@@ -2,24 +2,22 @@
 % Please edit documentation in R/accessors.R
 \name{get_citation}
 \alias{get_citation}
-\title{Method for extracting citation information from \verb{<epidist>} or
-\verb{<epiparam>} objects.}
+\title{Extract citation information from \verb{<epidist>} or \verb{<epiparam>} objects}
 \usage{
 get_citation(x, ...)
 }
 \arguments{
-\item{x}{An \code{epidist} or \code{epiparam} object.}
+\item{x}{An \verb{<epidist>} or \verb{<epiparam>} object.}
 
 \item{...}{Extra arguments to be passed to the method.}
 }
 \value{
 A single character string or list of character string citations.
-Length of list output is equal to number of rows in the \code{epiparam} object
+Length of list output is equal to number of rows in the \verb{<epiparam>} object
 passed to the function.
 }
 \description{
-Method for extracting citation information from \verb{<epidist>} or
-\verb{<epiparam>} objects.
+Extract citation information from \verb{<epidist>} or \verb{<epiparam>} objects
 }
 \examples{
 

--- a/man/get_parameters.Rd
+++ b/man/get_parameters.Rd
@@ -2,24 +2,24 @@
 % Please edit documentation in R/accessors.R
 \name{get_parameters}
 \alias{get_parameters}
-\title{Parameters method for \code{epidist} object}
+\title{Get parameters from an \verb{<epidist>} object}
 \usage{
 get_parameters(x, ...)
 }
 \arguments{
-\item{x}{An \code{epidist} object}
+\item{x}{An \verb{<epidist>} object.}
 
 \item{...}{Extra arguments to be passed to the method.}
 }
 \value{
 A named vector of parameters or \code{NA} when the \verb{<epidist>} object is
-unparameterised
+unparameterised.
 }
 \description{
-Extracts the parameters of the distribution stored in an \code{epidist} object.
+Extract the parameters of the distribution stored in an \verb{<epidist>} object.
 }
 \details{
-The \if{html}{\out{<epidist>}} object can be unparameterised in which it lacks
+The \verb{<epidist>} object can be unparameterised in which it lacks
 a probability distribution or parameters of a probability distribution.
 In this can the \code{parameters.epidist()} method with return \code{NA}.
 }

--- a/man/get_percentiles.Rd
+++ b/man/get_percentiles.Rd
@@ -32,10 +32,10 @@ decimal places should have the decimal point in the name (e.g.
 }
 \examples{
 \dontrun{
-  # 90th interval
-  get_percentiles(c(q_5 = 1, q_95 = 10))
-  # 95th interval
-  get_percentiles(c(q_2.5 = 1, q_97.5 = 10))
+# 90th interval
+get_percentiles(c(q_5 = 1, q_95 = 10))
+# 95th interval
+get_percentiles(c(q_2.5 = 1, q_97.5 = 10))
 }
 }
 \keyword{internal}

--- a/man/get_percentiles.Rd
+++ b/man/get_percentiles.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/get_percentiles.R
 \name{get_percentiles}
 \alias{get_percentiles}
-\title{Converts a vector of named percentiles into correct format and selects two
+\title{Convert a vector of named percentiles into correct format and selects two
 values for parameter extraction}
 \usage{
 get_percentiles(percentiles)
@@ -12,12 +12,12 @@ get_percentiles(percentiles)
 percentiles. See Details for the accepted vector name format.}
 }
 \value{
-A named vector of percentiles
+A named \code{numeric} vector of percentiles.
 }
 \description{
 Parameters of a probability distribution can be extracted using
 the values given at percentiles of the distribution and the percentiles using
-\code{\link[=extract_param]{extract_param()}}. \code{get_percentiles()} takes a named vector of percentiles
+\code{\link[=extract_param]{extract_param()}}. \code{\link[=get_percentiles]{get_percentiles()}} takes a named vector of percentiles
 (names) and values at those percentiles (elements in the vector) and selects
 two values as lower and upper percentiles to be used in extraction. If a
 lower and upper percentile are not available \code{NA} is returned.

--- a/man/get_sym_percentiles.Rd
+++ b/man/get_sym_percentiles.Rd
@@ -12,8 +12,8 @@ get_sym_percentiles(percentiles)
 correct format to be converted to their numeric value using \code{as.numeric()}.}
 }
 \value{
-A named numeric vector of two elements with the lower (first element)
-and upper (second element) percentiles
+A named \code{numeric} vector of two elements with the lower
+(first element) and upper (second element) percentiles.
 }
 \description{
 Get the lower and upper percentiles with a preference for symmetrical

--- a/man/head.epiparam.Rd
+++ b/man/head.epiparam.Rd
@@ -3,22 +3,22 @@
 \name{head.epiparam}
 \alias{head.epiparam}
 \alias{tail.epiparam}
-\title{\code{head} and \code{tail} methods for \code{\link{epiparam}} class}
+\title{\code{\link[=head]{head()}} and \code{\link[=tail]{tail()}} methods for \verb{<epiparam>} class}
 \usage{
 \method{head}{epiparam}(x, ...)
 
 \method{tail}{epiparam}(x, ...)
 }
 \arguments{
-\item{x}{An \code{\link{epiparam}} object}
+\item{x}{An \verb{<epiparam>} object.}
 
-\item{...}{further arguments passed to or from other methods}
+\item{...}{\link{dots} Extra arguments passed to or from other methods.}
 }
 \value{
 Data frame
 }
 \description{
-\code{head} and \code{tail} methods for \code{\link{epiparam}} class
+\code{\link[=head]{head()}} and \code{\link[=tail]{tail()}} methods for \verb{<epiparam>} class
 }
 \examples{
 head(epiparam())

--- a/man/is_epidist.Rd
+++ b/man/is_epidist.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/epidist.R
 \name{is_epidist}
 \alias{is_epidist}
-\title{Checks whether the object is an \code{epidist}}
+\title{Check object is an \verb{<epidist>}}
 \usage{
 is_epidist(x)
 }
 \arguments{
-\item{x}{An R object}
+\item{x}{An \R object.}
 }
 \value{
-A boolean logical, \code{TRUE} if the object is an \code{epidist} and \code{FALSE}
-if not
+A boolean logical, \code{TRUE} if the object is an \verb{<epidist>} and \code{FALSE}
+if not.
 }
 \description{
-Checks whether the object is an \code{epidist}
+Check object is an \verb{<epidist>}
 }
 \examples{
 edist <- epidist(

--- a/man/is_epidist.Rd
+++ b/man/is_epidist.Rd
@@ -18,7 +18,7 @@ Checks whether the object is an \code{epidist}
 }
 \examples{
 edist <- epidist(
-disease = "ebola",
+  disease = "ebola",
   epi_dist = "serial_interval",
   prob_distribution = "gamma",
   prob_distribution_params = c(shape = 1, scale = 1)

--- a/man/is_epidist_params.Rd
+++ b/man/is_epidist_params.Rd
@@ -2,23 +2,21 @@
 % Please edit documentation in R/epidist_utils.R
 \name{is_epidist_params}
 \alias{is_epidist_params}
-\title{A helper function to check whether the vector of parameters for the
-probability distribution are in the set of possible parameters used in
-the \code{epiparameter} package}
+\title{Check whether the vector of parameters for the probability distribution
+are in the set of possible parameters used in the epiparameter package}
 \usage{
 is_epidist_params(prob_dist_params)
 }
 \arguments{
 \item{prob_dist_params}{A named vector of probability distribution
-parameters}
+parameters.}
 }
 \value{
-A logical boolean
+A boolean \code{logical}.
 }
 \description{
-A helper function to check whether the vector of parameters for the
-probability distribution are in the set of possible parameters used in
-the \code{epiparameter} package
+Check whether the vector of parameters for the probability distribution
+are in the set of possible parameters used in the epiparameter package
 }
 \examples{
 is_epidist_params(prob_dist_params = c(shape = 2, scale = 1))

--- a/man/is_epiparam.Rd
+++ b/man/is_epiparam.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/epiparam.R
 \name{is_epiparam}
 \alias{is_epiparam}
-\title{Checks whether the object is an \code{epiparam}}
+\title{Check object is an \verb{<epiparam>}}
 \usage{
 is_epiparam(x)
 }
 \arguments{
-\item{x}{An R object}
+\item{x}{An \R object.}
 }
 \value{
-A boolean logical, \code{TRUE} if the object is an \code{epiparam} and \code{FALSE}
-if not
+A boolean \code{logical}, \code{TRUE} if the object is an \verb{<epiparam>} and
+\code{FALSE} if not.
 }
 \description{
-Checks whether the object is an \code{epiparam}
+Check object is an \verb{<epiparam>}
 }
 \examples{
 eparam <- epiparam()

--- a/man/is_parameterised.Rd
+++ b/man/is_parameterised.Rd
@@ -2,25 +2,26 @@
 % Please edit documentation in R/checkers.R
 \name{is_parameterised}
 \alias{is_parameterised}
-\title{Checks whether \if{html}{\out{<epidist>}} or \if{html}{\out{<epiparam>}} object contains a distribution and
-parameters for that distribution.}
+\title{Check if \verb{<epidist>} or \verb{<epiparam>} object contain a distribution and
+distribution parameters}
 \usage{
 is_parameterised(x, ...)
 }
 \arguments{
-\item{x}{An \code{epidist} or \code{epiparam} object.}
+\item{x}{An \verb{<epidist>} or \verb{<epiparam>} object.}
 
-\item{...}{\code{\link{dots}} not used, extra arguments supplied will cause a warning.}
+\item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}
 }
 \value{
-A boolean logical for \if{html}{\out{<epidist>}} or vector of boolean for each entry
-in the \if{html}{\out{<epiparam>}}.
+A single boolean \code{logical} for \verb{<epidist>} or vector of boolean
+\code{logical}s with length equal to the number of rows in the \verb{<epiparam>}.
+If the \verb{<epidist>} object or a row in the \verb{<epiparam>} is missing either
+a probability distribution or parameters for the probability distribution
+returns \code{FALSE}, otherwise it returns \code{TRUE}.
 }
 \description{
-If the \if{html}{\out{<epidist>}} object or a row in the \if{html}{\out{<epiparam>}} data frame
-is missing either a probability distribution or parameters for the
-probability distribution, \code{is_parameterised} returns \code{FALSE}, otherwise
-it returns \code{TRUE}.
+Check if \verb{<epidist>} or \verb{<epiparam>} object contain a distribution and
+distribution parameters
 }
 \examples{
 # parameterised <epidist>

--- a/man/is_truncated.Rd
+++ b/man/is_truncated.Rd
@@ -2,25 +2,25 @@
 % Please edit documentation in R/epidist.R
 \name{is_truncated}
 \alias{is_truncated}
-\title{Check if distribution in \code{epidist} is truncated}
+\title{Check if distribution in \verb{<epidist>} is truncated}
 \usage{
 is_truncated(x)
 }
 \arguments{
-\item{x}{An \code{epidist} object.}
+\item{x}{An \verb{<epidist>} object.}
 }
 \value{
-A boolean logical.
+A boolean \code{logical}.
 }
 \description{
-Check if distribution in \code{epidist} is truncated
+Check if distribution in \verb{<epidist>} is truncated
 }
 \details{
 The \verb{<epidist>} class can hold probability distribution objects
-from the {distributional} package or the {distcrete} package, however, only
-distribution objects from {distributional} can be truncated. If a
-\verb{<epidist>} object has a {distcrete} object \code{is_truncated} will return
-\code{FALSE} by default.
+from the \code{{distributional}} package or the \code{{distcrete}} package,
+however, only distribution objects from \code{{distributional}} can be truncated.
+If a \verb{<epidist>} object has a \verb{<distcrete>} object \code{is_truncated} will
+return \code{FALSE} by default.
 }
 \examples{
 edist <- epidist(

--- a/man/is_vb_epidist.Rd
+++ b/man/is_vb_epidist.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/vb_epidist.R
 \name{is_vb_epidist}
 \alias{is_vb_epidist}
-\title{Checks whether the object is a \code{vb_epidist}}
+\title{Check object is a \verb{<vb_epidist>}}
 \usage{
 is_vb_epidist(x)
 }
 \arguments{
-\item{x}{An R object}
+\item{x}{An \R object.}
 }
 \value{
-A boolean logical, \code{TRUE} if the object is an \code{vb_epidist} and
-\code{FALSE} if not
+A boolean \code{logical}, \code{TRUE} if the object is a \verb{<vb_epidist>} and
+\code{FALSE} if not.
 }
 \description{
-Checks whether the object is a \code{vb_epidist}
+Check object is a \verb{<vb_epidist>}
 }
 \examples{
 vb_edist <- vb_epidist(

--- a/man/list_distributions.Rd
+++ b/man/list_distributions.Rd
@@ -12,7 +12,7 @@ list_distributions(
 )
 }
 \arguments{
-\item{epiparam}{An \code{epiparam} object}
+\item{epiparam}{An \verb{<epiparam>} object.}
 
 \item{epi_dist}{A character defining parameter to be listed:
 \code{"incubation"}, \code{"onset_to_hospitalisation"}, \code{"onset_to_death"}, or

--- a/man/make_epidist.Rd
+++ b/man/make_epidist.Rd
@@ -2,19 +2,20 @@
 % Please edit documentation in R/epiparam_utils.R
 \name{make_epidist}
 \alias{make_epidist}
-\title{Creates an \code{epidist} object from a list of input from an \code{epiparam} object}
+\title{Create an \verb{<epidist>} object from a list of input from an
+\verb{<epiparam>} object}
 \usage{
 make_epidist(x)
 }
 \arguments{
-\item{x}{List of data to be used to construct an epidist object}
+\item{x}{List of data to be used to construct an \verb{<epidist>} object.}
 }
 \value{
-An \code{epidist} object
+An \verb{<epidist>} object.
 }
 \description{
-Unpacks list of inputs from an epiparam object into the epidist
-helper, including the parameters and uncertainty from the correct type of
-probability distribution
+Unpacks list of inputs from an \verb{<epiparam>} object into
+the \verb{<epidist>} helper, including the parameters and uncertainty from
+the correct type of probability distribution.
 }
 \keyword{internal}

--- a/man/names-set-.epiparam.Rd
+++ b/man/names-set-.epiparam.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/epiparam_utils.R
 \name{names<-.epiparam}
 \alias{names<-.epiparam}
-\title{Set names on \code{epiparam} class}
+\title{Set names for \verb{<epiparam>} class}
 \usage{
 \method{names}{epiparam}(x) <- value
 }
@@ -16,9 +16,9 @@
 An \code{epiparam} object or a \code{data.frame}
 }
 \description{
-If the modifying the names invalidates the \code{epiparam} object
+If the modifying the names invalidates the \verb{<epiparam>} object
 (defined by its invariants, and encoded in \code{\link[=validate_epiparam]{validate_epiparam()}}) the
 subsetting will return a data frame with a message to console stating the
-class of the object has been converted to \code{data.frame} with the other
+class of the object has been converted to data frame with the other
 attributes of the class preserved.
 }

--- a/man/new_epidist.Rd
+++ b/man/new_epidist.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/epidist.R
 \name{new_epidist}
 \alias{new_epidist}
-\title{Constructor for epidist class}
+\title{Constructor for \verb{<epidist>} class}
 \usage{
 new_epidist(
   disease = list(),
@@ -21,24 +21,24 @@ new_epidist(
 )
 }
 \arguments{
-\item{disease}{A list contains the \verb{$disease} a character string of the
-infectious disease specified in the study, and the \verb{$pathogen} a character
+\item{disease}{A list containing the \verb{$disease} a \code{character} string of the
+infectious disease specified in the study, and the \verb{$pathogen} a \code{character}
 string. If the pathogen is unknown it can be given as \code{NULL}.}
 
-\item{epi_dist}{A character string with the name of the
-epidemiological distribution type}
+\item{epi_dist}{A \code{character} string with the name of the
+epidemiological distribution type.}
 
 \item{prob_dist}{A character string specifying the probability
 distribution. This should match the R naming convention of probability
 distributions (e.g. lognormal is lnorm, negative binomial is nbinom, and
-geometric is geom)}
+geometric is geom).}
 
 \item{prob_dist_params}{A named vector of probability distribution
-parameters}
+parameters.}
 
 \item{uncertainty}{A list of named vectors with the uncertainty around
 the probability distribution parameters. If uncertainty around the parameter
-estimates is unknown use \code{create_epidist_uncertainty()} (which is the
+estimates is unknown use \code{\link[=create_epidist_uncertainty]{create_epidist_uncertainty()}} (which is the
 argument default) to create a list wiht the correct names with missing
 values.}
 
@@ -50,14 +50,14 @@ data used to fit the distribution such as lower and upper range. The summary
 statistics can also include uncertainty around metrics such as confidence
 interval around mean and standard deviation.}
 
-\item{auto_calc_params}{A boolean logical determining whether to try and
+\item{auto_calc_params}{A boolean \code{logical} determining whether to try and
 calculate the probability distribution parameters from summary statistics if
 distribution parameters are not provided. Default is \code{TRUE}. In the case when
 sufficient summary statistics are provided and the parameter(s) of the
 distribution are not, the \code{\link[=calc_dist_params]{calc_dist_params()}} function is called to
 calculate the parameters and add them to the \code{epidist} object created.}
 
-\item{citation}{A character string with the citation of the source of the
+\item{citation}{A \code{character} string with the citation of the source of the
 data or the paper that inferred the distribution parameters, use
 \code{create_epidist_citation()} to create citation.}
 
@@ -73,20 +73,21 @@ delay distribution such as extrinsic incubation period) unless
 the distribution, use \code{create_epidist_method_assess()} to create method
 assessment.}
 
-\item{discretise}{A boolean logical whether the distribution is discretised.
+\item{discretise}{A boolean \code{logical} whether the distribution is
+discretised.
 Default is FALSE which assumes a continuous probability distribution}
 
-\item{truncation}{A numeric specifying the truncation point if the inferred
-distribution was truncated, NA if not or unknown.}
+\item{truncation}{A \code{numeric} specifying the truncation point if the inferred
+distribution was truncated, \code{NA} if not or unknown.}
 
-\item{notes}{A character string with any additional information about the
+\item{notes}{A \code{character} string with any additional information about the
 data, inference method or disease.}
 }
 \value{
-epidist object
+An \verb{<epidist>} object.
 }
 \description{
-Creates an epidist object. The
+Create an \verb{<epidist>} object. The
 constructor will search whether parameters of the probability distribution
 are supplied and if not look to see whether they can be inferred/extracted/
 converted from summary statistics provided. It will also convert the

--- a/man/new_epiparam.Rd
+++ b/man/new_epiparam.Rd
@@ -2,16 +2,20 @@
 % Please edit documentation in R/epiparam.R
 \name{new_epiparam}
 \alias{new_epiparam}
-\title{epiparam constructor}
+\title{Constructor for \verb{<epiparam>} class}
 \usage{
 new_epiparam(epi_dist)
 }
+\arguments{
+\item{epi_dist}{A \code{character} string with the name of the
+epidemiological distribution type.}
+}
 \value{
-epiparam object
+An \verb{<epiparam>} object.
 }
 \description{
 The constructor reads the data stored internally in the package
-and subsets by epidemiological distribution (epi_dist)
+and subsets by epidemiological distribution (\code{epi_dist}).
 }
 \examples{
 eparam <- epiparameter:::new_epiparam("all")

--- a/man/new_vb_epidist.Rd
+++ b/man/new_vb_epidist.Rd
@@ -2,21 +2,20 @@
 % Please edit documentation in R/vb_epidist.R
 \name{new_vb_epidist}
 \alias{new_vb_epidist}
-\title{Constructor for \code{vb_epidist} class}
+\title{Constructor for \verb{<vb_epidist>} class}
 \usage{
 new_vb_epidist(intrinsic_epidist, extrinsic_epidist)
 }
 \arguments{
-\item{intrinsic_epidist}{An \code{epidist} object}
+\item{intrinsic_epidist}{An \verb{<epidist>} object.}
 
-\item{extrinsic_epidist}{An \code{epidist} object}
+\item{extrinsic_epidist}{An \verb{<epidist>} object.}
 }
 \value{
-\code{vb_epidist} object
+\verb{<vb_epidist>} object
 }
 \description{
-Create an \code{vb_epidist} object by binding two \code{epidist} objects
-and assigning the \code{vb_epidist} class. Not extra checks are made as these
-take place in the \code{epidist} helper function.
+Create an \verb{<vb_epidist>} object by binding two
+\verb{<epidist>} objects and assigning the \verb{<vb_epidist>} class.
 }
 \keyword{internal}

--- a/man/plot.epidist.Rd
+++ b/man/plot.epidist.Rd
@@ -2,26 +2,26 @@
 % Please edit documentation in R/epidist.R
 \name{plot.epidist}
 \alias{plot.epidist}
-\title{Plots an \code{epidist} object}
+\title{Plot method for \verb{<epidist>} class}
 \usage{
 \method{plot}{epidist}(x, day_range = 0:10, ..., vb = FALSE, title = NULL)
 }
 \arguments{
-\item{x}{An \code{epidist} object}
+\item{x}{An \verb{<epidist>} object.}
 
 \item{day_range}{A vector with the sequence of days to be plotted on the
-x-axis of the distribution}
+x-axis of the distribution.}
 
-\item{...}{Allow other graphical parameters}
+\item{...}{further arguments passed to or from other methods.}
 
 \item{vb}{A boolean logical determining whether the \code{epidist} being plotted
-has come from a \code{vb_epidist} object}
+has come from a \code{vb_epidist} object.}
 
 \item{title}{Either a character string or \code{NULL}. If not null the character
-string will be printed as a title to the plot}
+string will be printed as a title to the plot.}
 }
 \description{
-Plots an \code{epidist} object by displaying the either the
+Plot an \verb{<epidist>} object by displaying the either the
 probability mass function (PMF), (in the case of discrete distributions)
 or probability density function (PDF) (in the case of continuous
 distributions) and the cumulative distribution function (CDF). Resulting in

--- a/man/plot.vb_epidist.Rd
+++ b/man/plot.vb_epidist.Rd
@@ -2,20 +2,20 @@
 % Please edit documentation in R/vb_epidist.R
 \name{plot.vb_epidist}
 \alias{plot.vb_epidist}
-\title{Plots an \code{vb_epidist} object,}
+\title{Plot method for \verb{<vb_epidist>} class}
 \usage{
 \method{plot}{vb_epidist}(x, day_range = 0:10, ...)
 }
 \arguments{
-\item{x}{An \code{epidist} object}
+\item{x}{A \verb{<vb_epidist>} object.}
 
 \item{day_range}{A vector with the sequence of days to be plotted on the
-x-axis of the distribution}
+x-axis of the distribution.}
 
-\item{...}{Allow other graphical parameters}
+\item{...}{further arguments passed to or from other methods.}
 }
 \description{
-Plots a \code{vb_epidist} object by displaying the either the
+Plot a \verb{<vb_epidist>} object by displaying the either the
 probability mass function (PMF), (in the case of discrete distributions)
 or probability density function (PDF) (in the case of continuous
 distributions) and the cumulative distribution function (CDF), for both the

--- a/man/print.epidist.Rd
+++ b/man/print.epidist.Rd
@@ -2,28 +2,28 @@
 % Please edit documentation in R/epidist.R
 \name{print.epidist}
 \alias{print.epidist}
-\title{Print method for epidist class}
+\title{Print method for \verb{<epidist>} class}
 \usage{
 \method{print}{epidist}(x, header = TRUE, vb = NULL, ...)
 }
 \arguments{
-\item{x}{epidist object}
+\item{x}{An \verb{<epidist>} object.}
 
-\item{header}{Boolean logical determining whether the header (first part) of
-the print method is printed. This is used internally for plotting the
-vb_epidist class}
+\item{header}{Boolean \code{logical} determining whether the header (first part)
+of the print method is printed. This is used internally for plotting the
+\verb{<vb_epidist>} class.}
 
-\item{vb}{A character string containing whether it is the intrinsic
+\item{vb}{A \code{character} string containing whether it is the intrinsic
 (\code{"Intrinsic"}) or extrinsic (\code{"Extrinsic"}) distribution for vector-borne
-diseases}
+diseases.}
 
-\item{...}{further arguments passed to or from other methods}
+\item{...}{\link{dots} Extra arguments passed to or from other methods.}
 }
 \value{
-Invisibly returns an \code{\link{epidist}}. Called for side-effects.
+Invisibly returns an \verb{<epidist>}. Called for side-effects.
 }
 \description{
-Print method for epidist class
+Print method for \verb{<epidist>} class
 }
 \examples{
 epidist <- epidist(

--- a/man/print.epiparam.Rd
+++ b/man/print.epiparam.Rd
@@ -2,20 +2,20 @@
 % Please edit documentation in R/epiparam.R
 \name{print.epiparam}
 \alias{print.epiparam}
-\title{Print method for epiparam class}
+\title{Print method for \verb{<epiparam>} class}
 \usage{
 \method{print}{epiparam}(x, ...)
 }
 \arguments{
-\item{x}{epiparam object}
+\item{x}{An \verb{<epiparam>} object.}
 
-\item{...}{further arguments passed to or from other methods}
+\item{...}{\link{dots} Extra arguments passed to or from other methods.}
 }
 \value{
-Nothing (prints output)
+Invisibly returns an \verb{<epiparam>}. Called for side-effects.
 }
 \description{
-Print method for epiparam class
+Print method for \verb{<epiparam>} class
 }
 \examples{
 epiparam <- epiparam()

--- a/man/print.vb_epidist.Rd
+++ b/man/print.vb_epidist.Rd
@@ -2,21 +2,21 @@
 % Please edit documentation in R/vb_epidist.R
 \name{print.vb_epidist}
 \alias{print.vb_epidist}
-\title{Print method for vb_epidist class}
+\title{Print method for \verb{<vb_epidist>} class}
 \usage{
 \method{print}{vb_epidist}(x, ...)
 }
 \arguments{
-\item{x}{vb_epidist object}
+\item{x}{A \verb{<vb_epidist>} object.}
 
-\item{...}{further arguments passed to or from other methods}
+\item{...}{\link{dots} Extra arguments passed to or from other methods.}
 }
 \value{
-Invisibly returns a \code{\link{vb_epidist}}. Called for printing
+Invisibly returns a \verb{<vb_epidist>}. Called for printing
 side-effects.
 }
 \description{
-Print method for vb_epidist class
+Print method for \verb{<vb_epidist>} class
 }
 \examples{
 vb_epidist <- vb_epidist(

--- a/man/sub-.epiparam.Rd
+++ b/man/sub-.epiparam.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/epiparam_utils.R
 \name{[.epiparam}
 \alias{[.epiparam}
-\title{Subsetting method for \code{epiparam}}
+\title{Subset method for \verb{<epiparam>} class}
 \usage{
 \method{[}{epiparam}(epiparam, ...)
 }
 \arguments{
-\item{epiparam}{An \code{epiparam} object}
+\item{epiparam}{An \verb{<epiparam>} object.}
 
 \item{...}{further arguments to be passed to or from other methods.}
 }
@@ -15,9 +15,9 @@
 An \code{epiparam} object or a \code{data.frame}
 }
 \description{
-If the subsetting invalidates the \code{epiparam} object (defined by
-its invariants, and encoded in \code{\link[=validate_epiparam]{validate_epiparam()}}) the subsetting will
-return a data frame with a message to console stating the class of the object
-has been converted to \code{data.frame} with the other attributes of the class
-preserved.
+If the subsetting invalidates the \verb{<epiparam>} object (defined
+by its invariants, and encoded in \code{\link[=validate_epiparam]{validate_epiparam()}}) the subsetting
+will return a data frame with a message to console stating the class of the
+object has been converted to \code{data.frame} with the other attributes of the
+class preserved.
 }

--- a/man/summary.epiparam.Rd
+++ b/man/summary.epiparam.Rd
@@ -2,20 +2,20 @@
 % Please edit documentation in R/epiparam.R
 \name{summary.epiparam}
 \alias{summary.epiparam}
-\title{Summary method for epiparam class}
+\title{Summary method for \verb{<epiparam>} class}
 \usage{
 \method{summary}{epiparam}(object, ...)
 }
 \arguments{
-\item{object}{epiparam object}
+\item{object}{An \verb{<epiparam>} object.}
 
-\item{...}{further arguments passed to or from other methods}
+\item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}
 }
 \value{
 data frame of information
 }
 \description{
-Summary method for epiparam class
+Summary method for \verb{<epiparam>} class
 }
 \examples{
 x <- epiparam()

--- a/man/validate_epidist.Rd
+++ b/man/validate_epidist.Rd
@@ -2,19 +2,17 @@
 % Please edit documentation in R/epidist.R
 \name{validate_epidist}
 \alias{validate_epidist}
-\title{\code{epidist} class validator}
+\title{Validator for \verb{<epidist>} class}
 \usage{
 validate_epidist(epidist)
 }
 \arguments{
-\item{epidist}{An \code{epidist} object}
+\item{epidist}{An \verb{<epidist>} object}
 }
 \value{
-Invisibly returns an \code{\link{epidist}}. Called for side-effects (errors
-when invalid \code{epidist} object is provided).
-
-Nothing, errors when invalid \code{epidist} object is provided
+Invisibly returns an \verb{<epidist>}. Called for side-effects (errors
+when invalid \verb{<epidist>} object is provided).
 }
 \description{
-\code{epidist} class validator
+Validator for \verb{<epidist>} class
 }

--- a/man/validate_epiparam.Rd
+++ b/man/validate_epiparam.Rd
@@ -2,23 +2,23 @@
 % Please edit documentation in R/epiparam.R
 \name{validate_epiparam}
 \alias{validate_epiparam}
-\title{\code{epiparam} class validator}
+\title{Validator for \verb{<epiparam>} class}
 \usage{
 validate_epiparam(epiparam, reconstruct = FALSE)
 }
 \arguments{
-\item{epiparam}{An \code{epiparam} object}
+\item{epiparam}{An \verb{<epiparam>} object.}
 
-\item{reconstruct}{A boolean logical determining whether the validation
+\item{reconstruct}{A boolean \code{logical} determining whether the validation
 should be class specific. When \code{TRUE} the input object must be of type
-\code{epiparam} (default), when \code{FALSE} the input object can be of another class,
-e.g. \code{data.frame}. This argument is used in reconstruction operations see
-\code{\link[=epiparam_reconstruct]{epiparam_reconstruct()}}.}
+\verb{<epiparam>} (default), when \code{FALSE} the input object can be of another
+class, e.g. data frame. This argument is used in reconstruction operations
+see \code{\link[=epiparam_reconstruct]{epiparam_reconstruct()}}.}
 }
 \value{
-Invisibly returns an \code{\link{epiparam}}. Called for side-effects
-(errors when invalid \code{epiparam} object is provided).
+Invisibly returns an \verb{<epiparam>}. Called for side-effects
+(errors when invalid \verb{<epiparam>} object is provided).
 }
 \description{
-\code{epiparam} class validator
+Validator for \verb{<epiparam>} class
 }

--- a/man/validate_vb_epidist.Rd
+++ b/man/validate_vb_epidist.Rd
@@ -2,17 +2,17 @@
 % Please edit documentation in R/vb_epidist.R
 \name{validate_vb_epidist}
 \alias{validate_vb_epidist}
-\title{\code{vb_epidist} class validator}
+\title{Validator for \verb{<vb_epidist>} class}
 \usage{
 validate_vb_epidist(vb_epidist)
 }
 \arguments{
-\item{vb_epidist}{A \code{vb_epidist} object}
+\item{vb_epidist}{A \verb{<vb_epidist>} object}
 }
 \value{
-Invisibly returns a \code{\link{vb_epidist}}. Called for side-effects (errors
-when invalid \code{vb_epidist} object is provided).
+Invisibly returns a \verb{<vb_epidist>}. Called for side-effects (errors
+when invalid \verb{<vb_epidist>} object is provided).
 }
 \description{
-\code{vb_epidist} class validator
+Validator for \verb{<vb_epidist>} class
 }

--- a/man/vb_epidist.Rd
+++ b/man/vb_epidist.Rd
@@ -2,32 +2,32 @@
 % Please edit documentation in R/vb_epidist.R
 \name{vb_epidist}
 \alias{vb_epidist}
-\title{Create a \code{vb_epidist} object}
+\title{Create a \verb{<vb_epidist>} object}
 \usage{
 vb_epidist(intrinsic_epidist, extrinsic_epidist)
 }
 \arguments{
-\item{intrinsic_epidist}{An \code{epidist} object}
+\item{intrinsic_epidist}{An \verb{<epidist>} object.}
 
-\item{extrinsic_epidist}{An \code{epidist} object}
+\item{extrinsic_epidist}{An \verb{<epidist>} object.}
 }
 \value{
-\code{vb_epidist} object
+\verb{<vb_epidist>} object
 }
 \description{
-The \code{vb_epidist} class is an extension of the \code{epidist} class
-(although not a subclass of \code{epidist}). It is is used to store
-epidemiological parameters for vector-borne diseases. It has the same
-methods (\code{print()}, \code{format()}, \code{plot()}, \code{generate()}, \code{cdf()}, \code{density()},
-\code{quantile()}) as the \code{epidist} class and therefore there are used
-identically.
+The \verb{<vb_epidist>} class is an extension of the
+\verb{<epidist>} class (although not a subclass of \verb{<epidist>}). It is is
+used to store epidemiological parameters for vector-borne diseases.
+It has the same methods (\code{print()}, \code{format()}, \code{plot()}, \code{generate()},
+\code{cdf()}, \code{density()}, \code{quantile()}) as the \verb{<epidist>} class and
+therefore they are used identically.
 }
 \details{
-The \code{epidist} objects should contain metadata (\code{epidist$metadata})
-indicating it is a vector-borne disease
-(\code{epidist$metadata$transmission_mode == "vector_borne"}) and the extrinsic
+The \verb{<epidist>} objects should contain metadata
+(\code{epidist$metadata}) indicating it is a vector-borne disease
+(\code{epidist$metadata$transmission_mode = "vector_borne"}) and the extrinsic
 distribution should indicate in the metadata that it is the extrinsic
-distribution (\code{epidist$metadata$extrinsic} is TRUE). If these two aspects
+distribution (\code{epidist$metadata$extrinsic = TRUE}). If these two aspects
 are not given the construction of the class will throw a warning.
 }
 \examples{

--- a/man/vb_epidist.Rd
+++ b/man/vb_epidist.Rd
@@ -43,7 +43,7 @@ vb <- vb_epidist(
       extrinsic = FALSE
     )
   ),
-  extrinsic_epidist =  epidist(
+  extrinsic_epidist = epidist(
     disease = "dengue",
     pathogen = "dengue_virus",
     epi_dist = "incubation_period",

--- a/tests/testthat/test-convert_params.R
+++ b/tests/testthat/test-convert_params.R
@@ -51,7 +51,6 @@ test_that("convert_params_to_summary_stats works as expected", {
     ),
     tolerance = 1e-4
   )
-
 })
 
 test_that("convert_summary_stats_to_params works as expected", {

--- a/tests/testthat/test-epidist.R
+++ b/tests/testthat/test-epidist.R
@@ -1,5 +1,4 @@
 test_that("epidist works with minimal viable input", {
-
   # message about missing citation suppressed
   ebola_dist <- suppressMessages(epidist(
     disease = "ebola",
@@ -13,7 +12,6 @@ test_that("epidist works with minimal viable input", {
 })
 
 test_that("epidist works with all arguments set", {
-
   # suppress message about citation
   mers_dist <- suppressMessages(
     epidist(
@@ -109,7 +107,6 @@ test_that("epidist works with default helper functions", {
 })
 
 test_that("epidist fails as expected", {
-
   expect_error(
     epidist(
       disease = 1,
@@ -117,8 +114,9 @@ test_that("epidist fails as expected", {
       prob_distribution = "gamma",
       prob_distribution_params = c(shape = 1, scale = 1)
     ),
-    regexp = paste0("Assertion on 'disease' failed: Must be of type ",
-                   "'string', not 'double'."
+    regexp = paste0(
+      "Assertion on 'disease' failed: Must be of type ",
+      "'string', not 'double'."
     )
   )
 
@@ -129,8 +127,9 @@ test_that("epidist fails as expected", {
       prob_distribution = "gamma",
       prob_distribution_params = c(shape = 1, scale = 1)
     ),
-    regexp = paste0("Assertion on 'epi_dist' failed: Must be of type ",
-                   "'string', not 'double'."
+    regexp = paste0(
+      "Assertion on 'epi_dist' failed: Must be of type ",
+      "'string', not 'double'."
     )
   )
 
@@ -149,17 +148,19 @@ test_that("epidist fails as expected", {
 
   expect_error(
     # message about missing citation suppressed
-    suppressMessages(epidist(
-      disease = "ebola",
-      epi_dist = "incubation",
-      prob_distribution = "gamma",
-      prob_distribution_params = c(shape = "NA", scale = 1)
-    ),
-    regexp = paste0(
-      "(Assertion on 'prob_distribution_params' failed)*(Must be of type)*",
-      "(numeric)*(NULL)*(character)."
+    suppressMessages(
+      epidist(
+        disease = "ebola",
+        epi_dist = "incubation",
+        prob_distribution = "gamma",
+        prob_distribution_params = c(shape = "NA", scale = 1)
+      ),
+      regexp = paste0(
+        "(Assertion on 'prob_distribution_params' failed)*(Must be of type)*",
+        "(numeric)*(NULL)*(character)."
+      )
     )
-  ))
+  )
 })
 
 test_that("epidist.print works as expected", {
@@ -182,7 +183,6 @@ test_that("epidist.print works as expected", {
 })
 
 test_that("epidist.plot does not produce an error", {
-
   ebola_dist <- suppressMessages(epidist(
     disease = "ebola",
     epi_dist = "incubation",
@@ -201,7 +201,6 @@ test_that("epidist.plot does not produce an error", {
 })
 
 test_that("epidist.plot works with non-default day_range", {
-
   ebola_dist <- suppressMessages(epidist(
     disease = "ebola",
     epi_dist = "incubation",
@@ -229,7 +228,6 @@ test_that("epidist.plot works with non-default day_range", {
 })
 
 test_that("new_epidist works with minimal viable input", {
-
   epidist_obj <- suppressMessages(
     new_epidist(
       disease = list(
@@ -403,10 +401,10 @@ test_that("validate_epidist catches class faults when expected", {
 })
 
 test_that("validate_epidist fails as expected with input class", {
-    expect_error(
-      validate_epidist(epidist = 1),
-      regexp = "Object should be of class epidist"
-    )
+  expect_error(
+    validate_epidist(epidist = 1),
+    regexp = "Object should be of class epidist"
+  )
 })
 
 test_that("density works as expected on continuous epidist object", {
@@ -778,7 +776,7 @@ test_that("generate fails as expected on discrete epidist object with vector
 test_that("is_epidist returns TRUE when expected", {
   # suppress message about citation
   edist <- suppressMessages(epidist(
-  disease = "ebola",
+    disease = "ebola",
     epi_dist = "serial_interval",
     prob_distribution = "gamma",
     prob_distribution_params = c(shape = 1, scale = 1)
@@ -873,7 +871,6 @@ test_that("discretise works as expected on truncated dist", {
 })
 
 test_that("discretise fails as expected on non-epidist object", {
-
   expect_error(
     discretise("epidist"),
     regexp = "No discretise method defined for class character"
@@ -944,7 +941,6 @@ test_that("parameters works as expected on truncated dist", {
 })
 
 test_that("parameters fails as expected on non-epidist object", {
-
   expect_error(
     get_parameters("epidist"),
     regexp = paste0(

--- a/tests/testthat/test-epiparam.R
+++ b/tests/testthat/test-epiparam.R
@@ -76,7 +76,7 @@ test_that("epiparam summary method works as expected", {
       "num_entries", "num_diseases", "num_delay_dist", "num_offspring_dist",
       "num_studies", "num_continuous_distributions",
       "num_discrete_distributions", "num_vector_borne_diseases"
-      )
+    )
   )
 })
 

--- a/tests/testthat/test-epiparam_utils.R
+++ b/tests/testthat/test-epiparam_utils.R
@@ -17,7 +17,6 @@ test_that("as_epidist fails as expected when given invalidated epiparam", {
 })
 
 test_that("make_epidist works as expected for gamma", {
-
   # suppress message about citation
   edist <- suppressMessages(
     make_epidist(x = list(
@@ -220,7 +219,6 @@ test_that("make_epidist works as expected for lognormal", {
 })
 
 test_that("make_epidist works as expected for negative binomial", {
-
   # suppress message about citation
   edist <- suppressMessages(
     make_epidist(x = list(
@@ -289,7 +287,6 @@ test_that("make_epidist works as expected for negative binomial", {
 })
 
 test_that("make_epidist works as expected for geometric", {
-
   # suppress message about citation
   edist <- suppressMessages(
     make_epidist(x = list(

--- a/tests/testthat/test-extract_param.R
+++ b/tests/testthat/test-extract_param.R
@@ -146,7 +146,8 @@ test_that("extract_param warns when max_iter exceeded", {
       distribution = "lnorm",
       percentiles = c(0.05, 0.95),
       control = list(max_iter = 5)
-    )), regexp = paste0(
+    )),
+    regexp = paste0(
       "(Maximum optimisation iterations reached)*(returning result early)*",
       "(Result may not be reliable)"
     )
@@ -160,7 +161,8 @@ test_that("extract_param warns when max_iter exceeded", {
       distribution = "lnorm",
       samples = 10,
       control = list(max_iter = 5)
-    )), regexp = paste0(
+    )),
+    regexp = paste0(
       "(Maximum optimisation iterations reached)*(returning result early)*",
       "(Result may not be reliable)"
     )

--- a/tests/testthat/test-get_percentiles.R
+++ b/tests/testthat/test-get_percentiles.R
@@ -25,9 +25,8 @@ test_that("get_percentiles fails as expected", {
 })
 
 test_that("get_sym_percentiles works as expected for symmetrical", {
-
   # trivial case
-  percentiles <- c("5" = 5,  "95" = 15)
+  percentiles <- c("5" = 5, "95" = 15)
   sym_percentiles <- get_sym_percentiles(percentiles = percentiles)
   expect_identical(sym_percentiles, c("5" = 5, "95" = 15))
 
@@ -54,9 +53,8 @@ test_that("get_sym_percentiles works as expected for symmetrical", {
 })
 
 test_that("get_sym_percentiles works as expected for asymmetrical", {
-
   # trivial case
-  percentiles <- c("2.5" = 5,  "95" = 15)
+  percentiles <- c("2.5" = 5, "95" = 15)
   sym_percentiles <- get_sym_percentiles(percentiles = percentiles)
   expect_identical(sym_percentiles, c("2.5" = 5, "95" = 15))
 
@@ -83,7 +81,6 @@ test_that("get_sym_percentiles works as expected for asymmetrical", {
 })
 
 test_that("get_sym_percentiles works as expected for all NAs", {
-
-  percentiles <- c("2.5" = NA,  "95" = NA)
+  percentiles <- c("2.5" = NA, "95" = NA)
   expect_true(is.na(get_sym_percentiles(percentiles = percentiles)))
 })

--- a/tests/testthat/test-list_distributions.R
+++ b/tests/testthat/test-list_distributions.R
@@ -1,5 +1,4 @@
 test_that("list_distributions works as expected with defaults", {
-
   eparam <- epiparam()
   dist_tbl <- list_distributions(epiparam = eparam)
   expect_s3_class(dist_tbl, "data.frame")

--- a/tests/testthat/test-vb_epidist.R
+++ b/tests/testthat/test-vb_epidist.R
@@ -33,7 +33,6 @@ test_that("vb_epidist works with minimal viable input", {
 })
 
 test_that("vb_epidist works with all arguements set", {
-
   # message about missing citation suppressed
   dengue_dist <- suppressMessages(
     vb_epidist(
@@ -84,36 +83,35 @@ test_that("vb_epidist works with all arguements set", {
 })
 
 test_that("vb_epidist throws warning when expected", {
-
-    expect_warning(
-      suppressMessages(
-        vb_epidist(
-          intrinsic_epidist = epidist(
-            disease = "dengue",
-            epi_dist = "incubation",
-            prob_distribution = "gamma",
-            prob_distribution_params = c(shape = 1, scale = 1),
-            metadata = create_epidist_metadata(
-              transmission_mode = "natural_human_to_human",
-              extrinsic = FALSE
-            )
-          ),
-          extrinsic_epidist = epidist(
-            disease = "dengue",
-            epi_dist = "incubation",
-            prob_distribution = "gamma",
-            prob_distribution_params = c(shape = 1, scale = 1),
-            metadata = create_epidist_metadata(
-              transmission_mode = "vector_borne",
-              extrinsic = TRUE
-            )
+  expect_warning(
+    suppressMessages(
+      vb_epidist(
+        intrinsic_epidist = epidist(
+          disease = "dengue",
+          epi_dist = "incubation",
+          prob_distribution = "gamma",
+          prob_distribution_params = c(shape = 1, scale = 1),
+          metadata = create_epidist_metadata(
+            transmission_mode = "natural_human_to_human",
+            extrinsic = FALSE
+          )
+        ),
+        extrinsic_epidist = epidist(
+          disease = "dengue",
+          epi_dist = "incubation",
+          prob_distribution = "gamma",
+          prob_distribution_params = c(shape = 1, scale = 1),
+          metadata = create_epidist_metadata(
+            transmission_mode = "vector_borne",
+            extrinsic = TRUE
           )
         )
-      ),
-      regexp = paste0(
-        "(Distributions in vb_epidist class are not vector-borne)"
       )
+    ),
+    regexp = paste0(
+      "(Distributions in vb_epidist class are not vector-borne)"
     )
+  )
 
   expect_warning(
     suppressMessages(
@@ -207,7 +205,6 @@ test_that("vb_epidist throws warning when expected", {
 })
 
 test_that("vb_epidist fails as expected", {
-
   expect_error(
     suppressMessages(
       vb_epidist(
@@ -260,7 +257,8 @@ test_that("vb_epidist fails as expected", {
           )
         )
       )
-    ), regexp = "(epi distribution in intrinsic and extrinsic distributions)"
+    ),
+    regexp = "(epi distribution in intrinsic and extrinsic distributions)"
   )
 })
 
@@ -272,7 +270,6 @@ test_that("validate_vb_epidist fails as expected with input class", {
 })
 
 test_that("vb_epidist print & format method works as expected", {
-
   expect_snapshot(
     # suppress messages about citation
     dengue_dist <- suppressMessages(vb_epidist(
@@ -335,7 +332,6 @@ test_that("vb_epidist print & format method works as expected", {
 })
 
 test_that("vb_epidist.plot does not produce an error", {
-
   # message about missing citation suppressed
   dengue_dist <- suppressMessages(
     vb_epidist(
@@ -373,7 +369,6 @@ test_that("vb_epidist.plot does not produce an error", {
 })
 
 test_that("vb_epidist.plot works with non-default day_range", {
-
   # message about missing citation suppressed
   dengue_dist <- suppressMessages(
     vb_epidist(

--- a/vignettes/extract-bias.Rmd
+++ b/vignettes/extract-bias.Rmd
@@ -102,7 +102,6 @@ set.seed(1)
 estim_params <- vector("list", nrow(parameters_perc))
 # Loop through parameter space estimating parameters
 for (params_idx in seq_len(nrow(parameters_perc))) {
-
   dist <- as.character(parameters_perc[params_idx, "dist"])
   percen <- unname(unlist(parameters_perc[params_idx, c("lower", "upper")]))
 
@@ -205,7 +204,6 @@ parameters_range <- expand.grid(
 estim_params <- vector("list", nrow(parameters_range))
 # Loop through parameter space estimating parameters
 for (params_idx in seq_len(nrow(parameters_range))) {
-
   dist <- as.character(parameters_range[params_idx, "dist"])
   n_samples <- parameters_range[params_idx, "n_samples"]
 
@@ -251,7 +249,7 @@ for (params_idx in seq_len(nrow(parameters_range))) {
 
   # message about stochastic optimisation suppressed
   estim_params[[params_idx]] <- suppressMessages(
-    expr =  extract_param(
+    expr = extract_param(
       type = "range",
       values = true_values,
       distribution = dist,
@@ -297,7 +295,6 @@ ggplot(data = results) +
     strip.background = element_blank(),
     axis.text.x = element_text(angle = 30, vjust = 0.5)
   )
-
 ```
 
 ## Extraction precision
@@ -318,7 +315,6 @@ compute the variance of parameter estimates over those replicates.
 estim_param_var <- vector("list", nrow(parameters_perc))
 # Loop through parameter space estimating parameters
 for (params_idx in seq_len(nrow(parameters_perc))) {
-
   dist <- as.character(parameters_perc[params_idx, "dist"])
   percen <- unname(unlist(parameters_perc[params_idx, c("lower", "upper")]))
 
@@ -346,7 +342,7 @@ for (params_idx in seq_len(nrow(parameters_perc))) {
   estim <- suppressMessages(
     replicate(
       n = 5,
-      expr =  extract_param(
+      expr = extract_param(
         type = "percentiles",
         values = true_values,
         distribution = dist,
@@ -394,7 +390,6 @@ The same test of estimation precision can be performed for the extraction from m
 estim_param_var <- vector("list", nrow(parameters_range))
 # Loop through parameter space estimating parameters
 for (params_idx in seq_len(nrow(parameters_range))) {
-
   dist <- as.character(parameters_range[params_idx, "dist"])
   n_samples <- parameters_range[params_idx, "n_samples"]
 
@@ -442,7 +437,7 @@ for (params_idx in seq_len(nrow(parameters_range))) {
   estim <- suppressMessages(
     replicate(
       n = 5,
-      expr =  extract_param(
+      expr = extract_param(
         type = "range",
         values = true_values,
         distribution = dist,


### PR DESCRIPTION
This PR updates the package coding style and function documentation. These changes address comments from the full package review (PR #151).

The package coding style has followed the tidyverse style, but this PR applies a {styler} (using `styler::style_pkg()`) to enforce a consistency style. This is checked with `lintr::lint_package()` and the [lint workflow](https://github.com/epiverse-trace/.github/blob/main/workflows/lint-changed-files.yaml) which uses the .lintr file in the package root. 

The function documentation has been updated to firstly be more consistent across functions. It now uses imperative function descriptions in the `@title` and `@description`. It uses a `{packagename}` `<classname>` style. It makes use of [inheritance provided by {roxygen2}](https://roxygen2.r-lib.org/articles/reuse.html#inheriting-documentation) (`@inherit` and `@inheritParams`) to remove duplicated docs. Descriptions, parameter documentation and return values are all sentences ending in a full stop. The clarity and wording of some functions has been improved.