### PR TITLE
Fix {vdiffr} v1.0.5 install in R CMD check workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -78,7 +78,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages:
+            any::rcmdcheck,
+            vdiffr@1.0.5
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
This PR fixes the GitHub actions R CMD check for Ubuntu running R devel. This has been failing for the past few days (first mentioned in #168). The R CMD check yaml now specifies the version of {vdiffr} to install to avoid the workflow crash (`exist code 143`).