### PR TITLE
Restore normal vdiffr workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -79,8 +79,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages:
-            any::rcmdcheck,
-            vdiffr@1.0.5
+            any::rcmdcheck
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -29,7 +29,6 @@ jobs:
           extra-packages: |
             any::cffr
             any::V8
-            vdiffr@1.0.5
 
       - name: Update CITATION.cff
         run: |

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -217,10 +217,10 @@ references:
   authors:
   - family-names: Henry
     given-names: Lionel
-    email: lionel@rstudio.com
+    email: lionel@posit.co
   - family-names: Pedersen
     given-names: Thomas Lin
-    email: thomas.pedersen@rstudio.com
+    email: thomas.pedersen@posit.co
     orcid: https://orcid.org/0000-0002-5147-4711
   - family-names: Luciani
     given-names: T Jake
@@ -232,6 +232,7 @@ references:
     given-names: Vaudor
     email: lise.vaudor@ens-lyon.fr
   year: '2023'
+  version: '>= 1.0.7'
 - type: software
   title: dplyr
   abstract: 'dplyr: A Grammar of Data Manipulation'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ Suggests:
     knitr,
     bookdown,
     rmarkdown,
-    vdiffr,
+    vdiffr (>= 1.0.7),
     dplyr (>= 1.0.0),
     ggplot2,
     testthat (>= 3.0.0),


### PR DESCRIPTION
Since 1.0.7 should fix the issues that led to version pinning.