### PR TITLE
Remove {dplyr} from Suggests

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -234,31 +234,6 @@ references:
   year: '2023'
   version: '>= 1.0.7'
 - type: software
-  title: dplyr
-  abstract: 'dplyr: A Grammar of Data Manipulation'
-  notes: Suggests
-  url: https://dplyr.tidyverse.org
-  repository: https://CRAN.R-project.org/package=dplyr
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-    orcid: https://orcid.org/0000-0003-4757-117X
-  - family-names: François
-    given-names: Romain
-    orcid: https://orcid.org/0000-0002-2444-4226
-  - family-names: Henry
-    given-names: Lionel
-  - family-names: Müller
-    given-names: Kirill
-    orcid: https://orcid.org/0000-0002-1416-3412
-  - family-names: Vaughan
-    given-names: Davis
-    email: davis@posit.co
-    orcid: https://orcid.org/0000-0003-4777-038X
-  year: '2023'
-  version: '>= 1.0.0'
-- type: software
   title: ggplot2
   abstract: 'ggplot2: Create Elegant Data Visualisations Using the Grammar of Graphics'
   notes: Suggests

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,6 @@ Suggests:
     bookdown,
     rmarkdown,
     vdiffr (>= 1.0.7),
-    dplyr (>= 1.0.0),
     ggplot2,
     testthat (>= 3.0.0),
     spelling


### PR DESCRIPTION
Since PR #197 the need for {dplyr} as a suggested package dependency is no longer needed. The `<epiparam>` S3 class (a subclass of `<data.frame>`) was removed, and this is what used {dplyr} to import `dplyr_reconstruct()` generic (`dplyr_reconstruct.epiparam()`).