### PR TITLE
Allow creating Poisson `<epidist>` with lambda parameter name

### DIFF
--- a/R/epidist_utils.R
+++ b/R/epidist_utils.R
@@ -471,7 +471,7 @@ is_epidist_params <- function(prob_dist, prob_dist_params) {
     lnorm = list(c("meanlog", "sdlog"), c("mu", "sigma")),
     nbinom = list(c("mean", "dispersion"), c("mean", "k"), c("n", "p")),
     geom = list("mean", "p", "prob"),
-    pois = list("mean", "l")
+    pois = list("mean", "l", "lambda")
   )
   possible_params <- possible_params[[prob_dist]]
 
@@ -681,7 +681,7 @@ clean_epidist_params.geom <- function(prob_dist_params) {
 #' @return Named `numeric` vector of parameters.
 #' @keywords internal
 clean_epidist_params.pois <- function(prob_dist_params) {
-  if (names(prob_dist_params) %in% c("mean", "l")) {
+  if (names(prob_dist_params) %in% c("mean", "l", "lambda")) {
     names(prob_dist_params) <- "mean"
 
     # remove class attribute from prob_dist_params

--- a/tests/testthat/test-epidist_utils.R
+++ b/tests/testthat/test-epidist_utils.R
@@ -141,6 +141,11 @@ test_that("clean_epidist_params works as expected for pois", {
   class(pois_params) <- "pois"
   params <- clean_epidist_params(prob_dist_params = pois_params)
   expect_identical(params, c(mean = 0.5))
+
+  pois_params <- c(lambda = 0.5)
+  class(pois_params) <- "pois"
+  params <- clean_epidist_params(prob_dist_params = pois_params)
+  expect_identical(params, c(mean = 0.5))
 })
 
 test_that("clean_epidist_params fails when pois parameters are incorrect", {

--- a/tests/testthat/test-epidist_utils.R
+++ b/tests/testthat/test-epidist_utils.R
@@ -149,7 +149,7 @@ test_that("clean_epidist_params works as expected for pois", {
 })
 
 test_that("clean_epidist_params fails when pois parameters are incorrect", {
-  pois_param <- c("means" = 1)
+  pois_param <- c(means = 1)
   class(pois_param) <- "pois"
   expect_error(
     clean_epidist_params(prob_dist_params = pois_param),


### PR DESCRIPTION
This PR allows a user to create an `<epidist>` object (using the `epidist()` constructor function) for a Poisson distribution specifying the parameter as `lambda`. Previously, only `mean` and `l` were valid parameter names.