### PR TITLE
Move {jsonlite} to suggested dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,10 +46,10 @@ Imports:
     checkmate,
     distributional,
     distcrete,
-    jsonlite,
     stats,
     utils
 Suggests: 
+    jsonlite,
     knitr,
     bookdown,
     rmarkdown,

--- a/R/epidist_db.R
+++ b/R/epidist_db.R
@@ -229,6 +229,14 @@ epidist_db <- function(disease = "all",
 #' @keywords internal
 #' @noRd
 .read_epidist_db <- function() {
+
+  if (!.is_pkg_installed("jsonlite")) {
+    stop(
+      "Cannot use this internal function without {jsonlite} installed",
+      call. = FALSE
+    )
+  }
+
   params_json <- jsonlite::read_json(
     path = system.file(
       "extdata",
@@ -563,4 +571,18 @@ print.multi_epidist <- function(x, ...) {
     )
     invisible(x)
   }
+}
+
+#' Check whether a package is installed
+#'
+#' @details This functions allows mock testing for when a package is not
+#' installed on a users system (i.e. not a dependency of {epiparameter}).
+#'
+#' @inheritParams base::requireNamespace
+#'
+#' @return Invisibly returns a boolean `logical`.
+#' @noRd
+#' @keywords internal
+.is_pkg_installed <- function(package) {
+  requireNamespace(package, quietly = TRUE)
 }

--- a/tests/testthat/test-epidist_db.R
+++ b/tests/testthat/test-epidist_db.R
@@ -172,3 +172,19 @@ test_that("sysdata is the same as .read_epidist_db output", {
   db <- .read_epidist_db()
   expect_equal(sysdat, db, tolerance = 1e-3)
 })
+
+test_that(".read_epidist_db fails correctly when jsonlite is not installed", {
+  with_mocked_bindings(
+    .is_pkg_installed = function(package) FALSE,
+    code = expect_error(
+      .read_epidist_db(),
+      regexp =
+        "Cannot use this internal function without \\{jsonlite\\} installed" # nolint file.path
+    )
+  )
+})
+
+test_that(".is_pkg_installed works as expected", {
+  expect_true(.is_pkg_installed(package = "distributional"))
+  expect_false(.is_pkg_installed(package = "jsonlit"))
+})

--- a/vignettes/design_principles.Rmd
+++ b/vignettes/design_principles.Rmd
@@ -43,11 +43,12 @@ The aim is to restrict the number of dependencies to a minimal required set for 
 * [{checkmate}](https://CRAN.R-project.org/package=checkmate)
 * [{distributional}](https://CRAN.R-project.org/package=distributional)
 * [{distcrete}](https://CRAN.R-project.org/package=distcrete)
-* [{jsonlite}](https://CRAN.R-project.org/package=jsonlite)
 * {stats}
 * {utils}
 
-{stats} and {utils} are distributed with the R language so are viewed as a lightweight dependencies, that should already be installed on a user's machine if they have R. {checkmate} is an input checking package widely used across Epiverse-TRACE packages. {distributional} and {distcrete} are used to import S3 classes for handling and working with distributions. Both are required as only {distcrete} can handle discretised distributions. {jsonlite} is used to read the parameter library which is stored as a JSON file.
+{stats} and {utils} are distributed with the R language so are viewed as a lightweight dependencies, that should already be installed on a user's machine if they have R. {checkmate} is an input checking package widely used across Epiverse-TRACE packages. {distributional} and {distcrete} are used to import S3 classes for handling and working with distributions. Both are required as only {distcrete} can handle discretised distributions.
+
+[{jsonlite}](https://CRAN.R-project.org/package=jsonlite) is a suggested dependency because it is used to read the parameter library which is stored as a JSON file. However, it is only read by an internal function and instead the data is available to the user via `sysdata.rda`, so {jsonlite} is not required as an imported dependency.
 
 ## Contribute
 


### PR DESCRIPTION
This PR moves {jsonlite} from an imported dependency to a suggested dependency as it is only used within an internal function (`.read_epidist_db()`). 

A new check is added within `.read_epidist_db()` to error with an informative message if {jsonlite} is not installed. Tests are added to mock the behaviour of {jsonlite} not being installed and to test `.is_pkg_installed()`. The mock testing follows the [{cfr}](https://github.com/epiverse-trace/cfr/blob/555c9dcd6e41dfb487eeb5e6b5fa87dae40a75a8/tests/testthat/test-prepare_data.R#L62-L85) package.

The design principles vignette is updated to address changes to {jsonlite} dependency.