### PR TITLE
Add BibTeX example to `get_citation()`

### DIFF
--- a/R/accessors.R
+++ b/R/accessors.R
@@ -59,6 +59,11 @@ get_parameters.epidist <- function(x, ...) {
 #' edist <- epidist_db(single_epidist = TRUE)
 #' get_citation(edist)
 #'
+#' # example returning bibtex format
+#' edist <- epidist_db(disease = "COVID-19", single_epidist = TRUE)
+#' cit <- get_citation(edist)
+#' format(cit, style = "bibtex")
+#'
 #' # example with list of <epidist>
 #' edist <- epidist_db()
 #' get_citation(edist)

--- a/inst/extdata/data_dictionary.json
+++ b/inst/extdata/data_dictionary.json
@@ -257,7 +257,7 @@
           },
           "title": {
             "description": "The title of the article that published the epidemiological parameters.",
-            "examples": ["Incubation period of COVID-19", "Serial internval of Ebola"],
+            "examples": ["Incubation period of COVID-19", "Serial interval of Ebola"],
             "type": "string"
           },
           "journal": {

--- a/man/get_citation.Rd
+++ b/man/get_citation.Rd
@@ -24,6 +24,11 @@ Extract citation information from \verb{<epidist>} or list of \verb{<epidist>} o
 edist <- epidist_db(single_epidist = TRUE)
 get_citation(edist)
 
+# example returning bibtex format
+edist <- epidist_db(disease = "COVID-19", single_epidist = TRUE)
+cit <- get_citation(edist)
+format(cit, style = "bibtex")
+
 # example with list of <epidist>
 edist <- epidist_db()
 get_citation(edist)


### PR DESCRIPTION
This PR addresses two comments that were made in a previous PR (#168):

- A BibTeX citation formatting example is added to the documentation of `get_citation()`
- A typo in the data dictionary (`data_dictionary.json`) is fixed