### PR TITLE
Add option to create discretised normal distribution

### DIFF
--- a/R/create_prob_dist.R
+++ b/R/create_prob_dist.R
@@ -52,7 +52,10 @@ create_prob_dist <- function(prob_dist,
                              discretise,
                              truncation) {
   if (discretise) {
-    prob_dist <- match.arg(prob_dist, choices = c("gamma", "lnorm", "weibull"))
+    prob_dist <- match.arg(
+      prob_dist,
+      choices = c("gamma", "lnorm", "weibull", "norm")
+    )
     # create discretised probability distribution object
     prob_dist <- do.call(
       distcrete::distcrete,

--- a/tests/testthat/test-create_prob_dist.R
+++ b/tests/testthat/test-create_prob_dist.R
@@ -142,6 +142,22 @@ test_that("create_prob_dist works as expected for discrete Weibull", {
   )
 })
 
+test_that("create_prob_dist works as expected for discrete normal", {
+  res <- create_prob_dist(
+    prob_dist = "norm",
+    prob_dist_params = c(mean = 1, sd = 1),
+    discretise = TRUE,
+    truncation = NA
+  )
+
+  expect_s3_class(res, "distcrete")
+  expect_identical(res$name, "norm")
+  expect_identical(
+    res$parameters,
+    list(mean = 1, sd = 1)
+  )
+})
+
 test_that("create_prob_dist works as expected for truncated continuous", {
   res <- create_prob_dist(
     prob_dist = "gamma",


### PR DESCRIPTION
This PR fixes an issue on creating discretised normal distributions that was lingering since PR #210 (which added the capability for `<epidist>` to contain normal distributions). The `create_prob_dist()` function did not accept the normal distribution name (`"norm"`) as it was not included in the `match.arg()` `choices` argument. This issue also meant an `<epidist>` object in memory could not be discretised (using `discretise()`).

This PR resolves both of these issues by simply allowing `"norm"` as input for creating S3 discretised probability distributions (`<distcrete>` objects).

A test has also been added that covers this scenario.