### PR TITLE
Update subsetting in `epidist_db()`

### DIFF
--- a/R/epidist_db.R
+++ b/R/epidist_db.R
@@ -507,15 +507,25 @@ epidist_db <- function(disease = "all",
 .is_cond_epidist <- function(lst, condition, nse_subject) {
   # check input
   stopifnot(is_epidist(lst))
-  # apply condition to <epidist> name matching elements
-  lapply(lst, function(x) {
-    if (nse_subject %in% names(x)) {
-      # <epidist> is only nested once so no need for recursive search
-      eval(expr = condition, envir = x)
+  if (nse_subject == "prob_dist") {
+    # special case to subset by dist as name is extracted first
+    if (is.object(lst$prob_dist) || is.character(lst$prob_dist)) {
+      prob_dist <- family(lst) # nolint prob_dist used in eval
+      eval(expr = condition)
     } else {
       FALSE
     }
-  })
+  } else {
+    # apply condition to <epidist> name matching elements
+    lapply(lst, function(x) {
+      if (nse_subject %in% names(x)) {
+        # <epidist> is only nested once so no need for recursive search
+        eval(expr = condition, envir = x)
+      } else {
+        FALSE
+      }
+    })
+  }
 }
 
 #' Print method for `<multi_epidist>` class

--- a/R/epidist_db.R
+++ b/R/epidist_db.R
@@ -153,7 +153,7 @@ epidist_db <- function(disease = "all",
     }
 
     # subset by authors
-    multi_epidist <- subset(multi_epidist, author_set)
+    multi_epidist <- multi_epidist[author_set]
   }
 
   # subset by subset conditions

--- a/tests/testthat/test-epidist_db.R
+++ b/tests/testthat/test-epidist_db.R
@@ -78,6 +78,34 @@ test_that("epidist_db works as expected with subsetting and single_epidist", {
   expect_length(edist, 9)
 })
 
+test_that("epidist_db works as expected with subsetting and author", {
+  edist <- suppressMessages(
+    epidist_db(
+      disease = "COVID-19",
+      epi_dist = "incubation period",
+      author = "McAloon",
+      subset = sample_size > 10
+    )
+  )
+
+  expect_s3_class(edist, class = "multi_epidist")
+  expect_length(edist, 2)
+})
+
+test_that("epidist_db works as expected with subsetting by prod_dist", {
+  edist <- suppressMessages(
+    epidist_db(
+      disease = "COVID-19",
+      epi_dist = "serial interval",
+      author = "Nishiura",
+      subset = prob_dist == "weibull"
+    )
+  )
+
+  expect_s3_class(edist, class = "epidist")
+  expect_length(edist, 9)
+})
+
 test_that("epidist_db fails as expected when author not recognised", {
   expect_error(
     epidist_db(


### PR DESCRIPTION
This PR addresses #224 & #225. 

It uses the brackets (`[]`) to subset instead of using `subset()`, as this was incorrectly evaluating the expression passed to the `subset` argument in `epidist_db()` when `author` and `subset` were both given. This follows advice from `subset()` documentation stating:

> [This is a convenience function intended for use interactively. For programming it is better to use the standard subsetting functions like [], and in particular the non-standard evaluation of argument subset can have unanticipated consequences.](https://github.com/wch/r-source/blob/trunk/src/library/base/man/subset.Rd#L66-L71)

It also adds a special case to `.is_cond_epidist()` to subset by `prob_dist`. 