### PR TITLE
Fix ORCID links

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -58,7 +58,7 @@ references:
   - name: R Core Team
   location:
     name: Vienna, Austria
-  year: '2023'
+  year: '2024'
   institution:
     name: R Foundation for Statistical Computing
   version: '>= 3.6.0'
@@ -73,7 +73,7 @@ references:
     given-names: Michel
     email: michellang@gmail.com
     orcid: https://orcid.org/0000-0001-9754-0393
-  year: '2023'
+  year: '2024'
 - type: software
   title: distributional
   abstract: 'distributional: Vectorised Probability Distributions'
@@ -91,7 +91,7 @@ references:
   - family-names: Hayes
     given-names: Alex
     orcid: https://orcid.org/0000-0002-4985-5160
-  year: '2023'
+  year: '2024'
 - type: software
   title: distcrete
   abstract: 'distcrete: Discrete Distribution Approximations'
@@ -106,19 +106,7 @@ references:
     given-names: Anne
   - family-names: Jombart
     given-names: Thibaut
-  year: '2023'
-- type: software
-  title: jsonlite
-  abstract: 'jsonlite: A Simple and Robust JSON Parser and Generator for R'
-  notes: Imports
-  url: https://jeroen.r-universe.dev/jsonlite
-  repository: https://CRAN.R-project.org/package=jsonlite
-  authors:
-  - family-names: Ooms
-    given-names: Jeroen
-    email: jeroen@berkeley.edu
-    orcid: https://orcid.org/0000-0002-4035-0289
-  year: '2023'
+  year: '2024'
 - type: software
   title: stats
   abstract: 'R: A Language and Environment for Statistical Computing'
@@ -127,7 +115,7 @@ references:
   - name: R Core Team
   location:
     name: Vienna, Austria
-  year: '2023'
+  year: '2024'
   institution:
     name: R Foundation for Statistical Computing
 - type: software
@@ -138,9 +126,21 @@ references:
   - name: R Core Team
   location:
     name: Vienna, Austria
-  year: '2023'
+  year: '2024'
   institution:
     name: R Foundation for Statistical Computing
+- type: software
+  title: jsonlite
+  abstract: 'jsonlite: A Simple and Robust JSON Parser and Generator for R'
+  notes: Suggests
+  url: https://jeroen.r-universe.dev/jsonlite
+  repository: https://CRAN.R-project.org/package=jsonlite
+  authors:
+  - family-names: Ooms
+    given-names: Jeroen
+    email: jeroen@berkeley.edu
+    orcid: https://orcid.org/0000-0002-4035-0289
+  year: '2024'
 - type: software
   title: knitr
   abstract: 'knitr: A General-Purpose Package for Dynamic Report Generation in R'
@@ -152,7 +152,7 @@ references:
     given-names: Yihui
     email: xie@yihui.name
     orcid: https://orcid.org/0000-0003-0645-5666
-  year: '2023'
+  year: '2024'
 - type: software
   title: bookdown
   abstract: 'bookdown: Authoring Books and Technical Documents with R Markdown'
@@ -164,7 +164,7 @@ references:
     given-names: Yihui
     email: xie@yihui.name
     orcid: https://orcid.org/0000-0003-0645-5666
-  year: '2023'
+  year: '2024'
 - type: software
   title: rmarkdown
   abstract: 'rmarkdown: Dynamic Documents for R'
@@ -207,7 +207,7 @@ references:
     given-names: Richard
     email: rich@posit.co
     orcid: https://orcid.org/0000-0003-3925-190X
-  year: '2023'
+  year: '2024'
 - type: software
   title: vdiffr
   abstract: 'vdiffr: Visual Regression Testing and Graphical Diffing'
@@ -231,7 +231,7 @@ references:
   - family-names: Lise
     given-names: Vaudor
     email: lise.vaudor@ens-lyon.fr
-  year: '2023'
+  year: '2024'
   version: '>= 1.0.7'
 - type: software
   title: ggplot2
@@ -267,7 +267,7 @@ references:
   - family-names: Dunnington
     given-names: Dewey
     orcid: https://orcid.org/0000-0002-9415-4582
-  year: '2023'
+  year: '2024'
 - type: software
   title: testthat
   abstract: 'testthat: Unit Testing for R'
@@ -278,7 +278,7 @@ references:
   - family-names: Wickham
     given-names: Hadley
     email: hadley@posit.co
-  year: '2023'
+  year: '2024'
   version: '>= 3.0.0'
 - type: software
   title: spelling
@@ -294,4 +294,4 @@ references:
   - family-names: Hester
     given-names: Jim
     email: james.hester@rstudio.com
-  year: '2023'
+  year: '2024'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,28 +8,28 @@ Authors@R:
             family = "Lambert",
             role = c("aut", "cre", "cph"),
             email = "joshua.lambert@lshtm.ac.uk",
-            comment = c(ORCID = "https://orcid.org/0000-0001-5218-3046")
+            comment = c(ORCID = "0000-0001-5218-3046")
         ),
         person(
             given = "Adam", 
             family = "Kucharski",
             role = c("aut", "cph"),
             email = "adam.kucharski@lshtm.ac.uk", 
-            comment = c(ORCID = "https://orcid.org/0000-0001-8814-9421")
+            comment = c(ORCID = "0000-0001-8814-9421")
         ),
         person(
             given = "Hugo",
             family = "Gruson",
             role = c("ctb", "rev"),
             email = "hugo.gruson@data.org",
-            comment = c(ORCID = "https://orcid.org/0000-0002-4094-1476")
+            comment = c(ORCID = "0000-0002-4094-1476")
         ),
         person(
             given = "Pratik",
             family = "Gupte",
             role = c("rev"),
             email = "pratik.gupte@lshtm.ac.uk",
-            comment = c(ORCID = "https://orcid.org/0000-0001-5294-7819")
+            comment = c(ORCID = "0000-0001-5294-7819")
         )
       )
 Description: Library of epidemiological parameters for infectious diseases and a


### PR DESCRIPTION
This PR fixes the ORCID links for the `pkgdown` page. See also upstream change to the template - https://github.com/epiverse-trace/packagetemplate/pull/126