### PR TITLE
Accept dynamic dots for conversion functions

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -108,6 +108,20 @@ references:
     given-names: Thibaut
   year: '2024'
 - type: software
+  title: rlang
+  abstract: 'rlang: Functions for Base Types and Core R and ''Tidyverse'' Features'
+  notes: Imports
+  url: https://rlang.r-lib.org
+  repository: https://CRAN.R-project.org/package=rlang
+  authors:
+  - family-names: Henry
+    given-names: Lionel
+    email: lionel@posit.co
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  year: '2024'
+- type: software
   title: stats
   abstract: 'R: A Language and Environment for Statistical Computing'
   notes: Imports

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Imports:
     checkmate,
     distributional,
     distcrete,
+    rlang,
     stats,
     utils
 Suggests: 

--- a/R/accessors.R
+++ b/R/accessors.R
@@ -33,6 +33,7 @@ get_parameters <- function(x, ...) {
 #' )
 #' get_parameters(edist)
 get_parameters.epidist <- function(x, ...) {
+  chkDots(...)
   # extract parameters depending on prob distribution class
   if (inherits(x$prob_dist, "distcrete")) {
     params <- unlist(x$prob_dist$parameters)

--- a/R/accessors.R
+++ b/R/accessors.R
@@ -3,6 +3,7 @@
 #' Extract the parameters stored in an \R object.
 #'
 #' @inheritParams base::print
+#' @param ... [dots] Extra arguments to be passed to the method.
 #'
 #' @export
 get_parameters <- function(x, ...) {
@@ -18,7 +19,7 @@ get_parameters <- function(x, ...) {
 #' in this case the `get_parameters.epidist()` method will return `NA`.
 #'
 #' @inheritParams print.epidist
-#' @param ... Extra arguments to be passed to the method.
+#' @param ... [dots] Not used, extra arguments supplied will cause a warning.
 #'
 #' @return A named vector of parameters or `NA` when the `<epidist>` object is
 #' unparameterised.
@@ -64,6 +65,7 @@ get_parameters.epidist <- function(x, ...) {
 #' Extract the citation stored in an \R object.
 #'
 #' @inheritParams base::print
+#' @param ... [dots] Extra arguments to be passed to the method.
 #'
 #' @export
 get_citation <- function(x, ...) {
@@ -75,7 +77,7 @@ get_citation <- function(x, ...) {
 #' Extract the citation stored in an `<epidist>` object.
 #'
 #' @inheritParams print.epidist
-#' @param ... Extra arguments to be passed to the method.
+#' @param ... [dots] Not used, extra arguments supplied will cause a warning.
 #'
 #' @return A `<bibentry>` object.
 #' @export
@@ -104,7 +106,7 @@ get_citation.epidist <- function(x, ...) {
 #' Extract the citation stored in a list of `<epidist>` objects.
 #'
 #' @inheritParams print.epidist
-#' @param ... Extra arguments to be passed to the method.
+#' @param ... [dots] Not used, extra arguments supplied will cause a warning.
 #'
 #' @return A list of `<bibentry>` objects. The length of output list is
 #' equal to the length of the list of `<epidist>` objects supplied.

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -2,7 +2,7 @@
 #' and distribution parameters
 #'
 #' @param x An `<epidist>` or list of `<epidist>` objects.
-#' @param ... [dots] not used, extra arguments supplied will cause a warning.
+#' @param ... [dots] Extra arguments to be passed to the method.
 #'
 #' @return A single boolean `logical` for `<epidist>` or vector of `logical`s
 #' equal in length to the list of `<epidist>` objects input. If the `<epidist>`

--- a/R/convert_params.R
+++ b/R/convert_params.R
@@ -26,8 +26,8 @@
 #'
 #' @param distribution A `character` string specifying distribution to use.
 #' Default is `lnorm`; also takes `gamma` and `weibull`, `nbinom` and `geom`.
-#' @param ... `Numeric` named summary statistics used to convert to
-#' parameter(s). An example is the meanlog and sdlog parameters of the
+#' @param ... [dots] `Numeric` named summary statistics used to convert to
+#' parameter(s). An example is the `mean` and `sd` parameters of the
 #' lognormal (`lnorm`) distribution.
 #'
 #' @return A list of either one or two elements (depending on how many
@@ -80,8 +80,8 @@ convert_summary_stats_to_params <- function(distribution = c( # nolint
 #' and its parameters are `meanlog` and `sdlog`.
 #'
 #' @inheritParams convert_summary_stats_to_params
-#' @param ... `Numeric` named parameter(s) used to convert to summary
-#' statistics. An example is the meanlog and sdlog parameters of the
+#' @param ... [dots] `Numeric` named parameter(s) used to convert to summary
+#' statistics. An example is the `meanlog` and `sdlog` parameters of the
 #' lognormal (`lnorm`) distribution.
 #'
 #' @return A list of eight elements including: mean, median, mode,

--- a/R/convert_params.R
+++ b/R/convert_params.R
@@ -26,9 +26,9 @@
 #'
 #' @param distribution A `character` string specifying distribution to use.
 #' Default is `lnorm`; also takes `gamma` and `weibull`, `nbinom` and `geom`.
-#' @param ... [dots] `Numeric` named summary statistics used to convert to
-#' parameter(s). An example is the `mean` and `sd` parameters of the
-#' lognormal (`lnorm`) distribution.
+#' @param ... <[`dynamic-dots`][rlang::dyn-dots]> `Numeric` named summary
+#' statistics used to convert to parameter(s). An example is the `mean`
+#' and `sd` parameters of the lognormal (`lnorm`) distribution.
 #'
 #' @return A list of either one or two elements (depending on how many
 #' parameters the distribution has).
@@ -46,7 +46,9 @@ convert_summary_stats_to_params <- function(distribution = c( # nolint
                                             ...) {
   # check input
   distribution <- match.arg(distribution)
-  if (!checkmate::test_list(list(...), min.len = 1, names = "unique")) {
+  # capture dynamic dots
+  dots <- rlang::dots_list(..., .ignore_empty = "none", .homonyms = "error")
+  if (!checkmate::test_list(dots, min.len = 1, names = "unique")) {
     stop(
       "Summary statistics need to be named and supplied to the function",
       call. = FALSE
@@ -63,7 +65,7 @@ convert_summary_stats_to_params <- function(distribution = c( # nolint
   )
 
   # call selected function
-  out <- do.call(func, list(...))
+  out <- do.call(func, dots)
 
   # return output
   out
@@ -80,9 +82,9 @@ convert_summary_stats_to_params <- function(distribution = c( # nolint
 #' and its parameters are `meanlog` and `sdlog`.
 #'
 #' @inheritParams convert_summary_stats_to_params
-#' @param ... [dots] `Numeric` named parameter(s) used to convert to summary
-#' statistics. An example is the `meanlog` and `sdlog` parameters of the
-#' lognormal (`lnorm`) distribution.
+#' @param ... <[`dynamic-dots`][rlang::dyn-dots]> `Numeric` named parameter(s)
+#' used to convert to summary statistics. An example is the `meanlog` and
+#' `sdlog` parameters of the lognormal (`lnorm`) distribution.
 #'
 #' @return A list of eight elements including: mean, median, mode,
 #' variance (`var`), standard deviation (`sd`), coefficient of variation (`cv`),
@@ -106,7 +108,9 @@ convert_params_to_summary_stats <- function(distribution = c( # nolint
                                             ...) {
   # check input
   distribution <- match.arg(distribution)
-  if (!checkmate::test_list(list(...), min.len = 1, names = "unique")) {
+  # capture dynamic dots
+  dots <- rlang::dots_list(..., .ignore_empty = "none", .homonyms = "error")
+  if (!checkmate::test_list(dots, min.len = 1, names = "unique")) {
     stop(
       "Parameter(s) need to be named and supplied to the function",
       call. = FALSE
@@ -123,7 +127,7 @@ convert_params_to_summary_stats <- function(distribution = c( # nolint
   )
 
   # call selected function
-  out <- do.call(func, list(...))
+  out <- do.call(func, dots)
 
   # return output
   out
@@ -189,8 +193,8 @@ chk_ss <- function(x) {
 #' skewness, and excess kurtosis (`ex_kurtosis`).
 #' @keywords internal
 convert_params_lnorm <- function(...) {
-  # capture input
-  x <- list(...)
+  # capture dynamic dots
+  x <- rlang::dots_list(..., .ignore_empty = "none", .homonyms = "error")
 
   # check input params
   if (all(c("meanlog", "sdlog") %in% names(x))) {
@@ -238,8 +242,8 @@ convert_params_lnorm <- function(...) {
 #' @return A list of two elements: meanlog and sdlog
 #' @keywords internal
 convert_summary_stats_lnorm <- function(...) {
-  # capture input
-  x <- list(...)
+  # capture dynamic dots
+  x <- rlang::dots_list(..., .ignore_empty = "none", .homonyms = "error")
 
   # check input
   chk_ss(x)
@@ -285,8 +289,8 @@ convert_summary_stats_lnorm <- function(...) {
 #' skewness, and excess kurtosis (`ex_kurtosis`).
 #' @keywords internal
 convert_params_gamma <- function(...) {
-  # capture input
-  x <- list(...)
+  # capture dynamic dots
+  x <- rlang::dots_list(..., .ignore_empty = "none", .homonyms = "error")
 
   # check input params
   if (all(c("shape", "scale") %in% names(x))) {
@@ -333,8 +337,8 @@ convert_params_gamma <- function(...) {
 #' @return A list of two elements, the shape and scale
 #' @keywords internal
 convert_summary_stats_gamma <- function(...) {
-  # capture input
-  x <- list(...)
+  # capture dynamic dots
+  x <- rlang::dots_list(..., .ignore_empty = "none", .homonyms = "error")
 
   # check input
   chk_ss(x)
@@ -371,8 +375,8 @@ convert_summary_stats_gamma <- function(...) {
 #' skewness, and excess kurtosis (`ex_kurtosis`).
 #' @keywords internal
 convert_params_weibull <- function(...) {
-  # capture input
-  x <- list(...)
+  # capture dynamic dots
+  x <- rlang::dots_list(..., .ignore_empty = "none", .homonyms = "error")
 
   # check input params
   if (all(c("shape", "scale") %in% names(x))) {
@@ -422,8 +426,8 @@ convert_params_weibull <- function(...) {
 #' @return A list of two elements, the shape and scale.
 #' @keywords internal
 convert_summary_stats_weibull <- function(...) {
-  # capture input
-  x <- list(...)
+  # capture dynamic dots
+  x <- rlang::dots_list(..., .ignore_empty = "none", .homonyms = "error")
 
   # check input
   chk_ss(x)
@@ -474,8 +478,8 @@ convert_summary_stats_weibull <- function(...) {
 #' skewness, and ex_kurtosis.
 #' @keywords internal
 convert_params_nbinom <- function(...) {
-  # capture input
-  x <- list(...)
+  # capture dynamic dots
+  x <- rlang::dots_list(..., .ignore_empty = "none", .homonyms = "error")
 
   # check input params
   if (all(c("prob", "dispersion") %in% names(x))) {
@@ -527,8 +531,8 @@ convert_params_nbinom <- function(...) {
 #' @return A list of two elements, the probability and dispersion parameters.
 #' @keywords internal
 convert_summary_stats_nbinom <- function(...) {
-  # capture input
-  x <- list(...)
+  # capture dynamic dots
+  x <- rlang::dots_list(..., .ignore_empty = "none", .homonyms = "error")
 
   # check input
   chk_ss(x)
@@ -584,8 +588,8 @@ convert_summary_stats_nbinom <- function(...) {
 #' skewness, and excess kurtosis (`ex_kurtosis`).
 #' @keywords internal
 convert_params_geom <- function(...) {
-  # capture input
-  x <- list(...)
+  # capture dynamic dots
+  x <- rlang::dots_list(..., .ignore_empty = "none", .homonyms = "error")
 
   # check input params
   if (all("prob" %in% names(x))) {
@@ -634,8 +638,8 @@ convert_params_geom <- function(...) {
 #' @return A list of one element, the probability parameter.
 #' @keywords internal
 convert_summary_stats_geom <- function(...) {
-  # capture input
-  x <- list(...)
+  # capture dynamic dots
+  x <- rlang::dots_list(..., .ignore_empty = "none", .homonyms = "error")
 
   # check input
   checkmate::assert_list(

--- a/R/epidist.R
+++ b/R/epidist.R
@@ -388,7 +388,7 @@ validate_epidist <- function(epidist) {
 #' @param vb A `character` string containing whether it is the intrinsic
 #' (`"Intrinsic"`) or extrinsic (`"Extrinsic"`) distribution for vector-borne
 #' diseases.
-#' @param ... [dots] Extra arguments passed to or from other methods.
+#' @param ... [dots] Extra arguments to be passed to the method.
 #'
 #' @return Invisibly returns an `<epidist>`. Called for side-effects.
 #' @export
@@ -755,6 +755,7 @@ generate.epidist <- function(x, times, ...) {
 #' discretised distribution (using an object from the `{distcrete}` package).
 #'
 #' @inheritParams print.epidist
+#' @param ... [dots] Extra arguments to be passed to the method.
 #'
 #' @inherit epidist return
 #' @export
@@ -963,6 +964,7 @@ is_truncated <- function(x) {
 #' Mean method for `<epidist>` class
 #'
 #' @inheritParams print.epidist
+#' @param ... [dots] Not used, extra arguments supplied will cause a warning.
 #'
 #' @return A `numeric` mean of a distribution or `NA`.
 #' @export
@@ -975,6 +977,7 @@ is_truncated <- function(x) {
 #' )
 #' mean(edist)
 mean.epidist <- function(x, ...) {
+  chkDots(...)
   # extract mean if given
   if (utils::hasName(x$summary_stats, "mean")) {
     mean <- x$summary_stats$mean

--- a/man/as.function.epidist.Rd
+++ b/man/as.function.epidist.Rd
@@ -13,7 +13,7 @@
 convert \verb{<epidist>} object into. Default is \code{"density"}. Other options are
 \code{"cdf"}, \code{"generate"}, or \code{"quantile"}.}
 
-\item{...}{\link{dots} Extra arguments passed to or from other methods.}
+\item{...}{\link{dots} Extra arguments to be passed to the method.}
 }
 \value{
 A \link{function} object.

--- a/man/convert_params_gamma.Rd
+++ b/man/convert_params_gamma.Rd
@@ -7,9 +7,9 @@
 convert_params_gamma(...)
 }
 \arguments{
-\item{...}{\link{dots} \code{Numeric} named parameter(s) used to convert to summary
-statistics. An example is the \code{meanlog} and \code{sdlog} parameters of the
-lognormal (\code{lnorm}) distribution.}
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> \code{Numeric} named parameter(s)
+used to convert to summary statistics. An example is the \code{meanlog} and
+\code{sdlog} parameters of the lognormal (\code{lnorm}) distribution.}
 }
 \value{
 A list of eight elements including: mean, median, mode,

--- a/man/convert_params_gamma.Rd
+++ b/man/convert_params_gamma.Rd
@@ -7,8 +7,8 @@
 convert_params_gamma(...)
 }
 \arguments{
-\item{...}{\code{Numeric} named parameter(s) used to convert to summary
-statistics. An example is the meanlog and sdlog parameters of the
+\item{...}{\link{dots} \code{Numeric} named parameter(s) used to convert to summary
+statistics. An example is the \code{meanlog} and \code{sdlog} parameters of the
 lognormal (\code{lnorm}) distribution.}
 }
 \value{

--- a/man/convert_params_geom.Rd
+++ b/man/convert_params_geom.Rd
@@ -7,9 +7,9 @@
 convert_params_geom(...)
 }
 \arguments{
-\item{...}{\link{dots} \code{Numeric} named parameter(s) used to convert to summary
-statistics. An example is the \code{meanlog} and \code{sdlog} parameters of the
-lognormal (\code{lnorm}) distribution.}
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> \code{Numeric} named parameter(s)
+used to convert to summary statistics. An example is the \code{meanlog} and
+\code{sdlog} parameters of the lognormal (\code{lnorm}) distribution.}
 }
 \value{
 A list of eight elements including: mean, median, mode,

--- a/man/convert_params_geom.Rd
+++ b/man/convert_params_geom.Rd
@@ -7,8 +7,8 @@
 convert_params_geom(...)
 }
 \arguments{
-\item{...}{\code{Numeric} named parameter(s) used to convert to summary
-statistics. An example is the meanlog and sdlog parameters of the
+\item{...}{\link{dots} \code{Numeric} named parameter(s) used to convert to summary
+statistics. An example is the \code{meanlog} and \code{sdlog} parameters of the
 lognormal (\code{lnorm}) distribution.}
 }
 \value{
@@ -19,7 +19,8 @@ skewness, and excess kurtosis (\code{ex_kurtosis}).
 \description{
 Convert the probability (\code{prob}) of the geometric distribution
 to a number of summary statistics which can be calculated analytically given
-the geometric parameter.
+the geometric parameter. One exception is the median which is calculated
+using \code{\link[stats:Geometric]{stats::qgeom()}} as the analytical form is not always unique.
 }
 \details{
 This conversion function assumes that distribution represents the

--- a/man/convert_params_lnorm.Rd
+++ b/man/convert_params_lnorm.Rd
@@ -7,8 +7,8 @@
 convert_params_lnorm(...)
 }
 \arguments{
-\item{...}{\code{Numeric} named parameter(s) used to convert to summary
-statistics. An example is the meanlog and sdlog parameters of the
+\item{...}{\link{dots} \code{Numeric} named parameter(s) used to convert to summary
+statistics. An example is the \code{meanlog} and \code{sdlog} parameters of the
 lognormal (\code{lnorm}) distribution.}
 }
 \value{

--- a/man/convert_params_lnorm.Rd
+++ b/man/convert_params_lnorm.Rd
@@ -7,9 +7,9 @@
 convert_params_lnorm(...)
 }
 \arguments{
-\item{...}{\link{dots} \code{Numeric} named parameter(s) used to convert to summary
-statistics. An example is the \code{meanlog} and \code{sdlog} parameters of the
-lognormal (\code{lnorm}) distribution.}
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> \code{Numeric} named parameter(s)
+used to convert to summary statistics. An example is the \code{meanlog} and
+\code{sdlog} parameters of the lognormal (\code{lnorm}) distribution.}
 }
 \value{
 A list of eight elements including: mean, median, mode,

--- a/man/convert_params_nbinom.Rd
+++ b/man/convert_params_nbinom.Rd
@@ -8,8 +8,8 @@ statistics}
 convert_params_nbinom(...)
 }
 \arguments{
-\item{...}{\code{Numeric} named parameter(s) used to convert to summary
-statistics. An example is the meanlog and sdlog parameters of the
+\item{...}{\link{dots} \code{Numeric} named parameter(s) used to convert to summary
+statistics. An example is the \code{meanlog} and \code{sdlog} parameters of the
 lognormal (\code{lnorm}) distribution.}
 }
 \value{

--- a/man/convert_params_nbinom.Rd
+++ b/man/convert_params_nbinom.Rd
@@ -8,9 +8,9 @@ statistics}
 convert_params_nbinom(...)
 }
 \arguments{
-\item{...}{\link{dots} \code{Numeric} named parameter(s) used to convert to summary
-statistics. An example is the \code{meanlog} and \code{sdlog} parameters of the
-lognormal (\code{lnorm}) distribution.}
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> \code{Numeric} named parameter(s)
+used to convert to summary statistics. An example is the \code{meanlog} and
+\code{sdlog} parameters of the lognormal (\code{lnorm}) distribution.}
 }
 \value{
 A list of eight elements including: mean, median, mode,

--- a/man/convert_params_to_summary_stats.Rd
+++ b/man/convert_params_to_summary_stats.Rd
@@ -13,8 +13,8 @@ convert_params_to_summary_stats(
 \item{distribution}{A \code{character} string specifying distribution to use.
 Default is \code{lnorm}; also takes \code{gamma} and \code{weibull}, \code{nbinom} and \code{geom}.}
 
-\item{...}{\code{Numeric} named parameter(s) used to convert to summary
-statistics. An example is the meanlog and sdlog parameters of the
+\item{...}{\link{dots} \code{Numeric} named parameter(s) used to convert to summary
+statistics. An example is the \code{meanlog} and \code{sdlog} parameters of the
 lognormal (\code{lnorm}) distribution.}
 }
 \value{

--- a/man/convert_params_to_summary_stats.Rd
+++ b/man/convert_params_to_summary_stats.Rd
@@ -13,9 +13,9 @@ convert_params_to_summary_stats(
 \item{distribution}{A \code{character} string specifying distribution to use.
 Default is \code{lnorm}; also takes \code{gamma} and \code{weibull}, \code{nbinom} and \code{geom}.}
 
-\item{...}{\link{dots} \code{Numeric} named parameter(s) used to convert to summary
-statistics. An example is the \code{meanlog} and \code{sdlog} parameters of the
-lognormal (\code{lnorm}) distribution.}
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> \code{Numeric} named parameter(s)
+used to convert to summary statistics. An example is the \code{meanlog} and
+\code{sdlog} parameters of the lognormal (\code{lnorm}) distribution.}
 }
 \value{
 A list of eight elements including: mean, median, mode,

--- a/man/convert_params_weibull.Rd
+++ b/man/convert_params_weibull.Rd
@@ -7,9 +7,9 @@
 convert_params_weibull(...)
 }
 \arguments{
-\item{...}{\link{dots} \code{Numeric} named parameter(s) used to convert to summary
-statistics. An example is the \code{meanlog} and \code{sdlog} parameters of the
-lognormal (\code{lnorm}) distribution.}
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> \code{Numeric} named parameter(s)
+used to convert to summary statistics. An example is the \code{meanlog} and
+\code{sdlog} parameters of the lognormal (\code{lnorm}) distribution.}
 }
 \value{
 A list of eight elements including: mean, median, mode,

--- a/man/convert_params_weibull.Rd
+++ b/man/convert_params_weibull.Rd
@@ -7,8 +7,8 @@
 convert_params_weibull(...)
 }
 \arguments{
-\item{...}{\code{Numeric} named parameter(s) used to convert to summary
-statistics. An example is the meanlog and sdlog parameters of the
+\item{...}{\link{dots} \code{Numeric} named parameter(s) used to convert to summary
+statistics. An example is the \code{meanlog} and \code{sdlog} parameters of the
 lognormal (\code{lnorm}) distribution.}
 }
 \value{

--- a/man/convert_summary_stats_gamma.Rd
+++ b/man/convert_summary_stats_gamma.Rd
@@ -7,9 +7,9 @@
 convert_summary_stats_gamma(...)
 }
 \arguments{
-\item{...}{\link{dots} \code{Numeric} named summary statistics used to convert to
-parameter(s). An example is the \code{mean} and \code{sd} parameters of the
-lognormal (\code{lnorm}) distribution.}
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> \code{Numeric} named summary
+statistics used to convert to parameter(s). An example is the \code{mean}
+and \code{sd} parameters of the lognormal (\code{lnorm}) distribution.}
 }
 \value{
 A list of two elements, the shape and scale

--- a/man/convert_summary_stats_gamma.Rd
+++ b/man/convert_summary_stats_gamma.Rd
@@ -7,8 +7,8 @@
 convert_summary_stats_gamma(...)
 }
 \arguments{
-\item{...}{\code{Numeric} named summary statistics used to convert to
-parameter(s). An example is the meanlog and sdlog parameters of the
+\item{...}{\link{dots} \code{Numeric} named summary statistics used to convert to
+parameter(s). An example is the \code{mean} and \code{sd} parameters of the
 lognormal (\code{lnorm}) distribution.}
 }
 \value{

--- a/man/convert_summary_stats_geom.Rd
+++ b/man/convert_summary_stats_geom.Rd
@@ -7,9 +7,9 @@
 convert_summary_stats_geom(...)
 }
 \arguments{
-\item{...}{\link{dots} \code{Numeric} named summary statistics used to convert to
-parameter(s). An example is the \code{mean} and \code{sd} parameters of the
-lognormal (\code{lnorm}) distribution.}
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> \code{Numeric} named summary
+statistics used to convert to parameter(s). An example is the \code{mean}
+and \code{sd} parameters of the lognormal (\code{lnorm}) distribution.}
 }
 \value{
 A list of one element, the probability parameter.

--- a/man/convert_summary_stats_geom.Rd
+++ b/man/convert_summary_stats_geom.Rd
@@ -7,8 +7,8 @@
 convert_summary_stats_geom(...)
 }
 \arguments{
-\item{...}{\code{Numeric} named summary statistics used to convert to
-parameter(s). An example is the meanlog and sdlog parameters of the
+\item{...}{\link{dots} \code{Numeric} named summary statistics used to convert to
+parameter(s). An example is the \code{mean} and \code{sd} parameters of the
 lognormal (\code{lnorm}) distribution.}
 }
 \value{

--- a/man/convert_summary_stats_lnorm.Rd
+++ b/man/convert_summary_stats_lnorm.Rd
@@ -7,9 +7,9 @@
 convert_summary_stats_lnorm(...)
 }
 \arguments{
-\item{...}{\link{dots} \code{Numeric} named summary statistics used to convert to
-parameter(s). An example is the \code{mean} and \code{sd} parameters of the
-lognormal (\code{lnorm}) distribution.}
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> \code{Numeric} named summary
+statistics used to convert to parameter(s). An example is the \code{mean}
+and \code{sd} parameters of the lognormal (\code{lnorm}) distribution.}
 }
 \value{
 A list of two elements: meanlog and sdlog

--- a/man/convert_summary_stats_lnorm.Rd
+++ b/man/convert_summary_stats_lnorm.Rd
@@ -7,8 +7,8 @@
 convert_summary_stats_lnorm(...)
 }
 \arguments{
-\item{...}{\code{Numeric} named summary statistics used to convert to
-parameter(s). An example is the meanlog and sdlog parameters of the
+\item{...}{\link{dots} \code{Numeric} named summary statistics used to convert to
+parameter(s). An example is the \code{mean} and \code{sd} parameters of the
 lognormal (\code{lnorm}) distribution.}
 }
 \value{

--- a/man/convert_summary_stats_nbinom.Rd
+++ b/man/convert_summary_stats_nbinom.Rd
@@ -8,8 +8,8 @@ distribution}
 convert_summary_stats_nbinom(...)
 }
 \arguments{
-\item{...}{\code{Numeric} named summary statistics used to convert to
-parameter(s). An example is the meanlog and sdlog parameters of the
+\item{...}{\link{dots} \code{Numeric} named summary statistics used to convert to
+parameter(s). An example is the \code{mean} and \code{sd} parameters of the
 lognormal (\code{lnorm}) distribution.}
 }
 \value{

--- a/man/convert_summary_stats_nbinom.Rd
+++ b/man/convert_summary_stats_nbinom.Rd
@@ -8,9 +8,9 @@ distribution}
 convert_summary_stats_nbinom(...)
 }
 \arguments{
-\item{...}{\link{dots} \code{Numeric} named summary statistics used to convert to
-parameter(s). An example is the \code{mean} and \code{sd} parameters of the
-lognormal (\code{lnorm}) distribution.}
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> \code{Numeric} named summary
+statistics used to convert to parameter(s). An example is the \code{mean}
+and \code{sd} parameters of the lognormal (\code{lnorm}) distribution.}
 }
 \value{
 A list of two elements, the probability and dispersion parameters.

--- a/man/convert_summary_stats_to_params.Rd
+++ b/man/convert_summary_stats_to_params.Rd
@@ -13,9 +13,9 @@ convert_summary_stats_to_params(
 \item{distribution}{A \code{character} string specifying distribution to use.
 Default is \code{lnorm}; also takes \code{gamma} and \code{weibull}, \code{nbinom} and \code{geom}.}
 
-\item{...}{\link{dots} \code{Numeric} named summary statistics used to convert to
-parameter(s). An example is the \code{mean} and \code{sd} parameters of the
-lognormal (\code{lnorm}) distribution.}
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> \code{Numeric} named summary
+statistics used to convert to parameter(s). An example is the \code{mean}
+and \code{sd} parameters of the lognormal (\code{lnorm}) distribution.}
 }
 \value{
 A list of either one or two elements (depending on how many

--- a/man/convert_summary_stats_to_params.Rd
+++ b/man/convert_summary_stats_to_params.Rd
@@ -13,8 +13,8 @@ convert_summary_stats_to_params(
 \item{distribution}{A \code{character} string specifying distribution to use.
 Default is \code{lnorm}; also takes \code{gamma} and \code{weibull}, \code{nbinom} and \code{geom}.}
 
-\item{...}{\code{Numeric} named summary statistics used to convert to
-parameter(s). An example is the meanlog and sdlog parameters of the
+\item{...}{\link{dots} \code{Numeric} named summary statistics used to convert to
+parameter(s). An example is the \code{mean} and \code{sd} parameters of the
 lognormal (\code{lnorm}) distribution.}
 }
 \value{

--- a/man/convert_summary_stats_weibull.Rd
+++ b/man/convert_summary_stats_weibull.Rd
@@ -7,8 +7,8 @@
 convert_summary_stats_weibull(...)
 }
 \arguments{
-\item{...}{\code{Numeric} named summary statistics used to convert to
-parameter(s). An example is the meanlog and sdlog parameters of the
+\item{...}{\link{dots} \code{Numeric} named summary statistics used to convert to
+parameter(s). An example is the \code{mean} and \code{sd} parameters of the
 lognormal (\code{lnorm}) distribution.}
 }
 \value{

--- a/man/convert_summary_stats_weibull.Rd
+++ b/man/convert_summary_stats_weibull.Rd
@@ -7,9 +7,9 @@
 convert_summary_stats_weibull(...)
 }
 \arguments{
-\item{...}{\link{dots} \code{Numeric} named summary statistics used to convert to
-parameter(s). An example is the \code{mean} and \code{sd} parameters of the
-lognormal (\code{lnorm}) distribution.}
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> \code{Numeric} named summary
+statistics used to convert to parameter(s). An example is the \code{mean}
+and \code{sd} parameters of the lognormal (\code{lnorm}) distribution.}
 }
 \value{
 A list of two elements, the shape and scale.

--- a/man/discretise.Rd
+++ b/man/discretise.Rd
@@ -18,7 +18,7 @@ discretize(x, ...)
 \arguments{
 \item{x}{An \verb{<epidist>} object.}
 
-\item{...}{\link{dots} Extra arguments passed to or from other methods.}
+\item{...}{\link{dots} Extra arguments to be passed to the method.}
 }
 \value{
 An \verb{<epidist>} object.

--- a/man/epidist_distribution_functions.Rd
+++ b/man/epidist_distribution_functions.Rd
@@ -34,7 +34,7 @@
 
 \item{at}{The quantiles to evaluate at.}
 
-\item{...}{\link{dots} Extra arguments passed to or from other methods.}
+\item{...}{\link{dots} Extra arguments to be passed to the method.}
 
 \item{q}{The quantiles to evaluate at.}
 

--- a/man/format.epidist.Rd
+++ b/man/format.epidist.Rd
@@ -16,7 +16,7 @@ vb_epidist class}
 \item{vb}{Either NULL (default) or a character string of either "Intrinsic"
 or "Extrinsic" which is used internally for plotting the vb_epidist class}
 
-\item{...}{\link{dots} Extra arguments passed to or from other methods.}
+\item{...}{\link{dots} Extra arguments to be passed to the method.}
 }
 \value{
 Invisibly returns an \verb{<epidist>}. Called for printing side-effects.

--- a/man/format.vb_epidist.Rd
+++ b/man/format.vb_epidist.Rd
@@ -9,7 +9,7 @@
 \arguments{
 \item{x}{A \verb{<vb_epidist>} object.}
 
-\item{...}{\link{dots} Extra arguments passed to or from other methods.}
+\item{...}{\link{dots} Extra arguments to be passed to the method.}
 }
 \value{
 Invisibly returns a \verb{<vb_epidist>}. Called for printing

--- a/man/get_citation.Rd
+++ b/man/get_citation.Rd
@@ -9,7 +9,7 @@ get_citation(x, ...)
 \arguments{
 \item{x}{an object used to select a method.}
 
-\item{...}{further arguments passed to or from other methods.}
+\item{...}{\link{dots} Extra arguments to be passed to the method.}
 }
 \description{
 Extract the citation stored in an \R object.

--- a/man/get_citation.epidist.Rd
+++ b/man/get_citation.epidist.Rd
@@ -9,7 +9,7 @@
 \arguments{
 \item{x}{An \verb{<epidist>} object.}
 
-\item{...}{Extra arguments to be passed to the method.}
+\item{...}{\link{dots} Not used, extra arguments supplied will cause a warning.}
 }
 \value{
 A \verb{<bibentry>} object.

--- a/man/get_citation.multi_epidist.Rd
+++ b/man/get_citation.multi_epidist.Rd
@@ -9,7 +9,7 @@
 \arguments{
 \item{x}{An \verb{<epidist>} object.}
 
-\item{...}{Extra arguments to be passed to the method.}
+\item{...}{\link{dots} Not used, extra arguments supplied will cause a warning.}
 }
 \value{
 A list of \verb{<bibentry>} objects. The length of output list is

--- a/man/get_parameters.Rd
+++ b/man/get_parameters.Rd
@@ -9,7 +9,7 @@ get_parameters(x, ...)
 \arguments{
 \item{x}{an object used to select a method.}
 
-\item{...}{further arguments passed to or from other methods.}
+\item{...}{\link{dots} Extra arguments to be passed to the method.}
 }
 \description{
 Extract the parameters stored in an \R object.

--- a/man/get_parameters.epidist.Rd
+++ b/man/get_parameters.epidist.Rd
@@ -9,7 +9,7 @@
 \arguments{
 \item{x}{An \verb{<epidist>} object.}
 
-\item{...}{Extra arguments to be passed to the method.}
+\item{...}{\link{dots} Not used, extra arguments supplied will cause a warning.}
 }
 \value{
 A named vector of parameters or \code{NA} when the \verb{<epidist>} object is

--- a/man/is_parameterised.Rd
+++ b/man/is_parameterised.Rd
@@ -13,7 +13,7 @@ is_parameterized(x, ...)
 \arguments{
 \item{x}{An \verb{<epidist>} or list of \verb{<epidist>} objects.}
 
-\item{...}{\link{dots} not used, extra arguments supplied will cause a warning.}
+\item{...}{\link{dots} Extra arguments to be passed to the method.}
 }
 \value{
 A single boolean \code{logical} for \verb{<epidist>} or vector of \code{logical}s

--- a/man/mean.epidist.Rd
+++ b/man/mean.epidist.Rd
@@ -9,7 +9,7 @@
 \arguments{
 \item{x}{An \verb{<epidist>} object.}
 
-\item{...}{\link{dots} Extra arguments passed to or from other methods.}
+\item{...}{\link{dots} Not used, extra arguments supplied will cause a warning.}
 }
 \value{
 A \code{numeric} mean of a distribution or \code{NA}.

--- a/man/print.epidist.Rd
+++ b/man/print.epidist.Rd
@@ -17,7 +17,7 @@ of the print method is printed. This is used internally for plotting the
 (\code{"Intrinsic"}) or extrinsic (\code{"Extrinsic"}) distribution for vector-borne
 diseases.}
 
-\item{...}{\link{dots} Extra arguments passed to or from other methods.}
+\item{...}{\link{dots} Extra arguments to be passed to the method.}
 }
 \value{
 Invisibly returns an \verb{<epidist>}. Called for side-effects.

--- a/man/print.multi_epidist.Rd
+++ b/man/print.multi_epidist.Rd
@@ -9,7 +9,7 @@
 \arguments{
 \item{x}{A \verb{<multi_epidist>} object.}
 
-\item{...}{\link{dots} Extra arguments passed to or from other methods.}
+\item{...}{\link{dots} Extra arguments to be passed to the method.}
 }
 \value{
 Invisibly returns a \verb{<multi_epidist>}. Called for side-effects.

--- a/man/print.vb_epidist.Rd
+++ b/man/print.vb_epidist.Rd
@@ -9,7 +9,7 @@
 \arguments{
 \item{x}{A \verb{<vb_epidist>} object.}
 
-\item{...}{\link{dots} Extra arguments passed to or from other methods.}
+\item{...}{\link{dots} Extra arguments to be passed to the method.}
 }
 \value{
 Invisibly returns a \verb{<vb_epidist>}. Called for printing

--- a/tests/testthat/test-convert_params.R
+++ b/tests/testthat/test-convert_params.R
@@ -209,13 +209,6 @@ test_that("convert_params_to_summary_stats fails as expected", {
 
   expect_error(
     convert_params_to_summary_stats(
-      distribution = "lnorm", meanlog = 1, meanlog = 1 #nolint
-    ),
-    regexp = "(Parameter(s) need to be named and supplied)*(to the function)"
-  )
-
-  expect_error(
-    convert_params_to_summary_stats(
       distribution = "gamma", shape = -1, scale = 1
     ),
     regexp = "(Assertion on)*(shape)*(failed: Element 1 is not >= 0.)"
@@ -263,12 +256,6 @@ test_that("convert_summary_stats_to_params fails as expected", {
 
   expect_error(
     convert_summary_stats_to_params(distribution = "lnorm"),
-    regexp = "Summary statistics need to be named and supplied to the function"
-  )
-
-  expect_error(
-    convert_summary_stats_to_params(distribution = "lnorm",
-                                    mean = 1, mean = 1), #nolint
     regexp = "Summary statistics need to be named and supplied to the function"
   )
 

--- a/tests/testthat/test-convert_params.R
+++ b/tests/testthat/test-convert_params.R
@@ -53,6 +53,49 @@ test_that("convert_params_to_summary_stats works as expected", {
   )
 })
 
+test_that("convert_params_to_summary_stats works as expected with dyn-dots", {
+  expect_identical(
+    convert_params_to_summary_stats(
+      distribution = "lnorm", meanlog = 1, sdlog = 0.5
+    ),
+    convert_params_to_summary_stats(
+      distribution = "lnorm", !!!list(meanlog = 1, sdlog = 0.5)
+    )
+  )
+
+  expect_identical(
+    convert_params_to_summary_stats(
+      distribution = "nbinom", prob = 0.5, dispersion = 1
+    ),
+    convert_params_to_summary_stats(
+      distribution = "nbinom", !!!list(prob = 0.5, dispersion = 1)
+    )
+  )
+
+  expect_identical(
+    convert_params_to_summary_stats(
+      distribution = "gamma", shape = 1, scale = 1
+    ),
+    convert_params_to_summary_stats(
+      distribution = "gamma", !!!list(shape = 1, scale = 1)
+    )
+  )
+
+  expect_equal(
+    convert_params_to_summary_stats(
+      distribution = "weibull", shape = 1, scale = 1
+    ),
+    convert_params_to_summary_stats(
+      distribution = "weibull", !!!list(shape = 1, scale = 1)
+    )
+  )
+
+  expect_equal(
+    convert_params_to_summary_stats(distribution = "geom", prob = 0.5),
+    convert_params_to_summary_stats(distribution = "geom", !!!list(prob = 0.5))
+  )
+})
+
 test_that("convert_summary_stats_to_params works as expected", {
   expect_equal(
     convert_summary_stats_to_params(distribution = "gamma", mean = 1, sd = 0.5),
@@ -96,6 +139,58 @@ test_that("convert_summary_stats_to_params works as expected", {
     convert_summary_stats_to_params(distribution = "geom", mean = 0.5),
     list(prob = 0.6666667),
     tolerance = 1e-4
+  )
+})
+
+test_that("convert_summary_stats_to_params works as expected with dyn-dots", {
+  expect_identical(
+    convert_summary_stats_to_params(distribution = "gamma", mean = 1, sd = 0.5),
+    convert_summary_stats_to_params(
+      distribution = "gamma", !!!list(mean = 1, sd = 0.5)
+    )
+  )
+
+  expect_identical(
+    suppressMessages(
+      convert_summary_stats_to_params(
+        distribution = "weibull", mean = 0.5, cv = 1
+      )
+    ),
+    suppressMessages(
+      convert_summary_stats_to_params(
+        distribution = "weibull", !!!list(mean = 0.5, cv = 1)
+      )
+    )
+  )
+
+  expect_identical(
+    convert_summary_stats_to_params(distribution = "lnorm", median = 1, sd = 1),
+    convert_summary_stats_to_params(
+      distribution = "lnorm", !!!list(median = 1, sd = 1)
+    )
+  )
+
+  expect_identical(
+    convert_summary_stats_to_params(
+      distribution = "nbinom", mean = 1, dispersion = 1
+    ),
+    convert_summary_stats_to_params(
+      distribution = "nbinom", !!!list(mean = 1, dispersion = 1)
+    )
+  )
+
+  expect_identical(
+    convert_summary_stats_to_params(
+      distribution = "nbinom", mean = 1, sd = 1.5
+    ),
+    convert_summary_stats_to_params(
+      distribution = "nbinom", !!!list(mean = 1, sd = 1.5)
+    )
+  )
+
+  expect_identical(
+    convert_summary_stats_to_params(distribution = "geom", mean = 0.5),
+    convert_summary_stats_to_params(distribution = "geom", !!!list(mean = 0.5))
   )
 })
 


### PR DESCRIPTION
This PR addresses #222 by adding {rlang} as a package dependency and accepting [dynamic dots](https://rlang.r-lib.org/reference/dyn-dots.html) for the conversion functions (both internal and exported). New tests are added for dynamic dots.

The documentation of `...` is also standardised across S3 generic and methods functions. `chkDots()` is added for S3 methods that do not use `...`.