### PR TITLE
`get_citation.multi_epidist()` return a `<bibentry>`

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -9,7 +9,9 @@ linters: all_linters(
       modify_defaults(
         default_undesirable_functions,
         citEntry = "use the more modern bibentry() function",
-        library = NULL # too many false positive in too many files
+        library = NULL, # too many false positive in too many files
+        structure = NULL, # used for class constructor functions
+        par = NULL # used with on.exit() and {withrs} is not a dependency
       )
     ),
     function_argument_linter = NULL,

--- a/R/accessors.R
+++ b/R/accessors.R
@@ -109,8 +109,9 @@ get_citation.epidist <- function(x, ...) {
 #' @inheritParams print.epidist
 #' @param ... [dots] Not used, extra arguments supplied will cause a warning.
 #'
-#' @return A list of `<bibentry>` objects. The length of output list is
-#' equal to the length of the list of `<epidist>` objects supplied.
+#' @return A `<bibentry>` object containing multiple references. The length of
+#' output `<bibentry>` is equal to the length of the list of `<epidist>`
+#' objects supplied.
 #' @export
 #'
 #' @examples
@@ -119,8 +120,10 @@ get_citation.epidist <- function(x, ...) {
 #' get_citation(edist)
 get_citation.multi_epidist <- function(x, ...) {
   chkDots(...)
+  # dispatches to get_citation.epidist method
   citation_list <- lapply(x, get_citation)
-
-  # return citation list
-  citation_list
+  # dispatches to c.bibentry method
+  multi_bibentry <- Reduce(f = c, x = citation_list)
+  # return <bibentry>
+  multi_bibentry
 }

--- a/R/epidist_db.R
+++ b/R/epidist_db.R
@@ -201,7 +201,7 @@ epidist_db <- function(disease = "all",
 
     message(
       "Using ", format(get_citation(single_epidist)), ". \n",
-      "To retrieve the short citation use the 'get_citation' function"
+      "To retrieve the citation use the 'get_citation' function"
     )
 
     return(single_epidist)
@@ -212,7 +212,7 @@ epidist_db <- function(disease = "all",
     "(", sum(is_param), " are parameterised). \n",
     "Use subset to filter by entry variables or ",
     "single_epidist to return a single entry. \n",
-    "To retrieve the short citation for each use the ",
+    "To retrieve the citation for each use the ",
     "'get_citation' function"
   )
 

--- a/R/extract_param.R
+++ b/R/extract_param.R
@@ -119,11 +119,11 @@ extract_param <- function(type = c("percentiles", "range"),
 
   # Validate inputs
   switch(type,
-    "percentiles" = stopifnot( # nolint
+    percentiles = stopifnot( # nolint
       "'values' and 'percentiles' need to be a vector of length 2" =
         type == "percentiles" && length(values) == 2 || length(percentiles) == 2
     ),
-    "range" = stopifnot(
+    range = stopifnot(
       "'values need to be a vector of length 3" =
         type == "range" && length(values) == 3
     )

--- a/man/get_citation.multi_epidist.Rd
+++ b/man/get_citation.multi_epidist.Rd
@@ -12,8 +12,9 @@
 \item{...}{\link{dots} Not used, extra arguments supplied will cause a warning.}
 }
 \value{
-A list of \verb{<bibentry>} objects. The length of output list is
-equal to the length of the list of \verb{<epidist>} objects supplied.
+A \verb{<bibentry>} object containing multiple references. The length of
+output \verb{<bibentry>} is equal to the length of the list of \verb{<epidist>}
+objects supplied.
 }
 \description{
 Extract the citation stored in a list of \verb{<epidist>} objects.

--- a/tests/testthat/_snaps/epidist_db.md
+++ b/tests/testthat/_snaps/epidist_db.md
@@ -5,7 +5,7 @@
     Message
       Returning 122 results that match the criteria (99 are parameterised). 
       Use subset to filter by entry variables or single_epidist to return a single entry. 
-      To retrieve the short citation for each use the 'get_citation' function
+      To retrieve the citation for each use the 'get_citation' function
     Output
       List of <epidist> objects
         Number of entries in library: 122
@@ -21,7 +21,7 @@
     Message
       Returning 2 results that match the criteria (2 are parameterised). 
       Use subset to filter by entry variables or single_epidist to return a single entry. 
-      To retrieve the short citation for each use the 'get_citation' function
+      To retrieve the citation for each use the 'get_citation' function
     Output
       [[1]]
       Disease: SARS


### PR DESCRIPTION
This PR updates the `get_citation()` `<multi_epidist>` S3 method to return a `<bibentry>` object which can contain multiple references. This was requested in #259 and allows multiple references to use the `<bibentry>` methods, instead of having to loop or `lapply` over the list of references.