### PR TITLE
Return boolean without if else in `is_parameterised.epidist()`

### DIFF
--- a/R/checkers.R
+++ b/R/checkers.R
@@ -41,13 +41,8 @@ is_parameterized <- is_parameterised
 #' @export
 is_parameterised.epidist <- function(x, ...) {
   chkDots(...)
-
   # probability distribution object
-  if (is.object(x$prob_dist)) {
-    return(TRUE)
-  }
-
-  return(FALSE)
+  return(is.object(x$prob_dist))
 }
 
 #' @export


### PR DESCRIPTION
This PR removes the redundant if-else in `is_parameterised.epidist()` and instead directly returns the boolean `logical`. Suggested in #259.