### PR TITLE
Remove `@examples` in `calc_dist_params()`

### DIFF
--- a/R/calc_dist_params.R
+++ b/R/calc_dist_params.R
@@ -29,24 +29,6 @@
 #'
 #' @return A named `numeric` vector with parameters.
 #' @keywords internal
-#' @examples
-#' \dontrun{
-#' calc_dist_params(
-#'   prob_dist = "gamma",
-#'   summary_stats = create_epidist_summary_stats(
-#'     quantiles = c("2.5" = 0.2, "97.5" = 9.2)
-#'   ),
-#'   sample_size = NA
-#' )
-#'
-#' calc_dist_params(
-#'   prob_dist = "gamma",
-#'   summary_stats = create_epidist_summary_stats(
-#'     median = 5, lower_range = 3, upper_range = 12
-#'   ),
-#'   sample_size = 25
-#' )
-#' }
 calc_dist_params <- function(prob_dist, # nolint cyclocomp
                              prob_dist_params,
                              summary_stats,

--- a/man/calc_dist_params.Rd
+++ b/man/calc_dist_params.Rd
@@ -54,23 +54,4 @@ provided the lowest value is used for the calculation.
 \item The last method is the extraction using a median and range of the data.
 }
 }
-\examples{
-\dontrun{
-calc_dist_params(
-  prob_dist = "gamma",
-  summary_stats = create_epidist_summary_stats(
-    quantiles = c("2.5" = 0.2, "97.5" = 9.2)
-  ),
-  sample_size = NA
-)
-
-calc_dist_params(
-  prob_dist = "gamma",
-  summary_stats = create_epidist_summary_stats(
-    median = 5, lower_range = 3, upper_range = 12
-  ),
-  sample_size = 25
-)
-}
-}
 \keyword{internal}


### PR DESCRIPTION
This PR removes the `@examples` documentation from `calc_dist_params()`. The `calc_dist_params()` function had an example that was erroring but was being missed as it was wrapped in a `\dontrun{}`. This was pointed out in #259. I have removed the example documentation from this function as the function is internal, and only exported functions in this package should have example documentation. `calc_dist_params()` has tests to ensure the function is working as intended.