### PR TITLE
Remove `\dontrun{}` from `get_percentiles()` function documentation

### DIFF
--- a/R/get_percentiles.R
+++ b/R/get_percentiles.R
@@ -12,22 +12,24 @@
 #' numeric using `as.numeric()`.
 #'
 #' @details  The name format is a character of the value of the percentile.
-#' Numbers with decimal places should have the decimal point in the name (e.g.
-#' `c("2.5" = 1, "97.5" = 10)`).
+#' Numbers with decimal places should have the decimal point in the name. For
+#' example the 5th and 95th percentile can be given as
+#'
+#' ```r
+#' get_percentiles(c("5" = 1, "95" = 10))
+#' ```
+#'
+#' or the 2.5th and 97.5th percentile can be given as
+#'
+#' ```r
+#' get_percentiles(c("2.5" = 1, "97.5" = 10))
+#' ```
 #'
 #' @param percentiles A named vector of values at percentiles with the names the
 #' percentiles. See Details for the accepted vector name format.
 #'
 #' @return A named `numeric` vector of percentiles.
 #' @keywords internal
-#'
-#' @examples
-#' \dontrun{
-#' # 90th interval
-#' get_percentiles(c("5" = 1, "95" = 10))
-#' # 95th interval
-#' get_percentiles(c("2.5" = 1, "97.5" = 10))
-#' }
 get_percentiles <- function(percentiles) {
   # check input
   checkmate::assert_numeric(percentiles, names = "unique")

--- a/man/get_percentiles.Rd
+++ b/man/get_percentiles.Rd
@@ -27,15 +27,15 @@ numeric using \code{as.numeric()}.
 }
 \details{
 The name format is a character of the value of the percentile.
-Numbers with decimal places should have the decimal point in the name (e.g.
-\code{c("2.5" = 1, "97.5" = 10)}).
-}
-\examples{
-\dontrun{
-# 90th interval
-get_percentiles(c("5" = 1, "95" = 10))
-# 95th interval
-get_percentiles(c("2.5" = 1, "97.5" = 10))
-}
+Numbers with decimal places should have the decimal point in the name. For
+example the 5th and 95th percentile can be given as
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{get_percentiles(c("5" = 1, "95" = 10))
+}\if{html}{\out{</div>}}
+
+or the 2.5th and 97.5th percentile can be given as
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{get_percentiles(c("2.5" = 1, "97.5" = 10))
+}\if{html}{\out{</div>}}
 }
 \keyword{internal}


### PR DESCRIPTION
This PR removes the `@examples` from `get_percentiles()` because the development policy is to only have function examples for exported functions. 