### PR TITLE
Add DOI to `README` and `CITATION` 

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -21,6 +21,7 @@ knitr::opts_chunk$set(
 [![R-CMD-check](https://github.com/epiverse-trace/epiparameter/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/epiverse-trace/epiparameter/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://codecov.io/gh/epiverse-trace/epiparameter/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/epiparameter?branch=main)
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11110881.svg)](https://doi.org/10.5281/zenodo.11110881)
 <!-- badges: end -->
 
 `{epiparameter}` is an `R` package that contains a library of epidemiological parameters for infectious diseases and a set classes and helper functions to be able to work with the data. It also includes functions to extract and convert parameters from reported summary statistics.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.or
 coverage](https://codecov.io/gh/epiverse-trace/epiparameter/branch/main/graph/badge.svg)](https://app.codecov.io/gh/epiverse-trace/epiparameter?branch=main)
 [![Lifecycle:
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11110881.svg)](https://doi.org/10.5281/zenodo.11110881)
 <!-- badges: end -->
 
 `{epiparameter}` is an `R` package that contains a library of
@@ -168,6 +169,8 @@ citation("epiparameter")
 #> 
 #>   Lambert J, Kucharski A, Tamayo C (2024). _epiparameter: Library of
 #>   Epidemiological Parameters with Helper Functions and Classes_.
+#>   doi:10.5281/zenodo.11110881
+#>   <https://doi.org/10.5281/zenodo.11110881>,
 #>   <https://github.com/epiverse-trace/epiparameter/,https://epiverse-trace.github.io/epiparameter/>.
 #> 
 #> A BibTeX entry for LaTeX users is
@@ -176,6 +179,7 @@ citation("epiparameter")
 #>     title = {epiparameter: Library of Epidemiological Parameters with Helper Functions and Classes},
 #>     author = {Joshua W. Lambert and Adam Kucharski and Carmen Tamayo},
 #>     year = {2024},
+#>     doi = {10.5281/zenodo.11110881},
 #>     url = {https://github.com/epiverse-trace/epiparameter/,
 #> https://epiverse-trace.github.io/epiparameter/},
 #>   }

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -19,5 +19,6 @@ bibentry(
   title   = paste0(meta$Package, ": ", gsub("[[:space:]]+", " ", meta$Title)),
   author  = author,
   year    = date,
+  doi     = "10.5281/zenodo.11110881",
   url     = meta$URL
 )


### PR DESCRIPTION
The (version independent) DOI from zenodo after the v0.1.0 release of {epiparameter} is added to the `README` and `CITATION` files.