### PR TITLE
Select truncation adjusted library entry with `epidist_db()`

### DIFF
--- a/R/epidist_db.R
+++ b/R/epidist_db.R
@@ -76,10 +76,10 @@
 #' when only one is wanted.
 #'
 #' **Note**: If multiple entries match the arguments supplied and
-#' `single_epidist = TRUE` then the `<epidist>` that is parameterised and
-#' has the largest sample size will be returned (see [is_parameterised()]).
-#' If multiple entries are equal after this sorting the first entry will
-#' be returned.
+#' `single_epidist = TRUE` then the `<epidist>` that is parameterised
+#' (and accounts for truncation if available) and has the largest sample size
+#' will be returned (see [is_parameterised()]). If multiple entries are equal
+#' after this sorting the first entry will be returned.
 #'
 #' @return An `<epidist>` object or list of `<epidist>` objects.
 #' @export
@@ -188,6 +188,15 @@ epidist_db <- function(disease = "all",
     # select parameterised entries
     if (sum(is_param) >= 1) {
       multi_epidist <- multi_epidist[is_param]
+    }
+    # select entries that accounted for truncation
+    idx <- vapply(
+      multi_epidist,
+      function(x) x$method_assess$right_truncated,
+      FUN.VALUE = logical(1)
+    )
+    if (sum(idx) >= 1) {
+      multi_epidist <- multi_epidist[idx]
     }
     # select largest sample size
     idx <- which.max(

--- a/man/epidist_db.Rd
+++ b/man/epidist_db.Rd
@@ -58,10 +58,10 @@ argument is used to prevent multiple sets of parameters being returned
 when only one is wanted.
 
 \strong{Note}: If multiple entries match the arguments supplied and
-\code{single_epidist = TRUE} then the \verb{<epidist>} that is parameterised and
-has the largest sample size will be returned (see \code{\link[=is_parameterised]{is_parameterised()}}).
-If multiple entries are equal after this sorting the first entry will
-be returned.}
+\code{single_epidist = TRUE} then the \verb{<epidist>} that is parameterised
+(and accounts for truncation if available) and has the largest sample size
+will be returned (see \code{\link[=is_parameterised]{is_parameterised()}}). If multiple entries are equal
+after this sorting the first entry will be returned.}
 }
 \value{
 An \verb{<epidist>} object or list of \verb{<epidist>} objects.

--- a/tests/testthat/_snaps/parameter_tbl.md
+++ b/tests/testthat/_snaps/parameter_tbl.md
@@ -163,9 +163,9 @@
     Output
       # Parameter table:
       # A data frame:    1 x 7
-        disease   pathogen epi_distribution prob_distribution author  year sample_size
-        <chr>     <chr>    <chr>            <chr>             <chr>  <dbl>       <dbl>
-      1 Ebola Vi~ Ebola V~ onset to death   gamma             WHO E~  2015        2741
+        disease  pathogen  epi_distribution prob_distribution author  year sample_size
+        <chr>    <chr>     <chr>            <chr>             <chr>  <dbl>       <dbl>
+      1 COVID-19 SARS-CoV~ onset to hospit~ lnorm             Linto~  2020         155
 
 # parameter_tbl works as expected with discretised <epidist>
 

--- a/tests/testthat/test-epidist_db.R
+++ b/tests/testthat/test-epidist_db.R
@@ -64,6 +64,20 @@ test_that("epidist_db works as expected with single_epidist as TRUE", {
   expect_length(edist, 10)
 })
 
+test_that("epidist_db chooses truncated with single_epidist as TRUE", {
+  # suppress message about citation
+  edist <- suppressMessages(
+    epidist_db(
+      disease = "COVID-19",
+      epi_dist = "onset to death",
+      single_epidist = TRUE
+    )
+  )
+
+  expect_s3_class(edist, class = "epidist")
+  expect_true(edist$method_assess$right_truncated)
+})
+
 test_that("epidist_db works as expected with subsetting and single_epidist", {
   edist <- suppressMessages(
     epidist_db(


### PR DESCRIPTION
This PR addresses #243 by updating `epidist_db()` to select parameter entries that account for truncation in their estimation methods (`$method_assess$right_truncated == TRUE` in the `<epidist>` and `right_truncated: true` in the library database `parameters.json`).

A new unit test has been added to check that `epidist_db()` selects an entry with truncation when available. The function documentation of `epidist_db()` (`?epidist_db`) has been updated to state that truncation adjusted entries are chosen if available.