### PR TITLE
Remove some unnecessary nolint comments

### DIFF
--- a/R/coercion.R
+++ b/R/coercion.R
@@ -397,9 +397,10 @@ epireview_to_epidist <- function(x, ...) {
 
   # clean parameter type name by removing the parameter class
   epi_dist <- gsub(
-    pattern = paste0(x1$parameter_class, " \\- "), # nolint nonportable_path_linter
+    pattern = paste0(x1$parameter_class, " - "),
     replacement = "",
-    x = x1$parameter_type
+    x = x1$parameter_type,
+    fixed = TRUE
   )
 
   region <- as.vector(

--- a/R/coercion.R
+++ b/R/coercion.R
@@ -199,7 +199,7 @@ epidist_df_to_epidist <- function(x, ...) {
   }
 
   # remove <AsIs> from citation
-  class(x$citation) <- class(x$citation)[!class(x$citation) == "AsIs"] # nolint class_equals_linter
+  class(x$citation) <- setdiff(class(x$citation), "AsIs")
 
   # return <epidist> from class constructor
   epidist(

--- a/R/extract_param.R
+++ b/R/extract_param.R
@@ -118,16 +118,18 @@ extract_param <- function(type = c("percentiles", "range"),
   )
 
   # Validate inputs
-  switch(type,
-    percentiles = stopifnot( # nolint consecutive_assertion_linter
+  if (type == "percentiles") {
+    stopifnot(
       "'values' and 'percentiles' need to be a vector of length 2" =
-        type == "percentiles" && length(values) == 2 || length(percentiles) == 2
-    ),
-    range = stopifnot(
-      "'values need to be a vector of length 3" =
-        type == "range" && length(values) == 3
+        length(values) == 2 || length(percentiles) == 2
     )
-  )
+  }
+  if (type == "range") {
+    stopifnot(
+      "'values need to be a vector of length 3" =
+        length(values) == 3
+    )
+  }
 
   # initialise for the loop
   optim_conv <- FALSE

--- a/R/parameter_tbl.R
+++ b/R/parameter_tbl.R
@@ -78,7 +78,7 @@ parameter_tbl <- function(multi_epidist,
   }, FUN.VALUE = character(1))
 
   year <- vapply(
-    multi_epidist, function(x) as.numeric(x$citation$year), # nolint lambda
+    multi_epidist, function(x) as.numeric(x$citation$year),
     FUN.VALUE = numeric(1)
   )
   sample_size <- vapply(


### PR DESCRIPTION
I understand https://github.com/epiverse-trace/epiparameter/pull/330/commits/5bc086f8122e5323c7aa352ddff92337e33788d7 was flagging an actual lintr bug but I find the `switch()` + `stopifnot()` syntax very difficult to read so I wonder if that's worth bothering with it. Feel free to exclude this commit if you feel strongly.