### PR TITLE
Allow `<epidist>` to contain an exponential distribution

### DIFF
--- a/R/create_epidist_prob_dist.R
+++ b/R/create_epidist_prob_dist.R
@@ -137,6 +137,9 @@ create_epidist_prob_dist <- function(prob_dist,
         mu = prob_dist_params[["mean"]],
         sigma = prob_dist_params[["sd"]]
       ),
+      exp = distributional::dist_exponential(
+        rate = prob_dist_params[["rate"]]
+      ),
       stop("Did not recognise distribution name", call. = FALSE)
     )
   }

--- a/R/epidist.R
+++ b/R/epidist.R
@@ -811,6 +811,7 @@ family.epidist <- function(object, ...) {
     geometric = "geom",
     poisson = "pois",
     normal = "norm",
+    exponential = "exp",
     prob_dist
   )
 

--- a/R/epidist_utils.R
+++ b/R/epidist_utils.R
@@ -565,6 +565,7 @@ is_epidist_params <- function(prob_dist, prob_dist_params) {
     geom = .clean_epidist_params_geom,
     pois = .clean_epidist_params_pois,
     norm = .clean_epidist_params_norm,
+    exp = .clean_epidist_params_exp,
     stop("Probability distribution not recognised", call. = FALSE)
   )
   clean_params <- do.call(clean_func, list(prob_dist_params))
@@ -675,6 +676,19 @@ is_epidist_params <- function(prob_dist, prob_dist_params) {
 
     # rearrange vector
     prob_dist_params <- prob_dist_params[c("mean", "sd")]
+  }
+  # return prob_dist_params
+  prob_dist_params
+}
+
+#' @name .clean_epidist_params
+.clean_epidist_params_exp <- function(prob_dist_params) {
+  # no cleaning needed for rate parameterisation
+  if (identical(names(prob_dist_params), "lambda")) {
+    names(prob_dist_params) <- "rate"
+  } else if (identical(names(prob_dist_params), "mean")) {
+    names(prob_dist_params) <- "rate"
+    prob_dist_params[["rate"]] <- 1 / prob_dist_params[["rate"]]
   }
   # return prob_dist_params
   prob_dist_params

--- a/R/epidist_utils.R
+++ b/R/epidist_utils.R
@@ -497,7 +497,8 @@ is_epidist_params <- function(prob_dist, prob_dist_params) {
     nbinom = list(c("mean", "dispersion"), c("mean", "k"), c("n", "p")),
     geom = list("mean", "p", "prob"),
     pois = list("mean", "l", "lambda"),
-    norm = list(c("mean", "sd"), c("mu", "sigma"))
+    norm = list(c("mean", "sd"), c("mu", "sigma")),
+    exp = list("rate", "lambda", "mean")
   )
   possible_params <- possible_params[[prob_dist]]
 

--- a/man/dot-clean_epidist_params.Rd
+++ b/man/dot-clean_epidist_params.Rd
@@ -8,6 +8,7 @@
 \alias{.clean_epidist_params_geom}
 \alias{.clean_epidist_params_pois}
 \alias{.clean_epidist_params_norm}
+\alias{.clean_epidist_params_exp}
 \title{Standardise distribution parameters}
 \usage{
 .clean_epidist_params(prob_dist, prob_dist_params)
@@ -23,6 +24,8 @@
 .clean_epidist_params_pois(prob_dist_params)
 
 .clean_epidist_params_norm(prob_dist_params)
+
+.clean_epidist_params_exp(prob_dist_params)
 }
 \arguments{
 \item{prob_dist}{A character string specifying the probability

--- a/tests/testthat/test-create_epidist_prob_dist.R
+++ b/tests/testthat/test-create_epidist_prob_dist.R
@@ -94,6 +94,22 @@ test_that("create_epidist_prob_dist works for poisson", {
   )
 })
 
+test_that("create_epidist_prob_dist works for exponential", {
+  res <- create_epidist_prob_dist(
+    prob_dist = "exp",
+    prob_dist_params = c(rate = 2),
+    discretise = FALSE,
+    truncation = NA
+  )
+
+  expect_s3_class(res, "distribution")
+  expect_identical(family(res), "exponential")
+  expect_identical(
+    distributional::parameters(res),
+    data.frame(rate = 2)
+  )
+})
+
 test_that("create_epidist_prob_dist works for discrete gamma", {
   res <- create_epidist_prob_dist(
     prob_dist = "gamma",

--- a/tests/testthat/test-epidist_utils.R
+++ b/tests/testthat/test-epidist_utils.R
@@ -239,6 +239,36 @@ test_that(".clean_epidist_params fails when pois parameters are incorrect", {
   )
 })
 
+test_that(".clean_epidist_params works as expected for exp", {
+  params <- .clean_epidist_params(
+    prob_dist = "exp",
+    prob_dist_params = c(rate = 2)
+  )
+  expect_identical(params, c(rate = 2))
+
+  params <- .clean_epidist_params(
+    prob_dist = "exp",
+    prob_dist_params = c(lambda = 2)
+  )
+  expect_identical(params, c(rate = 2))
+
+  params <- .clean_epidist_params(
+    prob_dist = "exp",
+    prob_dist_params = c(mean = 0.5)
+  )
+  expect_identical(params, c(rate = 2))
+})
+
+test_that(".clean_epidist_params fails when exp parameters are incorrect", {
+  expect_error(
+    .clean_epidist_params(
+      prob_dist = "exp",
+      prob_dist_params = c(means = 1)
+    ),
+    regexp = "Invalid parameterisation for exp distribution"
+  )
+})
+
 test_that(".clean_epidist_params fails as expected", {
   expect_error(
     .clean_epidist_params(


### PR DESCRIPTION
This PR addresses #328 by adding the ability to construct and print `<epidist>` objects with an exponential distribution. 

The `create_epidist_prob_dist()`, `is_epidist_params()`,  `clean_epidist_params()` and `family.epidist()` are updated to accommodate an exponential distribution. `.clean_epidist_params_exp()` is added to standardise the various valid parameterisations for the exponential distribution input by users. 

Unit tests have been added for `create_epidist_prob_dist()` and `clean_epidist_params()`. 