### PR TITLE
Add data license to package

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 YEAR: 2024
 COPYRIGHT HOLDER: epiparameter authors
-
-All data included in the epiparameter R package is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt). This includes the parameter database (extdata/parameters.json) and data in the data/ folder.
-
-Please cite the individual parameter entries in the database when used.
+DATA LICENSE: All data included in the epiparameter R package is licensed under CC0
+            (https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt). This includes the parameter
+            database (extdata/parameters.json) and data in the data/ folder. Please cite the individual
+            parameter entries in the database when used.

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,6 @@
 YEAR: 2024
 COPYRIGHT HOLDER: epiparameter authors
+
+All data included in the epiparameter R package is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt). This includes the parameter database (extdata/parameters.json) and data in the data/ folder.
+
+Please cite the individual parameter entries in the database when used.


### PR DESCRIPTION
This PR addresses #300 by adding the [CC0](https://creativecommons.org/public-domain/cc0/) license to the `LICENSE` file. This resolves #300 and should be a CRAN-compliant way to license both the code and the data in the package in an unambiguous way. See #300 for discussion and considerations on which license was chosen and how it should be included in the package.