### PR TITLE
Fix {epireview} coercion tests from new {epireview} release

### DIFF
--- a/tests/testthat/test-coercion.R
+++ b/tests/testthat/test-coercion.R
@@ -2,10 +2,8 @@ test_that("as_epiparameter works for ebola infectious period (issue #327 & #306)
   # {epireview} is not a dependency so only run if already on system
   skip_if_not_installed("epireview")
   # suppress warning and message about loading data
-  ebola <- suppressWarnings(
-    suppressMessages(
-      epireview::load_epidata("ebola")
-    )
+  ebola <- suppressMessages(
+    epireview::load_epidata("ebola")
   )
   ebola_params <- ebola$params
   ebola_infectiousness <- ebola_params[
@@ -34,10 +32,8 @@ test_that("as_epiparameter works for lassa incubation period (issue #306)", {
   # {epireview} is not a dependency so only run if already on system
   skip_if_not_installed("epireview")
   # suppress warning and message about loading data
-  lassa_data <- suppressWarnings(
-    suppressMessages(
-      epireview::load_epidata("lassa")
-    )
+  lassa_data <- suppressMessages(
+    epireview::load_epidata("lassa")
   )
   lassa_params <- lassa_data$params
   lassa_incub <- lassa_params[
@@ -65,10 +61,8 @@ test_that("as_epiparameter works for ebola serial interval (issue #303)", {
   # {epireview} is not a dependency so only run if already on system
   skip_if_not_installed("epireview")
   # suppress warning and message about loading data
-  ebola_data <- suppressWarnings(
-    suppressMessages(
-      epireview::load_epidata("ebola")
-    )
+  ebola_data <- suppressMessages(
+    epireview::load_epidata("ebola")
   )
   ebola_params <- ebola_data$params
   ebola_serial <- ebola_params[
@@ -96,10 +90,8 @@ test_that("as_epiparameter works for ebola SI assumed prob_dist (issue #310)", {
   # {epireview} is not a dependency so only run if already on system
   skip_if_not_installed("epireview")
   # suppress warning and message about loading data
-  ebola_data <- suppressWarnings(
-    suppressMessages(
-      epireview::load_epidata("ebola")
-    )
+  ebola_data <- suppressMessages(
+    epireview::load_epidata("ebola")
   )
   ebola_params <- ebola_data$params
   ebola_serial <- ebola_params[
@@ -128,10 +120,8 @@ test_that("as_epiparameter works for lassa incubation overwritten prob_dist", {
   # {epireview} is not a dependency so only run if already on system
   skip_if_not_installed("epireview")
   # suppress warning and message about loading data
-  lassa_data <- suppressWarnings(
-    suppressMessages(
-      epireview::load_epidata("lassa")
-    )
+  lassa_data <- suppressMessages(
+    epireview::load_epidata("lassa")
   )
   lassa_params <- lassa_data$params
   lassa_incub <- lassa_params[
@@ -161,11 +151,10 @@ test_that("as_epiparameter works for overwritten prob_dist with same parameters"
   # {epireview} is not a dependency so only run if already on system
   skip_if_not_installed("epireview")
   # suppress warning and message about loading data
-  ebola_data <- suppressWarnings(
-    suppressMessages(
-      epireview::load_epidata("ebola")
-    )
+  ebola_data <- suppressMessages(
+    epireview::load_epidata("ebola")
   )
+
   ebola_params <- ebola_data$params
   ebola_si <- ebola_params[
     which(
@@ -196,10 +185,8 @@ test_that("as_epiparameter fails as expected with overwritten prob_dist", {
   # {epireview} is not a dependency so only run if already on system
   skip_if_not_installed("epireview")
   # suppress warning and message about loading data
-  ebola_data <- suppressWarnings(
-    suppressMessages(
-      epireview::load_epidata("ebola")
-    )
+  ebola_data <- suppressMessages(
+    epireview::load_epidata("ebola")
   )
   ebola_params <- ebola_data$params
   ebola_si <- ebola_params[

--- a/tests/testthat/test-coercion.R
+++ b/tests/testthat/test-coercion.R
@@ -1,4 +1,4 @@
-if (!requireNamespace("epireview", quietly = TRUE)) {
+if (requireNamespace("epireview", quietly = TRUE)) {
   # suppress message about loading data
   ebola_data <- suppressMessages(
     epireview::load_epidata("ebola")

--- a/tests/testthat/test-coercion.R
+++ b/tests/testthat/test-coercion.R
@@ -41,7 +41,8 @@ test_that("as_epiparameter works for lassa incubation period (issue #306)", {
   )
   lassa_params <- lassa_data$params
   lassa_incub <- lassa_params[
-    which(lassa_params$article_label == "Akhmetzhanov 2019" &
+    # TODO: temp use id until epireview #122 is fixed
+    which(lassa_params$id == "62332f18a631d2cdaafc5c5a500caea5" &
             lassa_params$parameter_type == "Human delay - incubation period"),
   ]
   # suppress warning and message about citation
@@ -134,7 +135,8 @@ test_that("as_epiparameter works for lassa incubation overwritten prob_dist", {
   )
   lassa_params <- lassa_data$params
   lassa_incub <- lassa_params[
-    which(lassa_params$article_label == "Akhmetzhanov 2019" &
+    # TODO: temp use id until epireview #122 is fixed
+    which(lassa_params$id == "62332f18a631d2cdaafc5c5a500caea5" &
             lassa_params$parameter_type == "Human delay - incubation period"),
   ]
   # suppress warning and message about citation

--- a/tests/testthat/test-coercion.R
+++ b/tests/testthat/test-coercion.R
@@ -1,11 +1,17 @@
+if (!requireNamespace("epireview", quietly = TRUE)) {
+  # suppress message about loading data
+  ebola_data <- suppressMessages(
+    epireview::load_epidata("ebola")
+  )
+  lassa_data <- suppressMessages(
+    epireview::load_epidata("lassa")
+  )
+}
+
 test_that("as_epiparameter works for ebola infectious period (issue #327 & #306)", {
   # {epireview} is not a dependency so only run if already on system
   skip_if_not_installed("epireview")
-  # suppress warning and message about loading data
-  ebola <- suppressMessages(
-    epireview::load_epidata("ebola")
-  )
-  ebola_params <- ebola$params
+  ebola_params <- ebola_data$params
   ebola_infectiousness <- ebola_params[
     ebola_params$parameter_type == "Human delay - infectious period",
   ]
@@ -31,10 +37,6 @@ test_that("as_epiparameter works for ebola infectious period (issue #327 & #306)
 test_that("as_epiparameter works for lassa incubation period (issue #306)", {
   # {epireview} is not a dependency so only run if already on system
   skip_if_not_installed("epireview")
-  # suppress warning and message about loading data
-  lassa_data <- suppressMessages(
-    epireview::load_epidata("lassa")
-  )
   lassa_params <- lassa_data$params
   lassa_incub <- lassa_params[
     # TODO: temp use id until epireview #122 is fixed
@@ -60,10 +62,6 @@ test_that("as_epiparameter works for lassa incubation period (issue #306)", {
 test_that("as_epiparameter works for ebola serial interval (issue #303)", {
   # {epireview} is not a dependency so only run if already on system
   skip_if_not_installed("epireview")
-  # suppress warning and message about loading data
-  ebola_data <- suppressMessages(
-    epireview::load_epidata("ebola")
-  )
   ebola_params <- ebola_data$params
   ebola_serial <- ebola_params[
     which(ebola_params$parameter_type == "Human delay - serial interval" &
@@ -89,10 +87,6 @@ test_that("as_epiparameter works for ebola serial interval (issue #303)", {
 test_that("as_epiparameter works for ebola SI assumed prob_dist (issue #310)", {
   # {epireview} is not a dependency so only run if already on system
   skip_if_not_installed("epireview")
-  # suppress warning and message about loading data
-  ebola_data <- suppressMessages(
-    epireview::load_epidata("ebola")
-  )
   ebola_params <- ebola_data$params
   ebola_serial <- ebola_params[
     which(
@@ -119,10 +113,6 @@ test_that("as_epiparameter works for ebola SI assumed prob_dist (issue #310)", {
 test_that("as_epiparameter works for lassa incubation overwritten prob_dist", {
   # {epireview} is not a dependency so only run if already on system
   skip_if_not_installed("epireview")
-  # suppress warning and message about loading data
-  lassa_data <- suppressMessages(
-    epireview::load_epidata("lassa")
-  )
   lassa_params <- lassa_data$params
   lassa_incub <- lassa_params[
     # TODO: temp use id until epireview #122 is fixed
@@ -150,11 +140,6 @@ test_that("as_epiparameter works for lassa incubation overwritten prob_dist", {
 test_that("as_epiparameter works for overwritten prob_dist with same parameters", {
   # {epireview} is not a dependency so only run if already on system
   skip_if_not_installed("epireview")
-  # suppress warning and message about loading data
-  ebola_data <- suppressMessages(
-    epireview::load_epidata("ebola")
-  )
-
   ebola_params <- ebola_data$params
   ebola_si <- ebola_params[
     which(
@@ -184,10 +169,6 @@ test_that("as_epiparameter works for overwritten prob_dist with same parameters"
 test_that("as_epiparameter fails as expected with overwritten prob_dist", {
   # {epireview} is not a dependency so only run if already on system
   skip_if_not_installed("epireview")
-  # suppress warning and message about loading data
-  ebola_data <- suppressMessages(
-    epireview::load_epidata("ebola")
-  )
   ebola_params <- ebola_data$params
   ebola_si <- ebola_params[
     which(


### PR DESCRIPTION
This PR fixes the failing `test-coverage` workflow which was due to new release of {epireview}. 

The subsetting of the Lassa parameters is temporarily changed to use the `$id` column instead of `$article_label` due to a possible bug in the new {epireview} release (see mrc-ide/epireview#122). 

Duplicated calls to `epireview::load_epidata()` have also been removed, as have the no longer needed calls to `suppressWarnings()`. Recent updates to `load_epidata()` have stopped it producing warnings. 