### PR TITLE
Clean probability distribution name internal to resolve case sensitive matching issue

### DIFF
--- a/R/epiparameter.R
+++ b/R/epiparameter.R
@@ -44,6 +44,13 @@ new_epiparameter <- function(disease = character(),
       identical(names(prob_dist_params), names(uncertainty))
   )
 
+  # set string to lowercase for downstream case sensitive matching of prob_dist
+  prob_dist <- ifelse(
+    test = is.character(prob_dist),
+    yes = .clean_string(prob_dist),
+    no = prob_dist
+  )
+
   # TODO: formalise if statement below or remove
   # include mean in prob_dist_params
   if (!is.null(summary_stats$mean) && !is.na(summary_stats$mean) &&


### PR DESCRIPTION
This PR addresses #375 by cleaning the probability distribution name internally. This resolves an issue whereby the resulting `<epiparameter>` would be unparameterised due to not matching the string to construct the distribution object to be stored in the `<epiparameter>` object.

The fix applied in this PR now means the `prob_distribution` argument is now insensitive to case and whitespace, e.g.

``` r
library(epiparameter)
epiparameter::epiparameter(
  disease = "Mpox", 
  epi_dist = "serial interval", 
  prob_distribution = " WeiBull  ", 
  prob_distribution_params = c(shape = 2, scale = 2), 
  citation = create_citation(
    author = "James Smith", 
    year = 2000, 
    title = "Mpox stuff", 
    journal = "Journal of Epi", 
    doi = "10.2812ha"
  )
)
#> Using Smith J (2000). "Mpox stuff." _Journal of Epi_. doi:10.2812ha
#> <https://doi.org/10.2812ha>. 
#> To retrieve the citation use the 'get_citation' function
#> Disease: Mpox
#> Pathogen: NA
#> Epi Distribution: serial interval
#> Study: Smith J (2000). "Mpox stuff." _Journal of Epi_. doi:10.2812ha
#> <https://doi.org/10.2812ha>.
#> Distribution: weibull
#> Parameters:
#>   shape: 2.000
#>   scale: 2.000
```

<sup>Created on 2024-09-13 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>