### PR TITLE
Add conversion for median and dispersion of lognormal distribution to parameters

### DIFF
--- a/R/convert_params.R
+++ b/R/convert_params.R
@@ -401,6 +401,16 @@ convert_params_to_summary_stats.epiparameter <- function(x, ...) {
     return(list(meanlog = meanlog, sdlog = sdlog))
   }
 
+  if (checkmate::test_number(x$median) &&
+      checkmate::test_number(x$dispersion)) {
+    # median and dispersion to params
+    checkmate::assert_number(x$median, lower = 0)
+    checkmate::assert_number(x$dispersion, lower = 0)
+    meanlog <- log(x$median)
+    sdlog <- log(x$dispersion)
+    return(list(meanlog = meanlog, sdlog = sdlog))
+  }
+
   if (!(checkmate::test_number(x$median) && checkmate::test_number(x$sd))) {
     stop("Cannot calculate lognormal parameters from given input")
   }

--- a/tests/testthat/_snaps/convert_params.md
+++ b/tests/testthat/_snaps/convert_params.md
@@ -81,6 +81,31 @@
         "names": {
           "type": "character",
           "attributes": {},
+          "value": ["meanlog", "sdlog"]
+        }
+      },
+      "value": [
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [1.60943791]
+        },
+        {
+          "type": "double",
+          "attributes": {},
+          "value": [0.69314718]
+        }
+      ]
+    }
+
+---
+
+    {
+      "type": "list",
+      "attributes": {
+        "names": {
+          "type": "character",
+          "attributes": {},
           "value": ["prob", "dispersion"]
         }
       },

--- a/tests/testthat/test-convert_params.R
+++ b/tests/testthat/test-convert_params.R
@@ -24,6 +24,10 @@ test_that("convert_summary_stats_to_params.character works as expected", {
     style = "json2"
   )
   expect_snapshot_value(
+    convert_summary_stats_to_params("lnorm", median = 5, dispersion = 2),
+    style = "json2"
+  )
+  expect_snapshot_value(
     convert_summary_stats_to_params("nbinom", mean = 1, dispersion = 1),
     style = "json2"
   )


### PR DESCRIPTION
This PR adds a new summary statistic conversion calculation to `.convert_summary_stats_lnorm()` which is called by the `convert_summary_stats_to_params()` function. The conversion is from median and dispersion to the lognormal parameters (meanlog and sdlog). 

This conversion is useful for papers that report in median and dispersion, such as [Lessler et al. (2009)](https://www.thelancet.com/journals/lancet/article/PIIS1473-3099(09)70069-6/fulltext).