### PR TITLE
Move dispersion from parameter to summary statistic in DB and add dispersion to `create_summary_stats()`

### DIFF
--- a/R/epiparameter-utils.R
+++ b/R/epiparameter-utils.R
@@ -226,18 +226,31 @@ create_region <- function(continent = NA_character_,
 #' @param mean_ci_limits A `numeric` vector of length two of the confidence
 #' interval around the mean.
 #' @param mean_ci A `numeric` specifying the confidence interval width,
-#' e.g. 95 would be the 95% CI
+#' e.g. `95` would be the 95% CI
 #' @param sd A `numeric` of the standard deviation of the probability
 #' distribution.
 #' @param sd_ci_limits A `numeric` vector of length 2 of the confidence interval
 #' around the standard deviation.
 #' @param sd_ci A `numeric` specifying the confidence interval width,
-#' e.g. 95 would be 95% confidence interval.
+#' e.g. `95` would be 95% confidence interval.
 #' @param median A `numeric` of the median of the probability distribution.
 #' @param median_ci_limits A `numeric` vector of length two of the confidence
 #' interval around the median.
 #' @param median_ci A `numeric` specifying the confidence interval width
 #' of the median.
+#' @param dispersion A `numeric` of the dispersion of the probability
+#' distribution. **Important** this is the dispersion for probability
+#' distributions that are not usually parameterised by a dispersion parameter,
+#' for example a lognormal distribution. If a probability distribution is
+#' usually parameterised with a dispersion parameter, e.g. negative binomial
+#' distribution, then this should be considered a parameter and not a summary
+#' statistic and should go in the `prob_distribution` argument when
+#' constructing an `<epiparameter>` object with [epiparameter()]
+#' (see [create_prob_distribution()]).
+#' @param dispersion_ci_limits A `numeric` vector of length 2 of the confidence
+#' interval around the dispersion.
+#' @param dispersion_ci A `numeric` specifying the confidence interval width,
+#' e.g. `95` would be 95% confidence interval.
 #' @param lower_range The lower range of the data, used to infer the parameters
 #' of the distribution when not provided.
 #' @param upper_range The upper range of the data, used to infer the parameters
@@ -285,6 +298,9 @@ create_summary_stats <- function(mean = NA_real_,
                                    NA_real_
                                  ),
                                  median_ci = NA_real_,
+                                 dispersion = NA_real_,
+                                 dispersion_ci_limits = c(NA_real_, NA_real_),
+                                 dispersion_ci = NA_real_,
                                  lower_range = NA_real_,
                                  upper_range = NA_real_,
                                  quantiles = NA_real_) {
@@ -298,6 +314,9 @@ create_summary_stats <- function(mean = NA_real_,
   checkmate::assert_number(median, na.ok = TRUE)
   checkmate::assert_numeric(median_ci_limits, len = 2, any.missing = TRUE)
   checkmate::assert_number(median_ci, na.ok = TRUE)
+  checkmate::assert_number(dispersion, na.ok = TRUE)
+  checkmate::assert_numeric(dispersion_ci_limits, len = 2, any.missing = TRUE)
+  checkmate::assert_number(dispersion_ci, na.ok = TRUE)
   checkmate::assert_number(lower_range, na.ok = TRUE)
   checkmate::assert_number(upper_range, na.ok = TRUE)
   checkmate::assert_numeric(quantiles)
@@ -316,6 +335,9 @@ create_summary_stats <- function(mean = NA_real_,
     median = median,
     median_ci_limits = median_ci_limits,
     median_ci = median_ci,
+    dispersion = dispersion,
+    dispersion_ci_limits = dispersion_ci_limits,
+    dispersion_ci = dispersion_ci,
     quantiles = quantiles,
     range = c(lower_range, upper_range)
   )

--- a/R/epiparameter-utils.R
+++ b/R/epiparameter-utils.R
@@ -214,6 +214,7 @@ create_region <- function(continent = NA_character_,
   )
 }
 
+# nolint start: line_length_linter
 #' Specify reported summary statistics
 #'
 #' @description A helper function when creating an `<epiparameter>` object to
@@ -259,11 +260,11 @@ create_region <- function(continent = NA_character_,
 #' If quantiles are not provided a default empty vector with the 2.5th, 5th,
 #' 25th, 75th, 95th, 97.5th quantiles are supplied.
 #'
-#' @return A nested list of summary statistics. The highest level are
-#' - `$centre_spread`
-#' - `$quantiles`
-#' - `$range`
-#' - `$dispersion`
+#' @return A list of summary statistics. The output list has element names
+#' equal to the function arguments:
+#' \preformatted{
+#' `r paste("$", names(formals(create_summary_stats)), sep = "", collapse = "\n")`
+#' }
 #' @export
 #'
 #' @examples
@@ -286,6 +287,7 @@ create_region <- function(continent = NA_character_,
 #'   lower_range = 1,
 #'   upper_range = 13
 #' )
+# nolint end: line_length_linter
 create_summary_stats <- function(mean = NA_real_,
                                  mean_ci_limits = c(NA_real_, NA_real_),
                                  mean_ci = NA_real_,

--- a/inst/extdata/data_dictionary.json
+++ b/inst/extdata/data_dictionary.json
@@ -150,6 +150,9 @@
       },
       "summary_statistics": {
         "type": "object",
+         "propertyNames": {
+           "enum": ["mean", "mean_ci_limits", "mean_ci", "sd", "sd_ci_limits", "sd_ci", "median", "median_ci_limits", "median_ci", "dispersion", "dispersion_ci_limits", "dispersion_ci", "quantile_values", "quantile_names", "lower_range", "upper_range"]
+         },
         "properties": {
           "mean": {
             "description": "The mean value (expectation) of the distribution. If the mean is not reported put NA.",

--- a/inst/extdata/parameters.json
+++ b/inst/extdata/parameters.json
@@ -5,18 +5,17 @@
     "epi_distribution": "incubation period",
     "probability_distribution": {
         "prob_distribution": "lnorm",
-        "parameters": {
-          "dispersion": 1.26,
-          "dispersion_ci_limits": [1.13, 1.38],
-          "dispersion_ci": 95
-        }
+        "parameters": { }
     },
     "summary_statistics": {
       "quantile_values": [4.8, 6.5],
       "quantile_names": ["25", "75"],
       "median": 5.6,
       "median_ci_limits": [4.8, 6.3],
-      "median_ci": 95
+      "median_ci": 95,
+      "dispersion": 1.26,
+      "dispersion_ci_limits": [1.13, 1.38],
+      "dispersion_ci": 95
     },
     "citation": {
       "author": [
@@ -73,18 +72,17 @@
     "epi_distribution": "incubation period",
     "probability_distribution": {
       "prob_distribution": "lnorm",
-      "parameters": {
-        "dispersion": 1.15,
-        "dispersion_ci_limits": [1.07, 1.34],
-        "dispersion_ci": 95
-      }
+      "parameters": { }
     },
     "summary_statistics": {
       "quantile_values": [2.9, 3.5],
       "quantile_names": ["25", "75"],
       "median": 3.2,
       "median_ci_limits": [2.8, 3.7],
-      "median_ci": 95
+      "median_ci": 95,
+      "dispersion": 1.15,
+      "dispersion_ci_limits": [1.07, 1.34],
+      "dispersion_ci": 95
     },
     "citation": {
       "author": [
@@ -141,18 +139,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.81,
-      "dispersion_ci_limits": [1.67, 1.95],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [1.5, 2.7, 5.9, 10.6],
     "quantile_names": ["5", "25", "75", "95"],
     "median": 4,
     "median_ci_limits": [3.6, 4.4],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.81,
+    "dispersion_ci_limits": [1.67, 1.95],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -209,18 +206,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.51,
-      "dispersion_ci_limits": [1.43, 1.6],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [0.7, 1.1, 1.9, 2.8],
     "quantile_names": ["5", "25", "75", "95"],
     "median": 1.4,
     "median_ci_limits": [1.3, 1.5],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.51,
+    "dispersion_ci_limits": [1.43, 1.6],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -277,18 +273,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.23,
-      "dispersion_ci_limits": [1.17, 1.29],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [1.4, 1.7, 2.2, 2.7],
     "quantile_names": ["5", "25", "75", "95"],
     "median": 1.9,
     "median_ci_limits": [1.8, 2],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.23,
+    "dispersion_ci_limits": [1.17, 1.29],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -345,18 +340,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.51,
-      "dispersion_ci_limits": [1.37, 1.64],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [0.3, 0.4, 0.7, 1.1],
     "quantile_names": ["5", "25", "75", "95"],
     "median": 0.6,
     "median_ci_limits": [0.5, 0.6],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.51,
+    "dispersion_ci_limits": [1.37, 1.64],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -413,18 +407,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.23,
-      "dispersion_ci_limits": [1.18, 1.28],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [8.9, 10.9, 14.4, 17.7],
     "quantile_names": ["5", "25", "75", "95"],
     "median": 12.5,
     "median_ci_limits": [11.8, 13.3],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.23,
+    "dispersion_ci_limits": [1.18, 1.28],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -481,18 +474,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.35,
-      "dispersion_ci_limits": [1.16, 1.55],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [2.1, 3.2],
     "quantile_names": ["25", "75"],
     "median": 2.6,
     "median_ci_limits": [2.1, 3.1],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.35,
+    "dispersion_ci_limits": [1.16, 1.55],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -549,18 +541,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
       "prob_distribution": "lnorm",
-      "parameters": {
-        "dispersion": 1.24,
-        "dispersion_ci_limits": [1.13, 1.35],
-        "dispersion_ci": 95
-      }
+      "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [3.1, 3.8, 5.1, 6.3],
     "quantile_names": ["5", "25", "75", "95"],
     "median": 4.4,
     "median_ci_limits": [3.9, 4.9],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.24,
+    "dispersion_ci_limits": [1.13, 1.35],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -617,18 +608,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.68,
-      "dispersion_ci_limits": [1.36, 2.01],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [0.8, 1.3, 2.7, 4.5],
     "quantile_names": ["5", "25", "75", "95"],
     "median": 1.9,
     "median_ci_limits": [1.4, 2.4],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.68,
+    "dispersion_ci_limits": [1.36, 2.01],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -685,18 +675,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.53,
-      "dispersion_ci_limits": [1.44, 1.61],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [0.73, 2.94],
     "quantile_names": ["5", "95"],
     "median": 1.46,
     "median_ci_limits": [1.35, 1.57],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.53,
+    "dispersion_ci_limits": [1.44, 1.61],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -745,18 +734,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.51,
-      "dispersion_ci_limits": [1.43, 1.6],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [0.73, 2.83],
     "quantile_names": ["5", "95"],
     "median": 1.43,
     "median_ci_limits": [1.33, 1.54],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.51,
+    "dispersion_ci_limits": [1.43, 1.6],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -805,18 +793,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.25,
-      "dispersion_ci_limits": [1.14, 1.36],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [3.05, 6.39],
     "quantile_names": ["5", "95"],
     "median": 4.41,
     "median_ci_limits": [3.9, 4.92],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.25,
+    "dispersion_ci_limits": [1.14, 1.36],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -865,18 +852,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.24,
-      "dispersion_ci_limits": [1.12, 1.35],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [3.11, 6.26],
     "quantile_names": ["5", "95"],
     "median": 4.41,
     "median_ci_limits": [3.89, 4.94],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.24,
+    "dispersion_ci_limits": [1.12, 1.35],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -2941,18 +2927,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.5,
-      "dispersion_ci_limits": [1.2, 1.9],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [3.2, 4.6, 7.6, 11.2],
     "quantile_names": ["5" ,"25", "75", "95"],
     "median": 5.9,
     "median_ci_limits": [4.4, 7.6],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.5,
+    "dispersion_ci_limits": [1.2, 1.9],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -3026,18 +3011,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.04,
-      "dispersion_ci_limits": [1.04, 1.08],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [2.9, 3],
     "quantile_names": ["25", "75"],
     "median": 3,
     "median_ci_limits": [0.5, 3.1],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.04,
+    "dispersion_ci_limits": [1.04, 1.08],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -3091,18 +3075,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.41,
-      "dispersion_ci_limits": [1.34, 1.5],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [4.5, 7.1],
     "quantile_names": ["25", "75"],
     "median": 5.6,
     "median_ci_limits": [5.3, 6],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.41,
+    "dispersion_ci_limits": [1.34, 1.5],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -3155,18 +3138,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.37,
-      "dispersion_ci_limits": [1.27, 1.52],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [4.3, 6.6],
     "quantile_names": ["25", "75"],
     "median": 5.3,
     "median_ci_limits": [5, 5.7],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.37,
+    "dispersion_ci_limits": [1.27, 1.52],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -3220,18 +3202,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.04,
-      "dispersion_ci_limits": [1.04, 1.05],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [8.1, 8.6],
     "quantile_names": ["25", "75"],
     "median": 8.4,
     "median_ci_limits": [5.1, 9.4],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.04,
+    "dispersion_ci_limits": [1.04, 1.05],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -3285,18 +3266,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.5,
-      "dispersion_ci_limits": [1.22, 1.82],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [3.1, 5.3],
     "quantile_names": ["25", "75"],
     "median": 4,
     "median_ci_limits": [3.4, 4.9],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.5,
+    "dispersion_ci_limits": [1.22, 1.82],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -3350,18 +3330,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.82,
-      "dispersion_ci_limits": [1.27, 2.67],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [1, 1.7, 3.8, 7],
     "quantile_names": ["5", "25", "75", "95"],
     "median": 2.6,
     "median_ci_limits": [1.6, 3.5],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.82,
+    "dispersion_ci_limits": [1.27, 2.67],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -3414,18 +3393,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.04,
-      "dispersion_ci_limits": [1.04, 1.29],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [2.8, 3],
     "quantile_names": ["25", "75"],
     "median": 2.9,
     "median_ci_limits": [0.5, 3.1],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.04,
+    "dispersion_ci_limits": [1.04, 1.29],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -3479,18 +3457,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.35,
-      "dispersion_ci_limits": [1.12, 1.47],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [8.7, 13.3],
     "quantile_names": ["25", "75"],
     "median": 10.8,
     "median_ci_limits": [8.4, 14.2],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.35,
+    "dispersion_ci_limits": [1.12, 1.47],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -3543,18 +3520,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.66,
-      "dispersion_ci_limits": [1.48, 1.82],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [1.9, 3.2, 6.3, 10.3],
     "quantile_names": ["5", "25", "75", "95"],
     "median": 4.4,
     "median_ci_limits": [4, 5],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.66,
+    "dispersion_ci_limits": [1.48, 1.82],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -3607,18 +3583,17 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.67,
-      "dispersion_ci_limits": [1.47, 1.84],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "quantile_values": [1.9, 3.1, 6.2, 10.3],
     "quantile_names": ["5", "25", "75", "95"],
     "median": 4.4,
     "median_ci_limits": [3.9, 5],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.67,
+    "dispersion_ci_limits": [1.47, 1.84],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [
@@ -10106,11 +10081,7 @@
   "epi_distribution": "incubation period",
   "probability_distribution": {
     "prob_distribution": "lnorm",
-    "parameters": {
-      "dispersion": 1.52,
-      "dispersion_ci_limits": [1.32, 1.72],
-      "dispersion_ci": 95
-    }
+    "parameters": { }
   },
   "summary_statistics": {
     "mean": 5.5,
@@ -10118,7 +10089,10 @@
     "quantile_names": ["2.5", "97.5"],
     "median": 5.1,
     "median_ci_limits": [4.5, 5.8],
-    "median_ci": 95
+    "median_ci": 95,
+    "dispersion": 1.52,
+    "dispersion_ci_limits": [1.32, 1.72],
+    "dispersion_ci": 95
   },
   "citation": {
     "author": [

--- a/man/create_summary_stats.Rd
+++ b/man/create_summary_stats.Rd
@@ -14,6 +14,9 @@ create_summary_stats(
   median = NA_real_,
   median_ci_limits = c(NA_real_, NA_real_),
   median_ci = NA_real_,
+  dispersion = NA_real_,
+  dispersion_ci_limits = c(NA_real_, NA_real_),
+  dispersion_ci = NA_real_,
   lower_range = NA_real_,
   upper_range = NA_real_,
   quantiles = NA_real_
@@ -27,7 +30,7 @@ distribution.}
 interval around the mean.}
 
 \item{mean_ci}{A \code{numeric} specifying the confidence interval width,
-e.g. 95 would be the 95\% CI}
+e.g. \code{95} would be the 95\% CI}
 
 \item{sd}{A \code{numeric} of the standard deviation of the probability
 distribution.}
@@ -36,7 +39,7 @@ distribution.}
 around the standard deviation.}
 
 \item{sd_ci}{A \code{numeric} specifying the confidence interval width,
-e.g. 95 would be 95\% confidence interval.}
+e.g. \code{95} would be 95\% confidence interval.}
 
 \item{median}{A \code{numeric} of the median of the probability distribution.}
 
@@ -45,6 +48,22 @@ interval around the median.}
 
 \item{median_ci}{A \code{numeric} specifying the confidence interval width
 of the median.}
+
+\item{dispersion}{A \code{numeric} of the dispersion of the probability
+distribution. \strong{Important} this is the dispersion for probability
+distributions that are not usually parameterised by a dispersion parameter,
+for example a lognormal distribution. If a probability distribution is
+usually parameterised with a dispersion parameter, e.g. negative binomial
+distribution, then this should be considered a parameter and not a summary
+statistic and should go in the \code{prob_distribution} argument when
+constructing an \verb{<epiparameter>} object with \code{\link[=epiparameter]{epiparameter()}}
+(see \code{\link[=create_prob_distribution]{create_prob_distribution()}}).}
+
+\item{dispersion_ci_limits}{A \code{numeric} vector of length 2 of the confidence
+interval around the dispersion.}
+
+\item{dispersion_ci}{A \code{numeric} specifying the confidence interval width,
+e.g. \code{95} would be 95\% confidence interval.}
 
 \item{lower_range}{The lower range of the data, used to infer the parameters
 of the distribution when not provided.}

--- a/man/create_summary_stats.Rd
+++ b/man/create_summary_stats.Rd
@@ -76,12 +76,24 @@ If quantiles are not provided a default empty vector with the 2.5th, 5th,
 25th, 75th, 95th, 97.5th quantiles are supplied.}
 }
 \value{
-A nested list of summary statistics. The highest level are
-\itemize{
-\item \verb{$centre_spread}
-\item \verb{$quantiles}
-\item \verb{$range}
-\item \verb{$dispersion}
+A list of summary statistics. The output list has element names
+equal to the function arguments:
+\preformatted{
+$mean
+$mean_ci_limits
+$mean_ci
+$sd
+$sd_ci_limits
+$sd_ci
+$median
+$median_ci_limits
+$median_ci
+$dispersion
+$dispersion_ci_limits
+$dispersion_ci
+$lower_range
+$upper_range
+$quantiles
 }
 }
 \description{


### PR DESCRIPTION
This PR redefines the dispersion parameter as a summary statistic for probability distributions that do not use the dispersion parameter in usual parameterisations (e.g lognormal distributions). It is kept as a parameter for distributions that use dispersion as a standard parameter (e.g. negative binomial). This change is made to the parameter database (`parameters.json`). 

The JSON schema (`data_dictionary.json`) is enhanced by adding a `propertyName` `enum` to make sure that summary statistics stored in the database are valid from a set of options. 

The `create_summary_stats()` function is updated to include `dispersion` and dispersion uncertainty as arguments and in the output list. The function documentation is also updated. 