### PR TITLE
Move mean to parameter for negative binomial in DB

### DIFF
--- a/.github/workflows/validate-json.yaml
+++ b/.github/workflows/validate-json.yaml
@@ -41,7 +41,7 @@ jobs:
             engine = "ajv",
             verbose = TRUE,
             greedy = TRUE,
-            strict = TRUE,
+            strict = FALSE,
             error = TRUE
           )
         shell: Rscript {0}

--- a/inst/extdata/data_dictionary.json
+++ b/inst/extdata/data_dictionary.json
@@ -34,7 +34,10 @@
           },
           "parameters": {
             "type": "object",
-            "properties": {
+            "propertyNames": {
+           "enum": ["shape", "shape_ci_limits", "shape_ci", "scale", "scale_ci_limits", "scale_ci", "meanlog", "meanlog_ci_limits", "meanlog_ci", "sdlog", "sdlog_ci_limits", "sdlog_ci", "dispersion", "dispersion_ci_limits", "dispersion_ci", "precision", "precision_ci_limits", "precision_ci", "mean", "mean_ci_limits", "mean_ci", "sd", "sd_ci_limits", "sd_ci"]
+         },
+         "properties": {
               "shape": {
                 "description": "The shape parameter of either the gamma or Weibull distribution.",
                 "examples": [2.0, 4.5],
@@ -108,7 +111,7 @@
                 "type": ["number", "null"]
               },
               "dispersion": {
-                "description": "The dispersion factor of the lognormal distribution. This can be used with the median to calculate the bounds that contain approximately two-thirds of The data.",
+                "description": "The dispersion parameter of the distribution. This is often used for negative binomial distributions and is often represented as k. This is distinct from the dispersion for a lognormal distribution, which is considered a summary statistic.",
                 "examples": [1.2, 1.4],
                 "type": "number"
               },
@@ -142,11 +145,95 @@
                 "description": "The interval of the uncertainty around the precision parameter, for example 95% confidence interval would be 95.",
                 "examples": [95, 90, 80],
                 "type": ["number", "null"]
+              },
+              "mean": {
+                "description": "The mean of the distribution. Only applies to normal and negative binomial distributions (checked by schema below), for other probability distributions the mean should be included in the summary statistics.",
+                "examples": [1.0, 2.5],
+                "type": ["number", "null"]
+              },
+              "mean_ci_limits": {
+                "description": "The confidence interval of the distribution's mean, specified by two numbers in an array.",
+                "examples": [[0.3, 0.8], [1.4, 1.45]],
+                "type": ["array", "null"],
+                "items": {
+                  "type": "number"
+                }
+              },
+              "mean_ci": {
+                "description": "The interval of the uncertainty around the mean, for example 95% confidence interval would be 95.",
+                "examples": [95, 90, 80],
+                "type": ["number", "null"]
+              },
+              "sd": {
+                "description": "The standard deviation of the distribution. Only applies to normal distributions (checked by schema below), for other probability distributions the standard deviation should be included in the summary statistics.",
+                "examples": [1.0, 2.5],
+                "type": ["number", "null"]
+              },
+              "sd_ci_limits": {
+                "description": "The confidence interval of the distribution's standard deviation, specified by two numbers in an array.",
+                "examples": [[0.3, 0.8], [1.4, 1.45]],
+                "type": ["array", "null"],
+                "items": {
+                  "type": "number"
+                }
+              },
+              "sd_ci": {
+                "description": "The interval of the uncertainty around the standard deviation, for example 95% confidence interval would be 95.",
+                "examples": [95, 90, 80],
+                "type": ["number", "null"]
               }
             }
           }
         },
-        "required": ["prob_distribution"]
+        "required": ["prob_distribution"],
+        "if": {
+          "properties": {
+            "prob_distribution": { "const": "norm" }
+          }
+        },
+        "then": {
+          "properties": {
+            "parameters": {
+              "type": "object",
+              "anyOf": [
+                { "required": ["mean"] },
+                { "required": ["sd"] }
+                ]
+            }
+          }
+        },
+        "else": {
+          "if": {
+            "properties": {
+              "prob_distribution": { "const": "nbinom" }
+            }
+          },
+          "then": {
+            "properties": {
+              "parameters": {
+                "type": "object",
+                "anyOf": [
+                  { "required": ["mean"] },
+                  { "required": ["dispersion"] }
+                  ]
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "parameters": {
+                "type": "object",
+                "not": {
+                  "anyOf": [
+                    { "required": ["mean"] },
+                    { "required": ["sd"] },
+                    { "required": ["dispersion"] }
+                    ]
+                }
+              }
+            }
+          }
+        }
       },
       "summary_statistics": {
         "type": "object",

--- a/inst/extdata/parameters.json
+++ b/inst/extdata/parameters.json
@@ -2196,16 +2196,15 @@
   "probability_distribution": {
     "prob_distribution": "nbinom",
     "parameters": {
+      "mean": 1.63,
+      "mean_ci_limits": [0.54, 2.65],
+      "mean_ci": 90,
       "dispersion": 0.16,
       "dispersion_ci_limits": [0.11, 0.64],
       "dispersion_ci": 90
     }
   },
-  "summary_statistics": {
-    "mean": 1.63,
-    "mean_ci_limits": [0.54, 2.65],
-    "mean_ci": 90
-  },
+  "summary_statistics": { },
   "citation": {
     "author": [
       {
@@ -2254,16 +2253,15 @@
   "probability_distribution": {
     "prob_distribution": "nbinom",
     "parameters": {
+      "mean": 0.94,
+      "mean_ci_limits": [0.27, 1.51],
+      "mean_ci": 90,
       "dispersion": 0.17,
       "dispersion_ci_limits": [0.1, 0.64],
       "dispersion_ci": 90
     }
   },
-  "summary_statistics": {
-    "mean": 0.94,
-    "mean_ci_limits": [0.27, 1.51],
-    "mean_ci": 90
-  },
+  "summary_statistics": { },
   "citation": {
     "author": [
       {
@@ -2312,16 +2310,15 @@
   "probability_distribution": {
     "prob_distribution": "nbinom",
     "parameters": {
+      "mean": 3.19,
+      "mean_ci_limits": [1.66, 4.62],
+      "mean_ci": 90,
       "dispersion": 0.37,
       "dispersion_ci_limits": [0.26, 0.69],
       "dispersion_ci": 90
     }
   },
-  "summary_statistics": {
-    "mean": 3.19,
-    "mean_ci_limits": [1.66, 4.62],
-    "mean_ci": 90
-  },
+  "summary_statistics": { },
   "citation": {
     "author": [
       {
@@ -2370,16 +2367,15 @@
   "probability_distribution": {
     "prob_distribution": "nbinom",
     "parameters": {
+      "mean": 0.8,
+      "mean_ci_limits": [0.32, 1.2],
+      "mean_ci": 90,
       "dispersion": 0.32,
       "dispersion_ci_limits": [0.16, 1.76],
       "dispersion_ci": 90
     }
   },
-  "summary_statistics": {
-    "mean": 0.8,
-    "mean_ci_limits": [0.32, 1.2],
-    "mean_ci": 90
-  },
+  "summary_statistics": { },
   "citation": {
     "author": [
       {
@@ -2428,16 +2424,15 @@
   "probability_distribution": {
     "prob_distribution": "nbinom",
     "parameters": {
+      "mean": 1.6,
+      "mean_ci_limits": [0.88, 2.16],
+      "mean_ci": 90,
       "dispersion": 0.65,
       "dispersion_ci_limits": [0.34, 2.32],
       "dispersion_ci": 90
     }
   },
-  "summary_statistics": {
-    "mean": 1.6,
-    "mean_ci_limits": [0.88, 2.16],
-    "mean_ci": 90
-  },
+  "summary_statistics": { },
   "citation": {
     "author": [
       {
@@ -2486,14 +2481,13 @@
   "probability_distribution": {
     "prob_distribution": "nbinom",
     "parameters": {
+      "mean": 1.49,
       "dispersion": 0.72,
       "dispersion_ci_limits": [0.44, 2.05],
       "dispersion_ci": 90
     }
   },
-  "summary_statistics": {
-    "mean": 1.49
-  },
+  "summary_statistics": { },
   "citation": {
     "author": [
       {
@@ -2542,16 +2536,15 @@
   "probability_distribution": {
     "prob_distribution": "nbinom",
     "parameters": {
+      "mean": 0.32,
+      "mean_ci_limits": [0.22, 0.40],
+      "mean_ci": 90,
       "dispersion": 0.58,
       "dispersion_ci_limits": [0.32, 3.57],
       "dispersion_ci": 90
     }
   },
-  "summary_statistics": {
-    "mean": 0.32,
-    "mean_ci_limits": [0.22, 0.40],
-    "mean_ci": 90
-  },
+  "summary_statistics": { },
   "citation": {
     "author": [
       {
@@ -2600,16 +2593,15 @@
   "probability_distribution": {
     "prob_distribution": "nbinom",
     "parameters": {
+      "mean": 1.32,
+      "mean_ci_limits": [1.01, 1.61],
+      "mean_ci": 90,
       "dispersion": 1.37,
       "dispersion_ci_limits": [0.88, 3.53],
       "dispersion_ci": 90
     }
   },
-  "summary_statistics": {
-    "mean": 1.32,
-    "mean_ci_limits": [1.01, 1.61],
-    "mean_ci": 90
-  },
+  "summary_statistics": { },
   "citation": {
     "author": [
       {
@@ -2658,14 +2650,13 @@
   "probability_distribution": {
     "prob_distribution": "nbinom",
     "parameters": {
+      "mean": 0.7,
+      "mean_ci_limits": [0.20, 1.05],
+      "mean_ci": 90,
       "dispersion": 1.66
     }
   },
-  "summary_statistics": {
-    "mean": 0.7,
-    "mean_ci_limits": [0.20, 1.05],
-    "mean_ci": 90
-  },
+  "summary_statistics": { },
   "citation": {
     "author": [
       {
@@ -2714,14 +2705,13 @@
   "probability_distribution": {
     "prob_distribution": "nbinom",
     "parameters": {
+      "mean": 1.5,
+      "mean_ci_limits": [0.85, 2.08],
+      "mean_ci": 90,
       "dispersion": 5.10
     }
   },
-  "summary_statistics": {
-    "mean": 1.5,
-    "mean_ci_limits": [0.85, 2.08],
-    "mean_ci": 90
-  },
+  "summary_statistics": { },
   "citation": {
     "author": [
       {


### PR DESCRIPTION
This PR moves the mean and any uncertainty around the mean from the summary statistics object to the parameters object in the JSON database (`parameters.json`). This is to consolidate what is considered a parameter or summary statistic in the package (matching `is_epiparameter_params()`), see also #379.

The JSON schema is updated to explicitly check if the mean, standard deviation and dispersion are being specified correctly depending on the probability distribution. For normal and negative binomial distributions, these should be specified as parameters, whereas for other distributions, e.g. lognormal, they should be specified as summary statistics.