### PR TITLE
Fix `as_parameter()` test 

### DIFF
--- a/tests/testthat/test-coercion.R
+++ b/tests/testthat/test-coercion.R
@@ -66,7 +66,7 @@ test_that("as_epiparameter works for ebola serial interval (issue #303)", {
   ebola_serial <- ebola_params[
     which(ebola_params$parameter_type == "Human delay - serial interval" &
             ebola_params$distribution_type == "Gamma" &
-            ebola_params$article_label == "Chan 2020 (1)"),
+            ebola_params$article_label == "Chan 2020"),
   ]
   # suppress warning and message about citation
   ebola_serial_epiparameter <- suppressWarnings(


### PR DESCRIPTION
This PR fixes a unit test that was breaking due to the `$article_label` of the entry being subset in the test changing in a recent version update of the {epireview} R package. This update likely traces to mrc-ide/epireview#86 and mrc-ide/epireview#113.