### PR TITLE
Fix `is_continuous()` for unparameterised `<epiparameter>` objects

### DIFF
--- a/R/epiparameter.R
+++ b/R/epiparameter.R
@@ -889,7 +889,8 @@ is_continuous <- function(x) {
       is_epiparameter(x)
   )
   # get individual distributions out of mixture to check if continuous
-  if (family(x) == "mixture") {
+  # isTRUE to control for family returning NA for unparameterised
+  if (isTRUE(family(x) == "mixture")) {
     fam <- .get_mixture_family(x)
   } else {
     fam <- family(x)


### PR DESCRIPTION
This PR fixes an issue with `is_continuous()` when supplied with an unparameterised `<epiparameter>` object, by adding an `isTRUE()` to an `if` statement in the function. This stops the functions failing with an uninformative error message due to the conditional in the `if` statement containing an `NA` from `family.epiparameter()`. 

This also prevents the `plot.epiparameter()` method erroring with the same uninformative error when the `<epiparameter>` object is unparameterised.