### PR TITLE
Refactor `test_epiparameter()` & `assert_epiparameter()`

### DIFF
--- a/man/test_epiparameter.Rd
+++ b/man/test_epiparameter.Rd
@@ -11,7 +11,7 @@ test_epiparameter(x)
 }
 \value{
 A boolean \code{logical} whether the object is a valid \verb{<epiparameter>}
-object.
+object (prints message when invalid \verb{<epiparameter>} object is provided).
 }
 \description{
 Test whether an object is a valid \verb{<epiparameter>} object

--- a/tests/testthat/test-epiparameter.R
+++ b/tests/testthat/test-epiparameter.R
@@ -1,3 +1,7 @@
+suppressMessages({
+  ep <- epiparameter_db(single_epiparameter = TRUE)
+})
+
 test_that("epiparameter works with minimal viable input", {
   # message about missing citation suppressed
   ebola_dist <- suppressMessages(epiparameter(
@@ -299,176 +303,50 @@ test_that("new_epiparameter works with minimal viable input", {
   expect_s3_class(assert_epiparameter(epiparameter_obj), class = "epiparameter")
 })
 
-test_that("assert_epiparameter passes when expected", {
-  epiparameter_obj <- suppressMessages(
-    new_epiparameter(
-      disease = "ebola",
-      pathogen = "ebola_virus",
-      epi_name = "incubation",
-      prob_distribution = create_prob_distribution(
-        prob_distribution = "gamma",
-        prob_distributions_params = c(shape = 1, scale = 1),
-        discretise = FALSE,
-        truncation = NA
-      ),
-      uncertainty = list(
-        shape = create_uncertainty(
-          ci_limits = c(0, 2),
-          ci = 95,
-          ci_type = "confidence interval"
-        ),
-        scale = create_uncertainty(
-          ci_limits = c(0, 2),
-          ci = 95,
-          ci_type = "confidence interval"
-        )
-      ),
-      citation = create_citation(
-        author = person(given = "John", family = "Smith"),
-        year = 2000,
-        title = "Ebola incubation",
-        journal = "Journal of Epi",
-        doi = "10.1872372hc"
-      ),
-      notes = "No notes",
-      auto_calc_params = FALSE
-    )
-  )
-
-  expect_silent(assert_epiparameter(epiparameter_obj))
+test_that("assert_epiparameter & test_epiparameter passes when expected", {
+  expect_silent(assert_epiparameter(ep))
+  expect_invisible(assert_epiparameter(ep))
+  expect_silent(test_epiparameter(ep))
+  expect_true(test_epiparameter(ep))
 })
 
-test_that("assert_epiparameter catches class faults when expected", {
-  epiparameter_obj <- new_epiparameter(
-    disease = "ebola",
-    pathogen = "ebola_virus",
-    epi_name = "incubation",
-    prob_distribution = create_prob_distribution(
-      prob_distribution = "gamma",
-      prob_dist_params = c(shape = 1, scale = 1),
-      discretise = FALSE,
-      truncation = NA
-    ),
-    uncertainty = list(
-      shape = create_uncertainty(
-        ci_limits = c(0, 2),
-        ci = 95,
-        ci_type = "confidence interval"
-      ),
-      scale = create_uncertainty(
-        ci_limits = c(0, 2),
-        ci = 95,
-        ci_type = "confidence interval"
-      )
-    ),
-    citation = "Smith (2002) <10.128372837>",
-    auto_calc_params = FALSE
-  )
-
-  epiparameter_obj$disease <- NULL
-
+test_that("assert_epiparameter & test_epiparameter fails when expected", {
+  ep_ <- ep
+  ep_$disease <- NULL
   expect_error(
-    assert_epiparameter(epiparameter_obj),
-    regexp = "(<epiparameter> must contain $disease)*($citation)*(<bibentry>)"
-  )
-
-  epiparameter_obj <- new_epiparameter(
-    disease = "ebola",
-    pathogen = "ebola_virus",
-    epi_name = "incubation",
-    prob_distribution = create_prob_distribution(
-      prob_distribution =  "gamma",
-      prob_dist_params = c(shape = 1, scale = 1),
-      discretise = FALSE,
-      truncation = NA
-    ),
-    uncertainty = list(
-      shape = create_uncertainty(
-        ci_limits = c(0, 2),
-        ci = 95,
-        ci_type = "confidence interval"
-      ),
-      scale = create_uncertainty(
-        ci_limits = c(0, 2),
-        ci = 95,
-        ci_type = "confidence interval"
-      )
-    ),
-    citation = "Smith (2002) <10.128372837>",
-    auto_calc_params = FALSE
-  )
-
-  epiparameter_obj$disease <- factor("disease")
-
-  expect_error(
-    assert_epiparameter(epiparameter_obj),
+    assert_epiparameter(ep_),
     regexp = "(<epiparameter> must contain one disease)"
   )
+  expect_false(suppressMessages(test_epiparameter(ep_)))
 
-  epiparameter_obj <- new_epiparameter(
-    disease = "ebola",
-    pathogen = "ebola_virus",
-    epi_name = "incubation",
-    prob_distribution = create_prob_distribution(
-      prob_distribution = "gamma",
-      prob_dist_params = c(shape = 1, scale = 1),
-      discretise = FALSE,
-      truncation = NA
-    ),
-    uncertainty = list(
-      shape = create_uncertainty(
-        ci_limits = c(0, 2),
-        ci = 95,
-        ci_type = "confidence interval"
-      ),
-      scale = create_uncertainty(
-        ci_limits = c(0, 2),
-        ci = 95,
-        ci_type = "confidence interval"
-      )
-    ),
-    citation = "Smith (2002) <10.128372837>",
-    auto_calc_params = FALSE
-  )
-
-  epiparameter_obj$epi_name <- c("incubation", "period")
-
+  ep_$disease <- factor("disease")
   expect_error(
-    assert_epiparameter(epiparameter_obj),
+    assert_epiparameter(ep_),
+    regexp = "(<epiparameter> must contain one disease)"
+  )
+  expect_false(suppressMessages(test_epiparameter(ep_)))
+
+  ep_ <- ep
+  ep_$epi_name <- c("incubation", "period")
+  expect_error(
+    assert_epiparameter(ep_),
     regexp = "(<epiparameter> must contain one epidemiological parameter)"
   )
-})
+  expect_false(suppressMessages(test_epiparameter(ep_)))
 
-test_that("assert_epiparameter fails as expected with input class", {
+  ep_ <- ep
+  ep_$citation <- "reference"
+  expect_error(
+    assert_epiparameter(ep_),
+    regexp = "(<epiparameter> \\$citation must be a <bibentry>)"
+  )
+  expect_false(suppressMessages(test_epiparameter(ep_)))
+
   expect_error(
     assert_epiparameter(1),
     regexp = "(Object should be of class <epiparameter>)"
   )
-})
-
-test_that("test_epiparameter returns TRUE as expected", {
-  suppressMessages(
-    ep <- epiparameter_db(single_epiparameter = TRUE)
-  )
-  expect_true(test_epiparameter(ep))
-})
-
-test_that("test_epiparameter returns FALSE as expected", {
-  suppressMessages({
-    expect_false(test_epiparameter(1))
-    suppressMessages(
-      ep <- epiparameter_db(single_epiparameter = TRUE)
-    )
-    ep1 <- ep
-    ep1$disease <- NULL
-    expect_false(test_epiparameter(ep1))
-    ep2 <- ep
-    ep2$disease <- 1
-    expect_false(test_epiparameter(ep2))
-    ep3 <- ep
-    ep3$citation <- "reference"
-    expect_false(test_epiparameter(ep3))
-  })
+  expect_false(suppressMessages(test_epiparameter(1)))
 })
 
 test_that("density works as expected on continuous epiparameter object", {

--- a/tests/testthat/test-epiparameter.R
+++ b/tests/testthat/test-epiparameter.R
@@ -149,9 +149,7 @@ test_that("epiparameter fails as expected", {
         prob_distribution = 1
       )
     ),
-    regexp = paste0(
-      "epiparameter must contain a <distribution> or <distcrete> or NA"
-    )
+    regexp = "(<epiparameter> $prob_distribution must contain)*(<distribution>)"
   )
 
   expect_error(
@@ -371,7 +369,7 @@ test_that("assert_epiparameter catches class faults when expected", {
 
   expect_error(
     assert_epiparameter(epiparameter_obj),
-    regexp = "Object is missing disease"
+    regexp = "(<epiparameter> must contain $disease)*($citation)*(<bibentry>)"
   )
 
   epiparameter_obj <- new_epiparameter(
@@ -404,7 +402,7 @@ test_that("assert_epiparameter catches class faults when expected", {
 
   expect_error(
     assert_epiparameter(epiparameter_obj),
-    regexp = "(epiparameter must contain a disease)"
+    regexp = "(<epiparameter> must contain one disease)"
   )
 
   epiparameter_obj <- new_epiparameter(
@@ -437,14 +435,14 @@ test_that("assert_epiparameter catches class faults when expected", {
 
   expect_error(
     assert_epiparameter(epiparameter_obj),
-    regexp = "epiparameter must contain an epidemiological distribution"
+    regexp = "(<epiparameter> must contain one epidemiological parameter)"
   )
 })
 
 test_that("assert_epiparameter fails as expected with input class", {
   expect_error(
     assert_epiparameter(1),
-    regexp = "Object should be of class epiparameter"
+    regexp = "(Object should be of class <epiparameter>)"
   )
 })
 
@@ -456,19 +454,21 @@ test_that("test_epiparameter returns TRUE as expected", {
 })
 
 test_that("test_epiparameter returns FALSE as expected", {
-  expect_false(test_epiparameter(1))
-  suppressMessages(
-    ep <- epiparameter_db(single_epiparameter = TRUE)
-  )
-  ep1 <- ep
-  ep1$disease <- NULL
-  expect_false(test_epiparameter(ep1))
-  ep2 <- ep
-  ep2$disease <- 1
-  expect_false(test_epiparameter(ep2))
-  ep3 <- ep
-  ep3$citation <- "reference"
-  expect_false(test_epiparameter(ep3))
+  suppressMessages({
+    expect_false(test_epiparameter(1))
+    suppressMessages(
+      ep <- epiparameter_db(single_epiparameter = TRUE)
+    )
+    ep1 <- ep
+    ep1$disease <- NULL
+    expect_false(test_epiparameter(ep1))
+    ep2 <- ep
+    ep2$disease <- 1
+    expect_false(test_epiparameter(ep2))
+    ep3 <- ep
+    ep3$citation <- "reference"
+    expect_false(test_epiparameter(ep3))
+  })
 })
 
 test_that("density works as expected on continuous epiparameter object", {


### PR DESCRIPTION
This PR refactors the `test_epiparameter()` and `assert_epiparameter()` functions by pulling out the body of each function and merging in a new `.validate_epiparameter()` function, which is called by each of the exported functions.

If `.validate_epiparameter()` finds invalid components of `<epiparameter>` objects it surfaces messages which `test_epiparameter()` and `assert_epiparameter()` use to message or error with, respectively.

The unit tests of `test_epiparameter()` and `assert_epiparameter()` have also been simplified. 

Unifying the bodies of `test_epiparameter()` and `assert_epiparameter()` was suggested in #394.