### PR TITLE
Decrease R mininum version to 4.0.0

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -59,6 +59,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: '3.6'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -59,7 +59,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: '3.6'}
+          - {os: ubuntu-latest,   r: '4.0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ URL: https://github.com/epiverse-trace/epiparameter/,
     https://epiverse-trace.github.io/epiparameter/
 BugReports: https://github.com/epiverse-trace/epiparameter/issues
 Depends: 
-    R (>= 4.1.0)
+    R (>= 3.6.0)
 Imports:
     checkmate,
     cli,
@@ -43,6 +43,7 @@ Suggests:
     ggplot2,
     jsonlite,
     knitr,
+    magrittr,
     RColorBrewer,
     rmarkdown,
     spelling,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ URL: https://github.com/epiverse-trace/epiparameter/,
     https://epiverse-trace.github.io/epiparameter/
 BugReports: https://github.com/epiverse-trace/epiparameter/issues
 Depends: 
-    R (>= 3.6.0)
+    R (>= 4.0.0)
 Imports:
     checkmate,
     cli,

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,10 @@ The are a large number of ***breaking changes*** in this release, primarily func
 * The `<vb_epidist>` class and it's methods have been removed from the package. It was not being used and was increasing the complexity and maintenance load of the package (PR #359).
 * `create_prob_dist()` has been renamed to `create_prob_distribution()` (PR #381).
 * `validate_epiparameter()` (previously `validate_epidist()`) has been renamed `assert_epiparameter()`, and `test_epiparameter()` has been added, with the aim to harmonise design with [{contactmatrix}](https://github.com/socialcontactdata/contactmatrix) (PR #366).
-* The minimum version of R required by the package is now 4.1.0 due to the use of the base R pipe (`|>`) in dependencies (PR #384).
+
+## Minor changes
+
+* The minimum version of R required by the package (3.6.0) is now explicitly tested on the R-CMD-check GitHub actions workflow (PR #404).
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,7 +29,7 @@ The are a large number of ***breaking changes*** in this release, primarily func
 
 ## Minor changes
 
-* The minimum version of R required by the package (3.6.0) is now explicitly tested on the R-CMD-check GitHub actions workflow (PR #404).
+* The minimum version of R required by the package is now 4.0.0 and is now explicitly tested on the R-CMD-check GitHub actions workflow (PR #384 & #404).
 
 ## Bug fixes
 

--- a/vignettes/design_principles.Rmd
+++ b/vignettes/design_principles.Rmd
@@ -117,18 +117,18 @@ if (!all(epiparameter_class_methods %in% groups$functions)) {
 }
 
 library(visNetwork)
-visNetwork(nodes, edges) |>
-  visNodes(font = list(size = 18)) |>
-  visGroups(groupname = "<epiparameter>", color = colours[1]) |>
-  visGroups(groupname = "Getters", color = colours[2]) |>
-  visGroups(groupname = "Modifiers", color = colours[3]) |>
+visNetwork(nodes, edges) %>%
+  visNodes(font = list(size = 18)) %>%
+  visGroups(groupname = "<epiparameter>", color = colours[1]) %>%
+  visGroups(groupname = "Getters", color = colours[2]) %>%
+  visGroups(groupname = "Modifiers", color = colours[3]) %>%
   visGroups(
     groupname = "Distribution functions",
     color = colours[4]
-  ) |>
-  visGroups(groupname = "Utilities", color = colours[5]) |>
-  visGroups(groupname = "Checkers", color = colours[6]) |>
-  visGroups(groupname = "Conversions", color = colours[7]) |>
+  ) %>%
+  visGroups(groupname = "Utilities", color = colours[5]) %>%
+  visGroups(groupname = "Checkers", color = colours[6]) %>%
+  visGroups(groupname = "Conversions", color = colours[7]) %>%
   visGroups(groupname = "Coercion", color = colours[8])
 ```
 
@@ -165,8 +165,6 @@ The aim is to restrict the number of dependencies to a minimal required set for 
 {stats} and {utils} are distributed with the R language so are viewed as a lightweight dependencies, that should already be installed on a user's machine if they have R. {checkmate} is an input checking package widely used across Epiverse-TRACE packages. {distributional} and {distcrete} are used to import S3 classes for handling and working with distributions. Both are required as only {distcrete} can handle discretised distributions.
 
 [{jsonlite}](https://CRAN.R-project.org/package=jsonlite) is a suggested dependency because it is used to read the parameter library which is stored as a JSON file. However, it is only read by an internal function and instead the data is available to the user via `sysdata.rda`, so {jsonlite} is not required as an imported dependency.
-
-Currently {epiparameter} deviates from the [Epiverse policy on the number of previous R versions it supports](https://epiverse-trace.github.io/blueprints/dependencies.html#base-r-support-schedule). The {epiparameter} package requires R version >= 4.1.0 which only includes the current version and the last three minor R versions rather than the policy of four minor versions, as of September 2024. The reasons for this change is to enable usage of the base R pipe (`|>`).
 
 ## Contribute
 


### PR DESCRIPTION
This PR changes the minimum R version required by {epiparameter} to 4.0.0, after it was incremented to 4.1.0 in PR #384 (due to mitchelloharawild/distributional#128). 

This PR also adds a R-CMD-check CI run for R 4.0 to check that the R package passes the check on the version stated in the `DESCRIPTION`. 

This PR initially checked to see if the minimum R version could be reverted to 3.6.0 as it was before #384, however, due to {epireview} depending on {flextable} which in turn depends on {gdtools} which requires R 4.0, then this is required for the R-CMD-check workflow to install {epireview}.

Usage of the base pipe (`|>`) has been replaced in a vignette by the pipe from {magrittr} (`%>%`), with {magrittr} added as a suggested dependency. 

The note in the `design_principles.Rmd` vignette on breaking the Epiverse R version policy has been removed as this will not longer be the case.