### PR TITLE
Add R-CMD-check workflow for R 4.1

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -59,7 +59,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: '4.0'}
+          - {os: ubuntu-latest,   r: '4.1'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -59,6 +59,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: '4.0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -1,8 +1,13 @@
+# tests are skipped when R version < 4.2.0 due to a change in base tools::Rd2txt()
+# https://github.com/r-devel/r-svn/commit/aaabe42cc32582db77ba275233def72b11e32e45
+
 test_that("epiparameter_db print method works as expected for > 5 <epiparameter>", {
+  skip_if(getRversion() < "4.2.0")
   expect_snapshot(epiparameter_db())
 })
 
 test_that("epiparameter_db print method works as expected for <= 5 <epiparameter>", {
+  skip_if(getRversion() < "4.2.0")
   expect_snapshot(
     epiparameter_db(disease = "SARS", epi_name = "offspring distribution")
   )


### PR DESCRIPTION
This PR also adds a R-CMD-check CI run for R 4.1 to check that the R package passes the check on the version stated in the `DESCRIPTION`.

