### PR TITLE
Abort CRAN release for v0.3.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,6 @@ The third minor release of the {epiparameter} R package contains a range of upda
 
 The are a large number of ***breaking changes*** in this release, primarily functions and function arguments being renamed or restructured, see the _Breaking changes_ section for an overview.
 
-This is the first version of {epiparameter} to be released on CRAN.
-
 ## New features
 
 * The library of epidemiological parameters has been updated to include 3 new Chikungunya parameter entries. The Mpox parameters previously missing from the Guzzetta et al. entry have been added (#346 & #374).

--- a/README.Rmd
+++ b/README.Rmd
@@ -31,12 +31,6 @@ knitr::opts_chunk$set(
 
 ## Installation
 
-The package can be installed from CRAN using:
-
-``` r
-install.packages("epiparameter")
-```
-
 The development version of `{epiparameter}` can be installed from [GitHub](https://github.com/epiverse-trace/epiparameter) using the `{pak}` package:
 
 ``` r

--- a/README.md
+++ b/README.md
@@ -29,12 +29,6 @@ Medicine](https://www.lshtm.ac.uk/) as part of
 
 ## Installation
 
-The package can be installed from CRAN using:
-
-``` r
-install.packages("epiparameter")
-```
-
 The development version of `{epiparameter}` can be installed from
 [GitHub](https://github.com/epiverse-trace/epiparameter) using the
 `{pak}` package:

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,0 @@
-## R CMD check results
-
-0 errors | 0 warnings | 1 note
-
-* This is a new release.


### PR DESCRIPTION
{epiparameter} v0.3.0 was submitted to CRAN but was rejected due to its licensing:

> A package can only be licensed as a whole. It can have a single license or a set of *alternative* licenes. If the data have to be licensed differently then the code, you have to provide the data in a separate data package with the other license.

Therefore, the v0.3.0 release is going ahead on GitHub, and the package code and data will be split. The {epiparameter} database will be in the [{epiparameterDB} R package (a data package)](https://github.com/epiverse-trace/epiparameterDB). The data will then be removed from {epiparameter} and the package will be relicensed solely under MIT to remove the blocker to CRAN. 

This PR removes the CRAN installation instructions from the `README` and the CRAN release from the `NEWS.md` file, as well as removing `cran-comments.md`. 