### PR TITLE
Cache DB on package loading

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ BugReports: https://github.com/epiverse-trace/epiparameter/issues
 Depends: 
     R (>= 4.1.0)
 Imports:
+    cachem,
     checkmate,
     cli,
     distcrete,

--- a/R/epiparameter_db.R
+++ b/R/epiparameter_db.R
@@ -129,7 +129,13 @@ epiparameter_db <- function(disease = "all",
     )
   }
 
-  multi_epiparameter <- .read_epiparameter_db()
+  cache_db <- cache_env$cache$get("multi_epiparameter")
+  if (inherits(cache_db, "multi_epiparameter")) {
+    multi_epiparameter <- cache_env$cache$get("multi_epiparameter")
+  } else {
+    multi_epiparameter <- .read_epiparameter_db()
+  }
+
   attrib <- attributes(multi_epiparameter)
 
   multi_epiparameter <- .filter_epiparameter_db(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,15 @@
+# package environment for storing global objects for caching
+cache_env <- new.env(parent = emptyenv())
+
 .onLoad <- function(libname, pkgname) {
   options(epiparameter = epiparameter_options) # nolint undersirable_function_linter
+
+  # create an in-memory cache
+  cache_env$cache <- cachem::cache_mem()
+
+  # suppress DB loading message on package loading
+  db <- suppressMessages(epiparameter_db())
+
+  # store epiparameter library in cache
+  cache_env$cache$set("multi_epiparameter", db)
 }


### PR DESCRIPTION
This PR adds data caching to the {epiparameter} package for library of epidemiological parameters (using {cachem}). 

Since #415 the epiparameter database was being created (i.e. parameters calculated and `<epiparameter>` objects created) each time `epiparameter_db()` was called. This resurfaced a previous issue (#198) that was resolved in PR #207 by using `sysdata`. However, since PR #415 `sysdata` was removed and instead the JSON library was loaded from {epiparameterDB}. 

NB: {epiparameter} cannot hold the library of parameters as it requires it's own data license and due to CRAN rules this requires being housed in its own package.

To resolve this issue with a new approach, this PR implements data caching of the database of parameters when the {epiparameter} package is loaded (using `.onLoad()`). This should reduce the runtime of `epiparameter_db()`, especially if called repeatedly. 

_Note_: data caching is not implement in `epidist_db()` as it is deprecated and will be removed after the next version release.