### PR TITLE
Remove `on.exit()` from `plot.epiparameter()`

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -10,8 +10,7 @@ linters: all_linters(
         default_undesirable_functions,
         citEntry = "use the more modern bibentry() function",
         library = NULL, # too many false positive in too many files
-        structure = NULL, # used for class constructor functions
-        par = NULL # used with on.exit() and {withrs} is not a dependency
+        structure = NULL # used for class constructor functions
       )
     ),
     function_argument_linter = NULL,

--- a/R/plot.R
+++ b/R/plot.R
@@ -52,9 +52,6 @@ plot.epiparameter <- function(x,
   # capture dots
   dots <- list(...)
 
-  oldpar <- graphics::par(no.readonly = TRUE)
-  on.exit(graphics::par(oldpar))
-
   if (is_continuous(x)) {
     main <- "Probability Density Function"
   } else {

--- a/tests/testthat/_snaps/epiparameter/epiparameter-plot-non-default-range.svg
+++ b/tests/testthat/_snaps/epiparameter/epiparameter-plot-non-default-range.svg
@@ -56,6 +56,4 @@
 <text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='178.50px' lengthAdjust='spacingAndGlyphs'>Probability Density Function</text>
 <text x='374.40' y='557.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='55.38px' lengthAdjust='spacingAndGlyphs'>Incubation</text>
 </g>
-<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
-</g>
 </svg>

--- a/tests/testthat/_snaps/epiparameter/epiparameter-plot-units.svg
+++ b/tests/testthat/_snaps/epiparameter/epiparameter-plot-units.svg
@@ -56,6 +56,4 @@
 <text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='178.50px' lengthAdjust='spacingAndGlyphs'>Probability Density Function</text>
 <text x='374.40' y='557.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='94.06px' lengthAdjust='spacingAndGlyphs'>Incubation (Days)</text>
 </g>
-<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
-</g>
 </svg>

--- a/tests/testthat/_snaps/epiparameter/epiparameter-plot.svg
+++ b/tests/testthat/_snaps/epiparameter/epiparameter-plot.svg
@@ -56,6 +56,4 @@
 <text x='374.40' y='34.48' text-anchor='middle' style='font-size: 14.40px; font-weight: bold; font-family: sans;' textLength='178.50px' lengthAdjust='spacingAndGlyphs'>Probability Density Function</text>
 <text x='374.40' y='557.28' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='55.38px' lengthAdjust='spacingAndGlyphs'>Incubation</text>
 </g>
-<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
-</g>
 </svg>

--- a/tests/testthat/test-epiparameter.R
+++ b/tests/testthat/test-epiparameter.R
@@ -174,6 +174,8 @@ test_that("epiparameter fails as expected", {
 })
 
 test_that("epiparameter.plot does not produce an error", {
+  # plotting changes global state of graphics pars so they are restored
+  op <- par(no.readonly = TRUE)
   ebola_dist <- suppressMessages(epiparameter(
     disease = "ebola",
     epi_name = "incubation",
@@ -182,18 +184,19 @@ test_that("epiparameter.plot does not produce an error", {
       prob_distribution_params = c(shape = 1, scale = 1)
     )
   ))
-
-
   expect_silent(plot(ebola_dist))
-
   f <- function() plot(ebola_dist)
   vdiffr::expect_doppelganger(
     title = "epiparameter.plot",
     fig = f
   )
+  # restore graphics pars
+  par(op)
 })
 
 test_that("epiparameter.plot prints units in x-axis", {
+  # plotting changes global state of graphics pars so they are restored
+  op <- par(no.readonly = TRUE)
   ebola_dist <- suppressMessages(epiparameter(
     disease = "ebola",
     epi_name = "incubation",
@@ -203,18 +206,19 @@ test_that("epiparameter.plot prints units in x-axis", {
     ),
     metadata = create_metadata(units = "days")
   ))
-
-
   expect_silent(plot(ebola_dist))
-
   f <- function() plot(ebola_dist)
   vdiffr::expect_doppelganger(
     title = "epiparameter.plot units",
     fig = f
   )
+  # restore graphics pars
+  par(op)
 })
 
 test_that("epiparameter.plot works with non-default x-axis", {
+  # plotting changes global state of graphics pars so they are restored
+  op <- par(no.readonly = TRUE)
   ebola_dist <- suppressMessages(epiparameter(
     disease = "ebola",
     epi_name = "incubation",
@@ -223,14 +227,12 @@ test_that("epiparameter.plot works with non-default x-axis", {
       prob_distribution_params = c(shape = 1, scale = 1)
     )
   ))
-
   expect_silent(
     plot(
       ebola_dist,
       xlim = c(0, 20)
     )
   )
-
   f <- function() {
     plot(
       ebola_dist,
@@ -241,6 +243,8 @@ test_that("epiparameter.plot works with non-default x-axis", {
     title = "epiparameter.plot non-default range",
     fig = f
   )
+  # restore graphics pars
+  par(op)
 })
 
 test_that("new_epiparameter works with minimal viable input", {


### PR DESCRIPTION
This PR addresses #409 by removing the call to `on.exit()` in `plot.epiparameter()` as the function no longer modifies graphics parameters in the body of the function. This now allows users to plot a matrix of plots using globally set graphics parameters which was being blocked by the use of `on.exit()` before. 

To suppress warnings from `set_state_inspector()` I've manually restored the graphics parameters in unit tests that call `plot()` as calling this function modifies some of the parameters. 

Plots snapshots are also updated (although the visuals of the plots are unchanged). 

`par()` is no longer called in any functions so the lintr for `par()` is turned back on in the `.lintr` file.