### PR TITLE
Fix `is_continuous()` bug for normal distributions

### DIFF
--- a/R/epiparameter.R
+++ b/R/epiparameter.R
@@ -812,7 +812,7 @@ is_continuous <- function(x) {
     fam <- family(x)
   }
 
-  all(fam %in% c("gamma", "lnorm", "weibull", "normal")) &&
+  all(fam %in% c("gamma", "lnorm", "weibull", "norm")) &&
     !inherits(x$prob_distribution, "distcrete")
 }
 


### PR DESCRIPTION
The PR addresses #421 by correcting a typo in the character string matching in `is_continuous()`. This bug was leading to `is_continuous()` incorrectly returning `FALSE` for normal distributions in `<epiparameter>` objects. This impacted the `<epiparameter>` plot method, see reprex in #421. 

This PR resolves the issue: 

``` r
library(epiparameter)
db <- epiparameter_db()
#> Returning 125 results that match the criteria (100 are parameterised). 
#> Use subset to filter by entry variables or single_epiparameter to return a single entry. 
#> To retrieve the citation for each use the 'get_citation' function
fam <- sapply(db, family)
norm_idx <- which(fam == "norm")
norm_ep <- db[norm_idx][[1]]
norm_ep
#> Disease: COVID-19
#> Pathogen: SARS-CoV-2
#> Epi Parameter: serial interval
#> Study: Yang L, Dai J, Zhao J, Wang Y, Deng P, Wang J (2020). "Estimation of
#> incubation period and serial interval of COVID-19: analysis of 178
#> cases and 131 transmission chains in Hubei province, China."
#> _Epidemiology and Infection_. doi:10.1017/S0950268820001338
#> <https://doi.org/10.1017/S0950268820001338>.
#> Distribution: norm (days)
#> Parameters:
#>   mean: 4.600
#>   sd: 4.400
norm_ep$prob_distribution
#> <distribution[1]>
#> [1] N(4.6, 19)
is_continuous(norm_ep)
#> [1] TRUE
plot(norm_ep)
```

![](https://i.imgur.com/2hOd97t.png)<!-- -->

<sup>Created on 2024-11-27 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>