### PR TITLE
Revert to using `$article_label` for {epireview} data

### DIFF
--- a/tests/testthat/test-coercion.R
+++ b/tests/testthat/test-coercion.R
@@ -39,8 +39,7 @@ test_that("as_epiparameter works for lassa incubation period (issue #306)", {
   skip_if_not_installed("epireview")
   lassa_params <- lassa_data$params
   lassa_incub <- lassa_params[
-    # TODO: temp use id until epireview #122 is fixed
-    which(lassa_params$id == "62332f18a631d2cdaafc5c5a500caea5" &
+    which(lassa_params$article_label == "Akhmetzhanov 2019" &
             lassa_params$parameter_type == "Human delay - incubation period"),
   ]
   # suppress warning and message about citation
@@ -115,8 +114,7 @@ test_that("as_epiparameter works for lassa incubation overwritten prob_dist", {
   skip_if_not_installed("epireview")
   lassa_params <- lassa_data$params
   lassa_incub <- lassa_params[
-    # TODO: temp use id until epireview #122 is fixed
-    which(lassa_params$id == "62332f18a631d2cdaafc5c5a500caea5" &
+    which(lassa_params$article_label == "Akhmetzhanov 2019" &
             lassa_params$parameter_type == "Human delay - incubation period"),
   ]
   # suppress warning and message about citation


### PR DESCRIPTION
This PR reverts to using `$article_label` to specify a column in the Lassa epidemiological parameters table from the {epireview} package in the `as_epiparameter()` unit tests.

This was changed in PR #370 due to changes in {epireview} which were raised as an issue in mrc-ide/epireview#122. This has now been resolved in the v1.4.3 release of {epireview}.