### PR TITLE
Add {tools} to Imports in `DESCRIPTION`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,7 @@ Imports:
     pillar,
     rlang,
     stats,
+    tools,
     utils
 Suggests: 
     bookdown,


### PR DESCRIPTION
Functions from the {tools} R package, part of R's base libraries, are used in {epiparameter}, however it wasn't explicitly listed as an imported dependency. To ensure there are no issues when calling these functions with a minimal R installation and to be consistent with explicitly importing other base libraries ({stats}, {utils}) this PR adds it to the `DESCRIPTION` file.