### PR TITLE
Add offset to `<epiparameter>`, class methods and helper functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,8 @@ Suggests:
     testthat (>= 3.0.0),
     vdiffr (>= 1.0.7),
     visNetwork
+Remotes:
+    epiverse-trace/epiparameterDB@offset
 VignetteBuilder: 
     knitr
 Config/Needs/check: mrc-ide/epireview

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     cli,
     distcrete,
     distributional,
-    epiparameterDB,
+    epiparameterDB (>= 0.1.0.9000),
     graphics,
     lifecycle,
     pillar,
@@ -57,7 +57,7 @@ Suggests:
     vdiffr (>= 1.0.7),
     visNetwork
 Remotes:
-    epiverse-trace/epiparameterDB@offset
+    epiverse-trace/epiparameterDB
 VignetteBuilder: 
     knitr
 Config/Needs/check: mrc-ide/epireview

--- a/R/create_prob_distribution.R
+++ b/R/create_prob_distribution.R
@@ -33,6 +33,9 @@
 #' distribution.
 #' @param truncation A `numeric` specifying the truncation point if the inferred
 #' distribution was truncated, `NA` if not or unknown.
+#' @param offset A `numeric` specifying the shift of a probability distribution
+#' left or right on the x-axis (i.e. decreasing or increasing all values by a
+#' constant).
 #' @param ... [dots] Extra arguments to be passed to
 #' \pkg{distributional} or \pkg{distcrete} functions that construct the S3
 #' distribution objects. To see which arguments can be adjusted for discretised
@@ -78,10 +81,17 @@
 #'   truncation = NA,
 #'   w = 0.5
 #' )
+#' # example using an offset
+#' create_prob_distribution(
+#'   prob_distribution = "gamma",
+#'   prob_distribution_params = c(shape = 1, scale = 1),
+#'   offset = 5
+#' )
 create_prob_distribution <- function(prob_distribution,
                                      prob_distribution_params,
                                      discretise = FALSE,
                                      truncation = NA,
+                                     offset = 0,
                                      ...) {
   checkmate::assert_character(
     prob_distribution,
@@ -102,6 +112,7 @@ create_prob_distribution <- function(prob_distribution,
   )
   checkmate::assert_logical(discretise, len = 1)
   checkmate::assert_number(truncation, na.ok = TRUE)
+  checkmate::assert_number(offset)
 
   # set prob_distribution to lowercase for downstream case sensitive matching
   prob_distribution <- .clean_string(prob_distribution)
@@ -193,6 +204,8 @@ create_prob_distribution <- function(prob_distribution,
       )
     }
   }
+
+  attr(prob_distribution, "offset") <- offset
 
   # return prob_distribution object
   prob_distribution

--- a/R/epiparameter.R
+++ b/R/epiparameter.R
@@ -495,6 +495,7 @@ density.epiparameter <- function(x, at, ...) {
   if (isFALSE(is_parameterised(x))) {
     stop("<epiparameter> is unparameterised", call. = FALSE)
   }
+  at <- at - attr(x$prob_distribution, "offset")
   if (inherits(x$prob_distribution, "distcrete")) {
     out <- x$prob_distribution$d(at)
   } else {
@@ -517,6 +518,7 @@ cdf.epiparameter <- function(x, q, ..., log = FALSE) {
   if (isFALSE(is_parameterised(x))) {
     stop("<epiparameter> is unparameterised", call. = FALSE)
   }
+  q <- q - attr(x$prob_distribution, "offset")
   if (inherits(x$prob_distribution, "distcrete")) {
     out <- x$prob_distribution$p(q)
     if (log) out <- log(out)
@@ -541,10 +543,11 @@ quantile.epiparameter <- function(x, p, ...) {
   } else {
     out <- stats::quantile(x$prob_distribution, p = p)
   }
+  offset <- attr(x$prob_distribution, "offset")
   if (is.atomic(out)) {
-    return(out)
+    return(out + offset)
   }
-  return(unlist(out, recursive = FALSE))
+  return(unlist(out, recursive = FALSE) + offset)
 }
 
 #' @importFrom distributional generate
@@ -569,6 +572,7 @@ generate.epiparameter <- function(x, times, ...) {
     out <- distributional::generate(x$prob_distribution, times = times)
     out <- unlist(out, recursive = recursive)
   }
+  out <- out + attr(x$prob_distribution, "offset")
   out
 }
 

--- a/R/epiparameter.R
+++ b/R/epiparameter.R
@@ -495,7 +495,7 @@ density.epiparameter <- function(x, at, ...) {
   if (isFALSE(is_parameterised(x))) {
     stop("<epiparameter> is unparameterised", call. = FALSE)
   }
-  at <- at - attr(x$prob_distribution, "offset")
+  at <- at - (attr(x$prob_distribution, "offset") %||% 0)
   if (inherits(x$prob_distribution, "distcrete")) {
     out <- x$prob_distribution$d(at)
   } else {
@@ -518,7 +518,7 @@ cdf.epiparameter <- function(x, q, ..., log = FALSE) {
   if (isFALSE(is_parameterised(x))) {
     stop("<epiparameter> is unparameterised", call. = FALSE)
   }
-  q <- q - attr(x$prob_distribution, "offset")
+  q <- q - (attr(x$prob_distribution, "offset") %||% 0)
   if (inherits(x$prob_distribution, "distcrete")) {
     out <- x$prob_distribution$p(q)
     if (log) out <- log(out)
@@ -543,7 +543,7 @@ quantile.epiparameter <- function(x, p, ...) {
   } else {
     out <- stats::quantile(x$prob_distribution, p = p)
   }
-  offset <- attr(x$prob_distribution, "offset")
+  offset <- attr(x$prob_distribution, "offset") %||% 0
   if (is.atomic(out)) {
     return(out + offset)
   }
@@ -572,7 +572,7 @@ generate.epiparameter <- function(x, times, ...) {
     out <- distributional::generate(x$prob_distribution, times = times)
     out <- unlist(out, recursive = recursive)
   }
-  out <- out + attr(x$prob_distribution, "offset")
+  out <- out + (attr(x$prob_distribution, "offset") %||% 0)
   out
 }
 
@@ -626,6 +626,9 @@ discretise.epiparameter <- function(x, ...) {
     }
     prob_dist_params <- get_parameters(x)
 
+    # preserve any offset applied to the continuous distribution
+    offset <- attr(x$prob_distribution, "offset") %||% 0
+
     # if distribution is truncated take only parameters
     if (is_truncated(x)) {
       warning(
@@ -656,7 +659,8 @@ discretise.epiparameter <- function(x, ...) {
       prob_distribution = prob_dist,
       prob_distribution_params = prob_dist_params,
       discretise = TRUE,
-      truncation = NA
+      truncation = NA,
+      offset = offset
     )
   }
 

--- a/R/epiparameter_db.R
+++ b/R/epiparameter_db.R
@@ -624,7 +624,8 @@ epidist_db <- function(disease = "all",
       prob_distribution = x$probability_distribution$prob_distribution,
       prob_distribution_params = params,
       discretise = discretised,
-      truncation = truncation
+      truncation = truncation,
+      offset = x$probability_distribution$offset
     ),
     uncertainty = uncertainty,
     summary_stats = ss,

--- a/R/epiparameter_db.R
+++ b/R/epiparameter_db.R
@@ -625,7 +625,7 @@ epidist_db <- function(disease = "all",
       prob_distribution_params = params,
       discretise = discretised,
       truncation = truncation,
-      offset = x$probability_distribution$offset
+      offset = x$probability_distribution$offset %||% 0
     ),
     uncertainty = uncertainty,
     summary_stats = ss,

--- a/R/format.R
+++ b/R/format.R
@@ -76,6 +76,9 @@ format.epiparameter <- function(x, ...) {
         )
       )
     )
+    if (attr(x$prob_distribution, "offset") != 0) {
+      writeLines(sprintf("Offset: %s", attr(x$prob_distribution, "offset")))
+    }
   }
 
   invisible(x)

--- a/R/format.R
+++ b/R/format.R
@@ -76,8 +76,9 @@ format.epiparameter <- function(x, ...) {
         )
       )
     )
-    if (attr(x$prob_distribution, "offset") != 0) {
-      writeLines(sprintf("Offset: %s", attr(x$prob_distribution, "offset")))
+    offset <- attr(x$prob_distribution, "offset") %||% 0
+    if (offset != 0) {
+      writeLines(sprintf("Offset: %s", offset))
     }
   }
 

--- a/man/create_prob_distribution.Rd
+++ b/man/create_prob_distribution.Rd
@@ -9,6 +9,7 @@ create_prob_distribution(
   prob_distribution_params,
   discretise = FALSE,
   truncation = NA,
+  offset = 0,
   ...
 )
 }
@@ -27,6 +28,10 @@ distribution.}
 
 \item{truncation}{A \code{numeric} specifying the truncation point if the inferred
 distribution was truncated, \code{NA} if not or unknown.}
+
+\item{offset}{A \code{numeric} specifying the shift of a probability distribution
+left or right on the x-axis (i.e. decreasing or increasing all values by a
+constant).}
 
 \item{...}{\link{dots} Extra arguments to be passed to
 \pkg{distributional} or \pkg{distcrete} functions that construct the S3
@@ -96,5 +101,11 @@ create_prob_distribution(
   discretise = TRUE,
   truncation = NA,
   w = 0.5
+)
+# example using an offset
+create_prob_distribution(
+  prob_distribution = "gamma",
+  prob_distribution_params = c(shape = 1, scale = 1),
+  offset = 5
 )
 }

--- a/tests/testthat/_snaps/parameter_tbl.md
+++ b/tests/testthat/_snaps/parameter_tbl.md
@@ -4,7 +4,7 @@
       dist_tbl
     Output
       # Parameter table:
-      # A data frame:    125 x 7
+      # A data frame:    133 x 7
          disease          pathogen epi_name prob_distribution author  year sample_size
          <chr>            <chr>    <chr>    <chr>             <chr>  <dbl>       <dbl>
        1 Adenovirus       Adenovi~ incubat~ lnorm             Lessl~  2009          14
@@ -17,7 +17,7 @@
        8 Parainfluenza    Parainf~ incubat~ lnorm             Lessl~  2009          11
        9 RSV              RSV      incubat~ lnorm             Lessl~  2009          24
       10 Rhinovirus       Rhinovi~ incubat~ lnorm             Lessl~  2009          28
-      # i 115 more rows
+      # i 123 more rows
 
 # parameter_tbl works for incubation period with db
 
@@ -25,7 +25,7 @@
       incub_tbl
     Output
       # Parameter table:
-      # A data frame:    73 x 7
+      # A data frame:    75 x 7
          disease          pathogen epi_name prob_distribution author  year sample_size
          <chr>            <chr>    <chr>    <chr>             <chr>  <dbl>       <dbl>
        1 Adenovirus       Adenovi~ incubat~ lnorm             Lessl~  2009          14
@@ -38,7 +38,7 @@
        8 Parainfluenza    Parainf~ incubat~ lnorm             Lessl~  2009          11
        9 RSV              RSV      incubat~ lnorm             Lessl~  2009          24
       10 Rhinovirus       Rhinovi~ incubat~ lnorm             Lessl~  2009          28
-      # i 63 more rows
+      # i 65 more rows
 
 # parameter_tbl works for different distribution with db
 
@@ -46,7 +46,7 @@
       serial_tbl
     Output
       # Parameter table:
-      # A data frame:    18 x 7
+      # A data frame:    22 x 7
          disease          pathogen epi_name prob_distribution author  year sample_size
          <chr>            <chr>    <chr>    <chr>             <chr>  <dbl>       <dbl>
        1 Influenza        Influen~ serial ~ gamma             Ghani~  2009          58
@@ -59,14 +59,7 @@
        8 Ebola Virus Dis~ Ebola V~ serial ~ gamma             WHO E~  2015         147
        9 Ebola Virus Dis~ Ebola V~ serial ~ gamma             WHO E~  2015         112
       10 MERS             MERS-Cov serial ~ lnorm             Assir~  2013          23
-      11 MERS             MERS-Cov serial ~ gamma             Cowli~  2015          99
-      12 COVID-19         SARS-Co~ serial ~ <NA>              Alene~  2021        3924
-      13 COVID-19         SARS-Co~ serial ~ lnorm             Nishi~  2020          28
-      14 COVID-19         SARS-Co~ serial ~ weibull           Nishi~  2020          18
-      15 COVID-19         SARS-Co~ serial ~ norm              Yang ~  2020         131
-      16 Mpox             Mpox Vi~ serial ~ gamma             Guo e~  2022          42
-      17 Mpox             Mpox Vi~ serial ~ <NA>              Wang ~  2022          16
-      18 Mpox             Mpox Vi~ serial ~ <NA>              Wang ~  2022          34
+      # i 12 more rows
 
 # parameter_tbl works for COVID-19 db
 

--- a/tests/testthat/_snaps/parameter_tbl.md
+++ b/tests/testthat/_snaps/parameter_tbl.md
@@ -8,7 +8,7 @@
          disease          pathogen epi_name prob_distribution author  year sample_size
          <chr>            <chr>    <chr>    <chr>             <chr>  <dbl>       <dbl>
        1 Adenovirus       Adenovi~ incubat~ lnorm             Lessl~  2009          14
-       2 Human Coronavir~ Human_C~ incubat~ lnorm             Lessl~  2009          13
+       2 Human Coronavir~ Human C~ incubat~ lnorm             Lessl~  2009          13
        3 SARS             SARS-Co~ incubat~ lnorm             Lessl~  2009         157
        4 Influenza        Influen~ incubat~ lnorm             Lessl~  2009         151
        5 Influenza        Influen~ incubat~ lnorm             Lessl~  2009          90
@@ -29,7 +29,7 @@
          disease          pathogen epi_name prob_distribution author  year sample_size
          <chr>            <chr>    <chr>    <chr>             <chr>  <dbl>       <dbl>
        1 Adenovirus       Adenovi~ incubat~ lnorm             Lessl~  2009          14
-       2 Human Coronavir~ Human_C~ incubat~ lnorm             Lessl~  2009          13
+       2 Human Coronavir~ Human C~ incubat~ lnorm             Lessl~  2009          13
        3 SARS             SARS-Co~ incubat~ lnorm             Lessl~  2009         157
        4 Influenza        Influen~ incubat~ lnorm             Lessl~  2009         151
        5 Influenza        Influen~ incubat~ lnorm             Lessl~  2009          90
@@ -52,13 +52,13 @@
        1 Influenza        Influen~ serial ~ gamma             Ghani~  2009          58
        2 Marburg Virus D~ Marburg~ serial ~ <NA>              Pavlin  2014          38
        3 Marburg Virus D~ Marburg~ serial ~ gamma             Ajell~  2012         374
-       4 Mpox             Mpox Vi~ serial ~ gamma             Madew~  2022          57
-       5 Mpox             Mpox Vi~ serial ~ gamma             Madew~  2022          40
+       4 Mpox             Monkeyp~ serial ~ gamma             Madew~  2022          57
+       5 Mpox             Monkeyp~ serial ~ gamma             Madew~  2022          40
        6 Ebola Virus Dis~ Ebola V~ serial ~ gamma             WHO E~  2015         305
        7 Ebola Virus Dis~ Ebola V~ serial ~ gamma             WHO E~  2015          37
        8 Ebola Virus Dis~ Ebola V~ serial ~ gamma             WHO E~  2015         147
        9 Ebola Virus Dis~ Ebola V~ serial ~ gamma             WHO E~  2015         112
-      10 MERS             MERS-Cov serial ~ lnorm             Assir~  2013          23
+      10 MERS             MERS-CoV serial ~ lnorm             Assir~  2013          23
       # i 12 more rows
 
 # parameter_tbl works for COVID-19 db

--- a/tests/testthat/_snaps/print.md
+++ b/tests/testthat/_snaps/print.md
@@ -3,11 +3,11 @@
     Code
       epiparameter_db()
     Message
-      Returning 125 results that match the criteria (100 are parameterised). 
+      Returning 133 results that match the criteria (108 are parameterised). 
       Use subset to filter by entry variables or single_epiparameter to return a single entry. 
       To retrieve the citation for each use the 'get_citation' function
     Output
-      # List of 125 <epiparameter> objects
+      # List of 133 <epiparameter> objects
       Number of diseases: 23
       > Adenovirus > COVID-19 > Chikungunya > Dengue > Ebola Virus Disease > Hantavirus Pulmonary Syndrome > Human Coronavirus > Influenza > Japanese Encephalitis > MERS > Marburg Virus Disease > Measles > Mpox > Parainfluenza > Pneumonic Plague > RSV > Rhinovirus > Rift Valley Fever > SARS > Smallpox > West Nile Fever > Yellow Fever > Zika Virus Disease
       Number of epi parameters: 13
@@ -54,7 +54,7 @@
         meanlog: 1.386
         sdlog: 0.593
       
-      # i 122 more elements
+      # i 130 more elements
       # i Use `print(n = ...)` to see more elements.
       # i Use `parameter_tbl()` to see a summary table of the parameters.
       # i Explore database online at: https://epiverse-trace.github.io/epiparameter/articles/database.html

--- a/tests/testthat/_snaps/print.md
+++ b/tests/testthat/_snaps/print.md
@@ -28,13 +28,13 @@
       
       [[2]]
       Disease: Human Coronavirus
-      Pathogen: Human_Cov
+      Pathogen: Human Coronavirus
       Epi Parameter: incubation period
       Study: Lessler J, Reich N, Brookmeyer R, Perl T, Nelson K, Cummings D (2009).
       "Incubation periods of acute respiratory viral infections: a systematic
       review." _The Lancet Infectious Diseases_.
-      doi:10.1016/S1473-3099(09)70069-7
-      <https://doi.org/10.1016/S1473-3099%2809%2970069-7>.
+      doi:10.1016/S1473-3099(09)70069-6
+      <https://doi.org/10.1016/S1473-3099%2809%2970069-6>.
       Distribution: lnorm (days)
       Parameters:
         meanlog: 1.163
@@ -42,13 +42,13 @@
       
       [[3]]
       Disease: SARS
-      Pathogen: SARS-Cov-1
+      Pathogen: SARS-CoV-1
       Epi Parameter: incubation period
       Study: Lessler J, Reich N, Brookmeyer R, Perl T, Nelson K, Cummings D (2009).
       "Incubation periods of acute respiratory viral infections: a systematic
       review." _The Lancet Infectious Diseases_.
-      doi:10.1016/S1473-3099(09)70069-8
-      <https://doi.org/10.1016/S1473-3099%2809%2970069-8>.
+      doi:10.1016/S1473-3099(09)70069-6
+      <https://doi.org/10.1016/S1473-3099%2809%2970069-6>.
       Distribution: lnorm (days)
       Parameters:
         meanlog: 1.386
@@ -75,7 +75,7 @@
       > offspring distribution
       [[1]]
       Disease: SARS
-      Pathogen: SARS-Cov-1
+      Pathogen: SARS-CoV-1
       Epi Parameter: offspring distribution
       Study: Lloyd-Smith J, Schreiber S, Kopp P, Getz W (2005). "Superspreading and
       the effect of individual variation on disease emergence." _Nature_.
@@ -87,7 +87,7 @@
       
       [[2]]
       Disease: SARS
-      Pathogen: SARS-Cov-1
+      Pathogen: SARS-CoV-1
       Epi Parameter: offspring distribution
       Study: Lloyd-Smith J, Schreiber S, Kopp P, Getz W (2005). "Superspreading and
       the effect of individual variation on disease emergence." _Nature_.

--- a/tests/testthat/test-accessors.R
+++ b/tests/testthat/test-accessors.R
@@ -160,7 +160,7 @@ test_that(".distributional_family works as expected for transformed", {
   ep <- aggregate(incub)
   expect_identical(
     .distributional_family(ep$prob_distribution),
-    c(rep("lnorm", 2), "gamma", rep("lnorm", 2))
+    c(rep("lnorm", 2), "gamma", rep("lnorm", 2), rep("weibull", 2))
   )
 
   ep <- epiparameter(

--- a/tests/testthat/test-create_prob_distribution.R
+++ b/tests/testthat/test-create_prob_distribution.R
@@ -186,6 +186,17 @@ test_that("create_prob_distribution works for truncated continuous", {
   expect_identical(family(res), "truncated")
 })
 
+test_that("create_prob_distribution works for offset", {
+  res <- create_prob_distribution(
+    prob_distribution = "gamma",
+    prob_distribution_params = c(shape = 1, scale = 1),
+    offset = 10
+  )
+
+  expect_s3_class(res, "distribution")
+  expect_identical(attr(x$prob_distribution, "offset"), 10)
+})
+
 test_that("create_prob_distribution works passing args via ...", {
   dist1 <- create_prob_distribution(
     prob_distribution = "gamma",
@@ -239,5 +250,16 @@ test_that("create_prob_distribution errors for discrete truncation", {
       truncation = 10
     ),
     regexp = "Truncation is not yet implemented for discrete distributions"
+  )
+})
+
+test_that("create_prob_distribution errors for incorrect offset", {
+  expect_error(
+    create_prob_distribution(
+      prob_distribution = "gamma",
+      prob_distribution_params = c(shape = 1, scale = 1),
+      offset = NA
+    ),
+    regexp = "(Assertion on)*(offset)*(failed)"
   )
 })

--- a/tests/testthat/test-create_prob_distribution.R
+++ b/tests/testthat/test-create_prob_distribution.R
@@ -194,7 +194,7 @@ test_that("create_prob_distribution works for offset", {
   )
 
   expect_s3_class(res, "distribution")
-  expect_identical(attr(x$prob_distribution, "offset"), 10)
+  expect_identical(attr(res, "offset"), 10)
 })
 
 test_that("create_prob_distribution works passing args via ...", {

--- a/tests/testthat/test-epiparameter.R
+++ b/tests/testthat/test-epiparameter.R
@@ -1277,7 +1277,7 @@ test_that("c.epiparameter works with <epiparameter> & <multi_epiparameter>", {
 test_that("c.multi_epiparameter works with two <multi_epiparameter>s", {
   res <- c(db, db)
   expect_s3_class(res, class = "multi_epiparameter")
-  expect_length(res, 250)
+  expect_length(res, 266)
   expect_s3_class(res[[1]], class = "epiparameter")
 })
 

--- a/tests/testthat/test-epiparameter.R
+++ b/tests/testthat/test-epiparameter.R
@@ -363,6 +363,36 @@ test_that("density works as expected on continuous epiparameter object", {
   expect_gte(res, 0)
 })
 
+test_that("distribution functions handle a missing offset attribute", {
+  # objects created before the offset feature (or distributions not built by
+  # create_prob_distribution()) lack an "offset" attribute; a missing offset
+  # is treated as zero rather than corrupting or erroring the result
+  ebola_dist <- suppressMessages(
+    epiparameter(
+      disease = "ebola",
+      epi_name = "incubation_period",
+      prob_distribution = create_prob_distribution(
+        prob_distribution =  "gamma",
+        prob_distribution_params = c(shape = 1, scale = 1)
+      )
+    )
+  )
+  attr(ebola_dist$prob_distribution, "offset") <- NULL
+
+  expect_identical(
+    stats::density(ebola_dist, at = 0.5),
+    stats::density(ebola_dist$prob_distribution, at = 0.5)[[1]]
+  )
+  expect_identical(
+    distributional::cdf(ebola_dist, q = 0.5),
+    distributional::cdf(ebola_dist$prob_distribution, q = 0.5)[[1]]
+  )
+  expect_length(quantile(ebola_dist, p = 0.5), 1)
+  expect_length(distributional::generate(ebola_dist, times = 5), 5)
+  # print method must not error on a missing offset
+  expect_output(print(ebola_dist), "Distribution: gamma")
+})
+
 test_that("density works as expected on discrete epiparameter object", {
   ebola_dist <- suppressMessages(
     epiparameter(
@@ -770,6 +800,25 @@ test_that("discretise works as expected on continuous gamma", {
   expect_s3_class(ep$prob_distribution, "distcrete")
   expect_identical(ep$prob_distribution$parameters, list(shape = 1, scale = 1))
   expect_identical(ep$prob_distribution$name, "gamma")
+})
+
+test_that("discretise preserves the offset", {
+  # suppress message about citation
+  ep <- suppressMessages(epiparameter(
+    disease = "ebola",
+    epi_name = "incubation",
+    prob_distribution = create_prob_distribution(
+      prob_distribution = "gamma",
+      prob_distribution_params = c(shape = 1, scale = 1),
+      offset = 5
+    )
+  ))
+  ep <- discretise(ep)
+
+  expect_s3_class(ep$prob_distribution, "distcrete")
+  expect_identical(attr(ep$prob_distribution, "offset"), 5)
+  # offset shifts the discretised distribution along the x-axis
+  expect_identical(cdf(ep, q = 4), 0)
 })
 
 test_that("discretise works as expected on continuous lognormal", {

--- a/tests/testthat/test-epiparameter_db.R
+++ b/tests/testthat/test-epiparameter_db.R
@@ -208,7 +208,7 @@ test_that(".read_epiparameter_db works as expected", {
   db <- .read_epiparameter_db()
   expect_s3_class(db, class = "multi_epiparameter")
   expect_type(db, type = "list")
-  expect_length(db, 125)
+  expect_length(db, 133)
   expect_true(all(vapply(db, is_epiparameter, FUN.VALUE = logical(1))))
 })
 
@@ -217,7 +217,7 @@ test_that("as.data.frame works for <multi_epiparameter>", {
   db <- suppressMessages(epiparameter_db())
   df <- as.data.frame(db)
   expect_s3_class(df, class = "data.frame")
-  expect_identical(dim(df), c(125L, 10L))
+  expect_identical(dim(df), c(133L, 10L))
   expect_identical(
     colnames(df),
     c("disease", "pathogen", "epi_name", "prob_distribution",

--- a/tests/testthat/test-parameter_tbl.R
+++ b/tests/testthat/test-parameter_tbl.R
@@ -4,7 +4,7 @@ db <- suppressMessages(epiparameter_db())
 test_that("parameter_tbl works as expected supplied with db", {
   dist_tbl <- parameter_tbl(multi_epiparameter = db)
   expect_s3_class(dist_tbl, "data.frame")
-  expect_identical(dim(dist_tbl), c(125L, 7L))
+  expect_identical(dim(dist_tbl), c(133L, 7L))
   expect_named(
     dist_tbl,
     c("disease", "pathogen", "epi_name", "prob_distribution",
@@ -19,7 +19,7 @@ test_that("parameter_tbl works for incubation period with db", {
     epi_name = "incubation period"
   )
   expect_s3_class(incub_tbl, "data.frame")
-  expect_identical(dim(incub_tbl), c(73L, 7L))
+  expect_identical(dim(incub_tbl), c(75L, 7L))
   expect_named(
     incub_tbl,
     c("disease", "pathogen", "epi_name", "prob_distribution",
@@ -34,7 +34,7 @@ test_that("parameter_tbl works for different distribution with db", {
     epi_name = "serial interval"
   )
   expect_s3_class(serial_tbl, "data.frame")
-  expect_identical(dim(serial_tbl), c(18L, 7L))
+  expect_identical(dim(serial_tbl), c(22L, 7L))
   expect_named(
     serial_tbl,
     c("disease", "pathogen", "epi_name", "prob_distribution",


### PR DESCRIPTION
This PR adds the functionality for an `<epiparameter>` object to have a distribution offset. See epiverse-trace/epiparameterDB#24 for addition of `offset` parameters to the database.

An `offset` argument is added to `create_prob_distribution()`, with the `offset` being stored as a class attribute of the returned object. This avoids the requirement of the distribution object to handle offsets explicitly (for example {distributional} and {distcrete} currently do not handle offsets). 

The `<epiparameter>` distribution functions (`density()`, `cdf()`, `quantile()` and `generate()`) are updated to use the offset. By default, a zero offset will produce the same behaviour as previous versions.

The `<epiparameter>` `format()` and `print()` methods are updated to print the `offset` if it is non-zero.

Two unit tests are added that check `create_prob_distribution()`.

This PR also temporarily adds the dependency on {epiparameterDB} from the ~`@offset` branch~ `main` branch on GitHub. ~The dependency will be removed from a specific branch when the Mpox parameters are merged into `main` in {epiparameterDB}~, the remote dependency will be removed once the new version of {epiparameterDB} is on CRAN.