### PR TITLE
Improve `epiparameter_db()` error message when disease/pathogen/epi_name not in DB

### DIFF
--- a/R/epiparameter_db.R
+++ b/R/epiparameter_db.R
@@ -502,15 +502,17 @@ epidist_db <- function(disease = "all",
       )
     },
     error = function(cnd) {
-      disease_str <- ifelse(
-        test = disease == "all", yes = "", no = paste(" for", disease_)
-      )
-      pathogen_str <- ifelse(
-        test = pathogen == "all", yes = "", no = paste(" for", pathogen_)
-      )
+      disease_str <- ifelse(test = disease == "all", yes = "", no = disease_)
+      pathogen_str <- ifelse(test = pathogen == "all", yes = "", no = pathogen_)
       epi_name_str <- ifelse(test = epi_name == "all", yes = "", no = epi_name_)
+      if (disease_str != "" && pathogen_str != "") {
+        disease_str <- paste0(disease_str, " & ")
+      }
       stop(
-        epi_name_str, " distribution not available", disease_str, pathogen_str,
+        cli::style_bold(epi_name_str), " distribution not available for ",
+        cli::style_bold(disease_str), cli::style_bold(pathogen_str),
+        " in the database.\n Please check spelling of disease/pathogen and ",
+        "epiparameter name.",
         call. = FALSE
       )
     }

--- a/R/epiparameter_db.R
+++ b/R/epiparameter_db.R
@@ -502,19 +502,32 @@ epidist_db <- function(disease = "all",
       )
     },
     error = function(cnd) {
-      disease_str <- ifelse(test = disease == "all", yes = "", no = disease_)
-      pathogen_str <- ifelse(test = pathogen == "all", yes = "", no = pathogen_)
-      epi_name_str <- ifelse(test = epi_name == "all", yes = "", no = epi_name_)
-      if (disease_str != "" && pathogen_str != "") {
-        disease_str <- paste0(disease_str, " & ")
+      msg <- character(0)
+      if (disease  != "all") msg <- c(msg, cli::style_bold(disease_))
+      if (pathogen != "all") msg <- c(msg, cli::style_bold(pathogen_))
+      msg_str <- paste(msg, collapse = " & ")
+
+      if (epi_name != "all" && length(msg) > 0L) {
+        stop(
+          cli::style_bold(epi_name_), " distribution not available for ",
+          msg_str, " in the database. \n Please check the spelling of ",
+          "the disease/pathogen and epiparameter name.",
+          call. = FALSE
+        )
+      } else if (epi_name != "all") {
+        stop(
+          cli::style_bold(epi_name_),
+          " distribution not available in the database. \n Please check the ",
+          "spelling of the epiparameter name.",
+          call. = FALSE
+        )
+      } else {
+        stop(
+          msg_str, " not found as a disease/pathogen in the database. \n ",
+          "Please check the spelling of the disease/pathogen name.",
+          call. = FALSE
+        )
       }
-      stop(
-        cli::style_bold(epi_name_str), " distribution not available for ",
-        cli::style_bold(disease_str), cli::style_bold(pathogen_str),
-        " in the database.\n Please check spelling of disease/pathogen and ",
-        "epiparameter name.",
-        call. = FALSE
-      )
     }
   )
 

--- a/R/epiparameter_db.R
+++ b/R/epiparameter_db.R
@@ -511,7 +511,7 @@ epidist_db <- function(disease = "all",
         stop(
           cli::style_bold(epi_name_), " distribution not available for ",
           msg_str, " in the database. \n Please check the spelling of ",
-          "the disease/pathogen and epiparameter name.",
+          "the disease/pathogen and epiparameter name.", # nolint
           call. = FALSE
         )
       } else if (epi_name != "all") {
@@ -524,7 +524,7 @@ epidist_db <- function(disease = "all",
       } else {
         stop(
           msg_str, " not found as a disease/pathogen in the database. \n ",
-          "Please check the spelling of the disease/pathogen name.",
+          "Please check the spelling of the disease/pathogen name.", # nolint
           call. = FALSE
         )
       }

--- a/tests/testthat/test-parameter_tbl.R
+++ b/tests/testthat/test-parameter_tbl.R
@@ -147,7 +147,7 @@ test_that("parameter_tbl fails correctly when subsetting a subset db", {
   ep <- suppressMessages(epiparameter_db(disease = "Ebola"))
   expect_error(
     parameter_tbl(multi_epiparameter = ep, disease = "COVID-19"),
-    regexp = "(distribution not available for COVID-19)"
+    regexp = "(COVID-19 not found as a distribution)*(in the database)"
   )
 })
 


### PR DESCRIPTION
This PR addresses #450 by improving the error message from `.filter_epiparameter_db()`, called by `epiparameter_db()`, when the disease, pathogen or epiparameter name is not found in the database. It adds a message telling the user to check spelling as this is a common reason for the error being throw, see example given by @Karim-Mane in #450. 

It also uses {cli} to style the error message to try and emphasise the important parts of the error message.