### PR TITLE
Fix suppressMessages() function signature

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,4 +66,4 @@ Encoding: UTF-8
 Language: en-GB
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/tests/testthat/test-epiparameter.R
+++ b/tests/testthat/test-epiparameter.R
@@ -164,11 +164,11 @@ test_that("epiparameter fails as expected", {
         epi_name = "incubation",
         prob_distribution = "gamma",
         prob_distribution_params = c(shape = "NA", scale = 1)
-      ),
-      regexp = paste0(
-        "(Assertion on 'prob_distribution_params' failed)*(Must be of type)*",
-        "(numeric)*(NULL)*(character)."
       )
+    ),
+    regexp = paste0(
+      "(Assertion on 'prob_distribution_params' failed)*(Must be of type)*",
+      "(numeric)*(NULL)*(character)."
     )
   )
 })

--- a/tests/testthat/test-epiparameter.R
+++ b/tests/testthat/test-epiparameter.R
@@ -162,14 +162,14 @@ test_that("epiparameter fails as expected", {
       epiparameter(
         disease = "ebola",
         epi_name = "incubation",
-        prob_distribution = "gamma",
-        prob_distribution_params = c(shape = "NA", scale = 1)
+        prob_distribution = create_prob_distribution(
+          prob_distribution = "gamma",
+          prob_distribution_params = c(shape = "NA", scale = 1)
+        )
       )
     ),
-    regexp = paste0(
-      "(Assertion on 'prob_distribution_params' failed)*(Must be of type)*",
-      "(numeric)*(NULL)*(character)."
-    )
+    regexp =
+      "`prob_distribution_params` must be a named vector of numerics or NA"
   )
 })
 


### PR DESCRIPTION
Detected with the experimental https://github.com/Bisaloo/signaturechecker package.

It's a fun coincidence this managed to go undetected:

- `suppressMessages()` did warn that `regexp=` is not a valid argument
- but it is wrapped in `expect_error()`, with no `regexp=` value, so it's silently ignored. 