### PR TITLE
Update `test-coverage.yaml` arguments

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -65,8 +65,8 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
-          file: ./cobertura.xml
-          plugin: noop
+          files: ./cobertura.xml
+          plugins: noop
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
This PR removes the warning on the GHA log by updating the [deprecated workflow arguments](https://github.com/codecov/codecov-action/releases/tag/v5.0.0), it also checks that the previous failure of `test-coverage.yaml` is fixed.