### PR TITLE
Add grEPI integration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,7 @@ Imports:
     distributional,
     epiparameterDB,
     graphics,
+    httr2,
     lifecycle,
     pillar,
     rlang,

--- a/R/epiparameter_db.R
+++ b/R/epiparameter_db.R
@@ -1,3 +1,4 @@
+# nolint start: line_length_linter
 #' Create `<epiparameter>` object(s) directly from the epiparameter library
 #' (database)
 #'
@@ -113,7 +114,8 @@
 #'   epi_name = "offspring_distribution",
 #'   single_epiparameter = TRUE
 #' )
-epiparameter_db <- function(disease = "all",
+#' # nolint end: line_length_linter
+epiparameter_db <- function(disease = "all",  # nolint: cyclocomp_linter
                             pathogen = "all",
                             epi_name = "all",
                             author = NULL,

--- a/R/epiparameter_db.R
+++ b/R/epiparameter_db.R
@@ -81,6 +81,12 @@
 #' will be returned (see [is_parameterised()]). If multiple entries are equal
 #' after this sorting the first entry will be returned.
 #'
+#' @param db A `character` string specifying which database to load
+#' epidemiological parameter from. Default is `"epiparameterDB"`, which loads
+#' from the \pkg{epiparameterDB} R package. The other option is `"grEPI"`,
+#' which loads from the
+#' [WHO Global Repository of Epidemiological Parameters](https://who-collaboratory.github.io/collaboratory-grepi-web/).
+#'
 #' @return An `<epiparameter>` object or list of `<epiparameter>` objects.
 #' @export
 #'
@@ -112,12 +118,29 @@ epiparameter_db <- function(disease = "all",
                             epi_name = "all",
                             author = NULL,
                             subset = NULL,
-                            single_epiparameter = FALSE) {
+                            single_epiparameter = FALSE,
+                            db = c("epiparameterDB", "grEPI")) {
   # check input
   checkmate::assert_string(disease)
   checkmate::assert_string(pathogen)
   checkmate::assert_string(epi_name)
   checkmate::assert_logical(single_epiparameter, len = 1)
+  db <- match.arg(db)
+
+  if (db == "grEPI") {
+    multi_epiparameter <- .read_grepi(
+      disease = disease,
+      pathogen = pathogen,
+      epi_name = epi_name,
+      author = author,
+      subset = subset,
+      single_epiparameter = single_epiparameter
+    )
+    if (length(multi_epiparameter) == 1) {
+      multi_epiparameter <- multi_epiparameter[[1]]
+    }
+    return(multi_epiparameter)
+  }
 
   # capture expression from subset and check type
   expr <- substitute(subset)

--- a/R/grepi.R
+++ b/R/grepi.R
@@ -167,16 +167,13 @@
   dist_lookup <- c(Weibull = "weibull", Gamma = "gamma",
                    "Log-normal" = "lnorm")
   dist_raw <- x$epiParameter_Distribution_Type
-  if (!is.null(dist_raw) && !is.na(dist_raw) &&
-      dist_raw %in% names(dist_lookup)) {
-    if (!isTRUE(x$epiParameter_Distribution_Parameter1_IsValueAvailable) ||
-        !isTRUE(x$epiParameter_Distribution_Parameter2_IsValueAvailable)) {
-      warning("Skipping grEPI record ", x$grEPI_ID, ": ", dist_raw,
-              " distribution declared but parameter values not available",
-              call. = FALSE)
-      return(NULL)
-    }
-    dist <- unname(dist_lookup[[dist_raw]])
+  has_dist <- !is.null(dist_raw) && !is.na(dist_raw) &&
+              dist_raw %in% names(dist_lookup)
+  dist <- if (has_dist) unname(dist_lookup[[dist_raw]]) else NA_character_
+  params_available <-
+    isTRUE(x$epiParameter_Distribution_Parameter1_IsValueAvailable) &&
+    isTRUE(x$epiParameter_Distribution_Parameter2_IsValueAvailable)
+  if (has_dist && params_available) {
     prob_distribution_params <- setNames(
       c(x$epiParameter_Distribution_Parameter1_Value,
         x$epiParameter_Distribution_Parameter2_Value),
@@ -193,23 +190,42 @@
         var = prob_distribution_params[["variance"]]
       ))
     }
-    prob_distribution <- create_prob_distribution(
-      prob_distribution = dist,
-      prob_distribution_params = prob_distribution_params,
-      discretise = isTRUE(x$epi_Parameter_Method_Inference_DataIsDiscretised)
-    )
-    uncertainty <- setNames(
-      lapply(seq_along(prob_distribution_params),
-             function(.) create_uncertainty()),
-      names(prob_distribution_params)
-    )
-    summary_stats <- create_summary_stats()
+    # Some entries (e.g. Lassa Gamma) declare a parametric family but report
+    # the values as summary statistics (mean + SD) rather than the
+    # distribution's canonical parameters. Carry the values forward as
+    # summary stats and keep `prob_distribution` as the family name only.
+    sd_alias <- c("sd", "standard deviation (sd)")
+    pp_names <- names(prob_distribution_params)
+    is_mean_sd <- length(pp_names) == 2L &&
+      "mean" %in% pp_names &&
+      any(sd_alias %in% pp_names)
+    if (is_mean_sd) {
+      mean_val <- unname(prob_distribution_params[["mean"]])
+      sd_val <- unname(
+        prob_distribution_params[pp_names %in% sd_alias][[1]]
+      )
+      prob_distribution <- create_prob_distribution(prob_distribution = dist)
+      uncertainty <- list(uncertainty = create_uncertainty())
+      summary_stats <- create_summary_stats(mean = mean_val, sd = sd_val)
+    } else {
+      prob_distribution <- create_prob_distribution(
+        prob_distribution = dist,
+        prob_distribution_params = prob_distribution_params,
+        discretise = isTRUE(x$epi_Parameter_Method_Inference_DataIsDiscretised)
+      )
+      uncertainty <- setNames(
+        lapply(seq_along(prob_distribution_params),
+               function(.) create_uncertainty()),
+        names(prob_distribution_params)
+      )
+      summary_stats <- create_summary_stats()
+    }
   } else if (x$epiParameter_Estimate_IsPoint) {
-    # Unparameterised entry: encode the typed point value as a summary stat
-    # rather than fabricating a degenerate distribution.
-    prob_distribution <- create_prob_distribution(
-      prob_distribution = NA_character_
-    )
+    # Entry without canonical distribution parameters: encode the typed point
+    # value as a summary stat rather than fabricating a degenerate distribution.
+    # If the family was declared (e.g. Mpox Log-normal with no shape/scale)
+    # carry its name forward so the prob_distribution slot still records it.
+    prob_distribution <- create_prob_distribution(prob_distribution = dist)
     uncertainty <- list(uncertainty = create_uncertainty())
     pv <- x$epiParameter_Estimate_Point_Value
     is_ci <- isTRUE(grepl("Confidence|Credible",
@@ -298,9 +314,9 @@
     ),
     notes = paste0(
       "Loaded from the ", x$epi_Parameter_DataSource_Name, " (",
-      x$epi_Parameter_DataSource_Location, ").",
+      x$epi_Parameter_DataSource_Location, "). ",
       "The data was extracted by",
-      x$epi_Parameter_Data_ExtractedBy_OrganizationGroup_Name, ".",
+      x$epi_Parameter_Data_ExtractedBy_OrganizationGroup_Name, ". ",
       x$epi_Parameter_DataSource_Primary_Import_Comment, ": ",
       x$epi_Parameter_DataSource_Primary_ImportedFrom_Project
     ),

--- a/R/grepi.R
+++ b/R/grepi.R
@@ -1,4 +1,5 @@
-#' Reads in parameter library from ***grEPI*** and formats data to <epiparameter>
+#' Reads in parameter library from ***grEPI*** and formats data to
+#' <epiparameter>
 #'
 #' @inheritParams epiparameter_db
 #'
@@ -6,7 +7,7 @@
 #' nicer printing)
 #' @keywords internal
 #' @noRd
-.read_grepi <- function(disease,
+.read_grepi <- function(disease, # nolint: cyclocomp_linter
                         pathogen,
                         epi_name,
                         author,
@@ -16,7 +17,7 @@
   if (!is.null(author)) {
     warning(
       "Subsetting the grEPI database by `author` is not yet implemented. \n",
-      "Returning all studies that match disease/pathogen and epidemiological ",
+      "Returning all studies that match disease/pathogen and epidemiological ", # nolint
       "parameter",
       call. = FALSE
     )
@@ -24,7 +25,7 @@
   if (!is.null(subset)) {
     warning(
       "Subsetting the grEPI database using `subset` is not yet implemented. \n",
-      "Returning all studies that match disease/pathogen and epidemiological ",
+      "Returning all studies that match disease/pathogen and epidemiological ", # nolint
       "parameter",
       call. = FALSE
     )
@@ -32,7 +33,7 @@
   if (single_epiparameter) {
     warning(
       "`single_epiparameter` is not yet implemented for the grEPI database. \n",
-      "Returning all studies that match disease/pathogen and epidemiological ",
+      "Returning all studies that match disease/pathogen and epidemiological ", # nolint
       "parameter",
       call. = FALSE
     )
@@ -120,7 +121,7 @@
           )
         } else {
           stop(
-            msg_str, " not found as a disease/pathogen in the grEPI database. ",
+            msg_str, " not found as a disease/pathogen in the grEPI database. ", # nolint
             "\n Please check the spelling of the disease/pathogen name.", # nolint
             call. = FALSE
           )
@@ -160,7 +161,7 @@
 #' @inherit epiparameter return
 #' @keywords internal
 #' @noRd
-.grepi_to_epiparameter <- function(x, ...) {
+.grepi_to_epiparameter <- function(x, ...) { # nolint: cyclocomp_linter
 
   # parameterised-distribution support for 2-parameter families. To add a new
   # family, extend dist_lookup; the rest of the branch is family-agnostic.
@@ -174,7 +175,7 @@
     isTRUE(x$epiParameter_Distribution_Parameter1_IsValueAvailable) &&
     isTRUE(x$epiParameter_Distribution_Parameter2_IsValueAvailable)
   if (has_dist && params_available) {
-    prob_distribution_params <- setNames(
+    prob_distribution_params <- stats::setNames(
       c(x$epiParameter_Distribution_Parameter1_Value,
         x$epiParameter_Distribution_Parameter2_Value),
       tolower(c(x$epiParameter_Distribution_Parameter1_Value_Type,
@@ -213,7 +214,7 @@
         prob_distribution_params = prob_distribution_params,
         discretise = isTRUE(x$epi_Parameter_Method_Inference_DataIsDiscretised)
       )
-      uncertainty <- setNames(
+      uncertainty <- stats::setNames(
         lapply(seq_along(prob_distribution_params),
                function(.) create_uncertainty()),
         names(prob_distribution_params)
@@ -243,10 +244,10 @@
            x$epiParameter_Estimate_Range_Upper_Bound_Value %||% NA_real_)
     summary_stats <- switch(
       as.character(x$epiParameter_Estimate_Value_Type),
-      "Mean" = create_summary_stats(
+      Mean = create_summary_stats(
         mean = pv, mean_ci_limits = ci, mean_ci = ci_level
       ),
-      "Median" = create_summary_stats(
+      Median = create_summary_stats(
         median = pv, median_ci_limits = ci, median_ci = ci_level
       ),
       "Standard deviation (SD)" = create_summary_stats(
@@ -269,7 +270,7 @@
   # format citation
   citation <- suppressMessages(
     create_citation(
-      author = as.person(x$article_Authors[[1]]),
+      author = utils::as.person(x$article_Authors[[1]]),
       year = x$article_Publication_Year,
       title = x$article_Title,
       journal = x$literature_Source_Name,
@@ -305,7 +306,7 @@
       units = x$epiParameter_Estimate_Unit,
       sample_size = x$epi_Parameter_Population_Sample_Size,
       inference_method = x$epi_Parameter_Method_Inference,
-      region = region,
+      region = region
     ),
     method_assess = create_method_assess(
       censored = x$epi_Parameter_Method_Inference_DataIsCensored,

--- a/R/grepi.R
+++ b/R/grepi.R
@@ -6,7 +6,37 @@
 #' nicer printing)
 #' @keywords internal
 #' @noRd
-.read_grepi <- function(disease = "all", pathogen = "all") {
+.read_grepi <- function(disease = "all",
+                        pathogen = "all",
+                        epi_name = "all",
+                        author,
+                        subset,
+                        single_epiparameter) {
+
+  if (!is.null(author)) {
+    warning(
+      "Subsetting the grEPI database by `author` is not yet implemented. \n",
+      "Returning all studies that match disease/pathogen and epidemiological ",
+      "parameter",
+      call. = FALSE
+    )
+  }
+  if (!is.null(subset)) {
+    warning(
+      "Subsetting the grEPI database using `subset` is not yet implemented. \n",
+      "Returning all studies that match disease/pathogen and epidemiological ",
+      "parameter",
+      call. = FALSE
+    )
+  }
+  if (single_epiparameter) {
+    warning(
+      "`single_epiparameter` is not yet implemented for the grEPI database. \n",
+      "Returning all studies that match disease/pathogen and epidemiological ",
+      "parameter",
+      call. = FALSE
+    )
+  }
 
   req <- httr2::request(
     "https://collaboratory.who.int/grepi/api/EpiParameterEstimates"
@@ -17,6 +47,8 @@
   if (!identical(pathogen, "all")) {
     req <- httr2::req_url_query(req, pathogen_Species_Name_Preferred = pathogen)
   }
+
+  message("Loading epidemiological parameters from grEPI...")
   resp <- tryCatch(
     httr2::req_perform(req),
     error = function(cnd) {
@@ -28,17 +60,95 @@
     }
   )
   if (is.null(resp)) {
-    return(structure(list(), class = "multi_epiparameter"))
+    stop(
+      "No grEPI entries could be converted to <epiparameter> objects.",
+      call. = FALSE
+    )
   }
   grepi_params <- httr2::resp_body_json(resp, simplifyVector = TRUE)
   if (!is.data.frame(grepi_params) || nrow(grepi_params) == 0L) {
-    return(structure(list(), class = "multi_epiparameter"))
+    stop(
+      "No grEPI entries could be converted to <epiparameter> objects.",
+      call. = FALSE
+    )
+  }
+
+  # epi_name is filtered locally: the grEPI API ignores the
+  # epiParameter_Estimate_Type query parameter
+  # matched case-insensitively against either the
+  # broad Estimate_Type category (e.g. "Human Delay") or the specific Subtype
+  # (e.g. "Incubation period").
+  if (!identical(epi_name, "all")) {
+    en <- .clean_string(epi_name)
+    grepi_types <- c(
+      tolower(grepi_params$epiParameter_Estimate_Type),
+      tolower(grepi_params$epiParameter_Estimate_Subtype)
+    )
+    tryCatch(
+      {
+        en <- match.arg(
+          arg = en,
+          choices = unique(grepi_types),
+          several.ok = FALSE
+        )
+      },
+      error = function(cnd) {
+        msg <- character(0)
+        if (disease  != "all") msg <- c(msg, cli::style_bold(disease))
+        if (pathogen != "all") msg <- c(msg, cli::style_bold(pathogen))
+        msg_str <- paste(msg, collapse = " & ")
+
+        if (epi_name != "all" && length(msg) > 0L) {
+          stop(
+            cli::style_bold(epi_name), " not available for ",
+            msg_str, " in the grEPI database. \n Please check the spelling of ",
+            "the disease/pathogen and epiparameter name.", # nolint
+            "\n", cli::symbol$info, " If the epidemiological parameter name ",
+            "partially matches multiple \n parameter types in the grEPI ",
+            "database please specify the full name.",
+            call. = FALSE
+          )
+        } else if (epi_name != "all") {
+          stop(
+            cli::style_bold(epi_name),
+            " not available in the database grEPI. \n Please ",
+            "check the spelling of the epiparameter name.",
+            "\n", cli::symbol$info, " If the epidemiological parameter name ",
+            "partially matches multiple \n parameter types in the grEPI ",
+            "database please specify the full name.",
+            call. = FALSE
+          )
+        } else {
+          stop(
+            msg_str, " not found as a disease/pathogen in the grEPI database. ",
+            "\n Please check the spelling of the disease/pathogen name.", # nolint
+            call. = FALSE
+          )
+        }
+      }
+    )
+    keep <- tolower(grepi_params$epiParameter_Estimate_Type) == en |
+            tolower(grepi_params$epiParameter_Estimate_Subtype) == en
+    keep[is.na(keep)] <- FALSE
+    grepi_params <- grepi_params[keep, , drop = FALSE]
+    if (nrow(grepi_params) == 0L) {
+      stop(
+        "No grEPI entries could be converted to <epiparameter> objects.",
+        call. = FALSE
+      )
+    }
   }
   ep_list <- lapply(
     seq_len(nrow(grepi_params)),
     function(i) .grepi_to_epiparameter(grepi_params[i, , drop = FALSE])
   )
   ep_list <- Filter(Negate(is.null), ep_list)
+  if (length(ep_list) == 0L) {
+    stop(
+      "No grEPI entries could be converted to <epiparameter> objects.",
+      call. = FALSE
+    )
+  }
   structure(ep_list, class = "multi_epiparameter")
 }
 
@@ -59,6 +169,13 @@
   dist_raw <- x$epiParameter_Distribution_Type
   if (!is.null(dist_raw) && !is.na(dist_raw) &&
       dist_raw %in% names(dist_lookup)) {
+    if (!isTRUE(x$epiParameter_Distribution_Parameter1_IsValueAvailable) ||
+        !isTRUE(x$epiParameter_Distribution_Parameter2_IsValueAvailable)) {
+      warning("Skipping grEPI record ", x$grEPI_ID, ": ", dist_raw,
+              " distribution declared but parameter values not available",
+              call. = FALSE)
+      return(NULL)
+    }
     dist <- unname(dist_lookup[[dist_raw]])
     prob_distribution_params <- setNames(
       c(x$epiParameter_Distribution_Parameter1_Value,
@@ -86,21 +203,52 @@
              function(.) create_uncertainty()),
       names(prob_distribution_params)
     )
+    summary_stats <- create_summary_stats()
   } else if (x$epiParameter_Estimate_IsPoint) {
+    # Unparameterised entry: encode the typed point value as a summary stat
+    # rather than fabricating a degenerate distribution.
     prob_distribution <- create_prob_distribution(
-      prob_distribution = "norm",
-      prob_distribution_params = c(
-        mean = x$epiParameter_Estimate_Point_Value,
-        sd = 0
-      )
+      prob_distribution = NA_character_
     )
-    uncertainty <- list(mean = create_uncertainty(), sd = create_uncertainty())
+    uncertainty <- list(uncertainty = create_uncertainty())
+    pv <- x$epiParameter_Estimate_Point_Value
+    is_ci <- isTRUE(grepl("Confidence|Credible",
+                          x$epiParameter_Uncertainty_Value_Type %||% ""))
+    ci <- if (is_ci) c(x$epiParameter_Uncertainty_Range_Lower_Bound_Value,
+                       x$epiParameter_Uncertainty_Range_Upper_Bound_Value)
+          else c(NA_real_, NA_real_)
+    ci_level <- if (is_ci) 95 else NA_real_
+    # Range comes from either Uncertainty_Range_* (when UT=Range) or from the
+    # parallel Estimate_Range_* field grEPI also carries.
+    range_src <- if (identical(x$epiParameter_Uncertainty_Value_Type, "Range"))
+      c(x$epiParameter_Uncertainty_Range_Lower_Bound_Value %||% NA_real_,
+        x$epiParameter_Uncertainty_Range_Upper_Bound_Value %||% NA_real_)
+    else c(x$epiParameter_Estimate_Range_Lower_Bound_Value %||% NA_real_,
+           x$epiParameter_Estimate_Range_Upper_Bound_Value %||% NA_real_)
+    summary_stats <- switch(
+      as.character(x$epiParameter_Estimate_Value_Type),
+      "Mean" = create_summary_stats(
+        mean = pv, mean_ci_limits = ci, mean_ci = ci_level
+      ),
+      "Median" = create_summary_stats(
+        median = pv, median_ci_limits = ci, median_ci = ci_level
+      ),
+      "Standard deviation (SD)" = create_summary_stats(
+        sd = pv, sd_ci_limits = ci, sd_ci = ci_level
+      ),
+      create_summary_stats()
+    )
+    summary_stats$range <- range_src
   } else {
     warning("Skipping grEPI record ", x$grEPI_ID,
             ": unsupported distribution and not a point estimate",
             call. = FALSE)
     return(NULL)
   }
+
+  # Drop empty (all-NA) summary_stats slots so format.epiparameter() doesn't
+  # print uninformative "NA" lines, matching the epiparameterDB convention.
+  summary_stats <- Filter(function(x) !all(is.na(x)), summary_stats)
 
   # format citation
   citation <- suppressMessages(
@@ -135,7 +283,7 @@
     epi_name = epi_name,
     prob_distribution = prob_distribution,
     uncertainty = uncertainty,
-    summary_stats = create_summary_stats(),
+    summary_stats = summary_stats,
     citation = citation,
     metadata = create_metadata(
       units = x$epiParameter_Estimate_Unit,
@@ -155,6 +303,7 @@
       x$epi_Parameter_Data_ExtractedBy_OrganizationGroup_Name, ".",
       x$epi_Parameter_DataSource_Primary_Import_Comment, ": ",
       x$epi_Parameter_DataSource_Primary_ImportedFrom_Project
-    )
+    ),
+    auto_calc_params = FALSE
   )
 }

--- a/R/grepi.R
+++ b/R/grepi.R
@@ -6,9 +6,9 @@
 #' nicer printing)
 #' @keywords internal
 #' @noRd
-.read_grepi <- function(disease = "all",
-                        pathogen = "all",
-                        epi_name = "all",
+.read_grepi <- function(disease,
+                        pathogen,
+                        epi_name,
                         author,
                         subset,
                         single_epiparameter) {

--- a/R/grepi.R
+++ b/R/grepi.R
@@ -1,0 +1,160 @@
+#' Reads in parameter library from ***grEPI*** and formats data to <epiparameter>
+#'
+#' @inheritParams epiparameter_db
+#'
+#' @return `<multi_epiparameter>` object (i.e. a list of `<epiparameter>` with
+#' nicer printing)
+#' @keywords internal
+#' @noRd
+.read_grepi <- function(disease = "all", pathogen = "all") {
+
+  req <- httr2::request(
+    "https://collaboratory.who.int/grepi/api/EpiParameterEstimates"
+  )
+  if (!identical(disease, "all")) {
+    req <- httr2::req_url_query(req, Disease_Name_Preferred = disease)
+  }
+  if (!identical(pathogen, "all")) {
+    req <- httr2::req_url_query(req, pathogen_Species_Name_Preferred = pathogen)
+  }
+  resp <- tryCatch(
+    httr2::req_perform(req),
+    error = function(cnd) {
+      warning(
+        "Could not reach the grEPI API: ", conditionMessage(cnd),
+        call. = FALSE
+      )
+      NULL
+    }
+  )
+  if (is.null(resp)) {
+    return(structure(list(), class = "multi_epiparameter"))
+  }
+  grepi_params <- httr2::resp_body_json(resp, simplifyVector = TRUE)
+  if (!is.data.frame(grepi_params) || nrow(grepi_params) == 0L) {
+    return(structure(list(), class = "multi_epiparameter"))
+  }
+  ep_list <- lapply(
+    seq_len(nrow(grepi_params)),
+    function(i) .grepi_to_epiparameter(grepi_params[i, , drop = FALSE])
+  )
+  ep_list <- Filter(Negate(is.null), ep_list)
+  structure(ep_list, class = "multi_epiparameter")
+}
+
+#' Convert `<data.frame>` from \pkg{grEPI} to `<epiparameter>`
+#'
+#' @param x A `<data.frame>`.
+#' @param ... [dots] Extra arguments to pass to [epiparameter()].
+#'
+#' @inherit epiparameter return
+#' @keywords internal
+#' @noRd
+.grepi_to_epiparameter <- function(x, ...) {
+
+  # parameterised-distribution support for 2-parameter families. To add a new
+  # family, extend dist_lookup; the rest of the branch is family-agnostic.
+  dist_lookup <- c(Weibull = "weibull", Gamma = "gamma",
+                   "Log-normal" = "lnorm")
+  dist_raw <- x$epiParameter_Distribution_Type
+  if (!is.null(dist_raw) && !is.na(dist_raw) &&
+      dist_raw %in% names(dist_lookup)) {
+    dist <- unname(dist_lookup[[dist_raw]])
+    prob_distribution_params <- setNames(
+      c(x$epiParameter_Distribution_Parameter1_Value,
+        x$epiParameter_Distribution_Parameter2_Value),
+      tolower(c(x$epiParameter_Distribution_Parameter1_Value_Type,
+                x$epiParameter_Distribution_Parameter2_Value_Type))
+    )
+    # lnorm in grEPI is sometimes parameterised as (mean, variance);
+    # convert to the canonical (meanlog, sdlog) via the package's converter.
+    if (dist == "lnorm" &&
+        setequal(names(prob_distribution_params), c("mean", "variance"))) {
+      prob_distribution_params <- unlist(convert_summary_stats_to_params(
+        "lnorm",
+        mean = prob_distribution_params[["mean"]],
+        var = prob_distribution_params[["variance"]]
+      ))
+    }
+    prob_distribution <- create_prob_distribution(
+      prob_distribution = dist,
+      prob_distribution_params = prob_distribution_params,
+      discretise = isTRUE(x$epi_Parameter_Method_Inference_DataIsDiscretised)
+    )
+    uncertainty <- setNames(
+      lapply(seq_along(prob_distribution_params),
+             function(.) create_uncertainty()),
+      names(prob_distribution_params)
+    )
+  } else if (x$epiParameter_Estimate_IsPoint) {
+    prob_distribution <- create_prob_distribution(
+      prob_distribution = "norm",
+      prob_distribution_params = c(
+        mean = x$epiParameter_Estimate_Point_Value,
+        sd = 0
+      )
+    )
+    uncertainty <- list(mean = create_uncertainty(), sd = create_uncertainty())
+  } else {
+    warning("Skipping grEPI record ", x$grEPI_ID,
+            ": unsupported distribution and not a point estimate",
+            call. = FALSE)
+    return(NULL)
+  }
+
+  # format citation
+  citation <- suppressMessages(
+    create_citation(
+      author = as.person(x$article_Authors[[1]]),
+      year = x$article_Publication_Year,
+      title = x$article_Title,
+      journal = x$literature_Source_Name,
+      doi = x$article_DOI
+    )
+  )
+
+  # format epi_name
+  subtype <- x$epiParameter_Estimate_Subtype
+  subtype[is.na(subtype)] <- ""
+  if (subtype == "Other") {
+    subtype <- paste(x$epiParameter_EventFrom, "to", x$epiParameter_EventTo)
+  }
+  epi_name <- trimws(paste(subtype, x$epiParameter_Estimate_Type))
+
+  # handle entries missing Country info
+  if (is.null(x$epi_Parameter_Population_Country_list[[1]]$country_Name)) {
+    region <- NA_character_
+  } else {
+    region <- x$epi_Parameter_Population_Country_list[[1]]$country_Name
+  }
+
+  # return <epiparameter>
+  epiparameter(
+    disease = x$disease_Name_Preferred,
+    pathogen = x$pathogen_Species_Name_Preferred,
+    epi_name = epi_name,
+    prob_distribution = prob_distribution,
+    uncertainty = uncertainty,
+    summary_stats = create_summary_stats(),
+    citation = citation,
+    metadata = create_metadata(
+      units = x$epiParameter_Estimate_Unit,
+      sample_size = x$epi_Parameter_Population_Sample_Size,
+      inference_method = x$epi_Parameter_Method_Inference,
+      region = region,
+    ),
+    method_assess = create_method_assess(
+      censored = x$epi_Parameter_Method_Inference_DataIsCensored,
+      right_truncated = x$epi_Parameter_Method_Inference_DataIsTruncated,
+      phase_bias_adjusted = x$epi_Parameter_Method_Inference_DataIsBiasAdjusted
+    ),
+    notes = paste0(
+      "Loaded from the ", x$epi_Parameter_DataSource_Name, " (",
+      x$epi_Parameter_DataSource_Location, ").",
+      "The data was extracted by",
+      x$epi_Parameter_Data_ExtractedBy_OrganizationGroup_Name, ".",
+      x$epi_Parameter_DataSource_Primary_Import_Comment, ": ",
+      x$epi_Parameter_DataSource_Primary_ImportedFrom_Project
+    )
+  )
+}

--- a/man/epiparameter_db.Rd
+++ b/man/epiparameter_db.Rd
@@ -11,7 +11,8 @@ epiparameter_db(
   epi_name = "all",
   author = NULL,
   subset = NULL,
-  single_epiparameter = FALSE
+  single_epiparameter = FALSE,
+  db = c("epiparameterDB", "grEPI")
 )
 }
 \arguments{
@@ -62,6 +63,12 @@ when only one is wanted.
 (and accounts for truncation if available) and has the largest sample size
 will be returned (see \code{\link[=is_parameterised]{is_parameterised()}}). If multiple entries are equal
 after this sorting the first entry will be returned.}
+
+\item{db}{A \code{character} string specifying which database to load
+epidemiological parameter from. Default is \code{"epiparameterDB"}, which loads
+from the \pkg{epiparameterDB} R package. The other option is \code{"grEPI"},
+which loads from the
+\href{https://who-collaboratory.github.io/collaboratory-grepi-web/}{WHO Global Repository of Epidemiological Parameters}.}
 }
 \value{
 An \verb{<epiparameter>} object or list of \verb{<epiparameter>} objects.


### PR DESCRIPTION
This PR addresses #479 by adding a proof-of-concept integration for the WHO Global Repository of Epidemiological Parameters (grEPI) with the {epiparameter} package. 

This integrates the first public release version of grEPI.

`epiparameter_db()` is updated by adding a new `db` argument that allows users to specify `db = "grEPI"` which will then load data from the grEPI API and format the epidemiological parameters into `<epiparameter>` objects. The default is `db = "epiparameterDB"`, so these changes are backwards compatible.

Internally, `epiparameter_db()` calls a new internal function, `.read_grepi()`, which itself calls another new function added in this PR `.grepi_to_epiparameter()`. `.read_grepi()` handles the API call and condition handling, and `.grepi_to_epiparameter()` handles the coersion from the tabular (`data.frame`) data from the grEPI API and formats it into an `<epiparameter>` object. `.grepi_to_epiparameter()` is analogous to `.epireview_to_epiparameter()` for interoperability with other epiparameter databases.

{httr2} is added as a new `Import` dependency to get data from the grEPI API.