### PR TITLE
Add `verbose` to `epiparameter()`

### DIFF
--- a/R/calc_dist_params.R
+++ b/R/calc_dist_params.R
@@ -31,12 +31,15 @@
 #' @keywords internal
 .calc_dist_params <- function(prob_distribution, # nolint cyclocomp
                               summary_stats,
-                              sample_size) {
+                              sample_size,
+                              verbose = TRUE) {
   if (is.na(prob_distribution)) {
-    message(
-      "No adequate summary statistics available to calculate the parameters ",
-      "of the ", prob_distribution, " distribution"
-    )
+    if (verbose) {
+      message(
+        "No adequate summary statistics available to calculate the parameters ",
+        "of the ", prob_distribution, " distribution"
+      )
+    }
     return(NA)
   }
 
@@ -130,10 +133,12 @@
       samples = sample_size
     )
   } else {
-    message(
-      "No adequate summary statistics available to calculate the parameters ",
-      "of the ", prob_distribution, " distribution"
-    )
+    if (verbose) {
+      message(
+        "No adequate summary statistics available to calculate the parameters ",
+        "of the ", prob_distribution, " distribution"
+      )
+    }
     return(NA)
   }
 

--- a/R/epiparameter-utils.R
+++ b/R/epiparameter-utils.R
@@ -373,6 +373,7 @@ create_summary_stats <- function(mean = NA_real_,
 #' (PMID) assigned to papers to give them a unique identifier within PubMed.
 #' @param doi A `character` string of the Digital Object Identifier (DOI)
 #' assigned to papers which are unique to each paper.
+#' @inheritParams epiparameter_db
 #'
 #' @return A `<bibentry>` object of the citation
 #' @export
@@ -390,7 +391,8 @@ create_citation <- function(author = utils::person(),
                             title = NA_character_,
                             journal = NA_character_,
                             doi = NA_character_,
-                            pmid = NA_integer_) {
+                            pmid = NA_integer_,
+                            verbose = getOption("epiparameter")$verbose) {
   # if not <person> try and convert author to <person>
   if (!inherits(author, "person"))
     tryCatch(expr = {
@@ -409,11 +411,15 @@ create_citation <- function(author = utils::person(),
   checkmate::assert_character(journal)
   checkmate::assert_character(doi)
   checkmate::assert_number(pmid, na.ok = TRUE)
+  checkmate::assert_logical(verbose, len = 1, any.missing = FALSE)
 
   if (length(author) == 0 || is.na(year) || is.na(journal) || is.na(title)) {
-    message(
-      "Citation cannot be created as author, year, journal or title is missing"
-    )
+    if (verbose) {
+      message(
+        "Citation cannot be created as author, year, journal or ",
+        "title is missing"
+      )
+    }
     return(utils::bibentry(bibtype = "Misc", title = "No citation"))
   }
 
@@ -427,10 +433,12 @@ create_citation <- function(author = utils::person(),
   )
   citation$pmid <- pmid
 
-  message(
-    "Using ", format(citation), " \n",
-    "To retrieve the citation use the 'get_citation' function"
-  )
+  if (verbose) {
+    message(
+      "Using ", format(citation), " \n",
+      "To retrieve the citation use the 'get_citation' function"
+    )
+  }
 
   citation
 }

--- a/R/epiparameter.R
+++ b/R/epiparameter.R
@@ -24,13 +24,15 @@ new_epiparameter <- function(disease = character(),
                              method_assess = list(),
                              notes = character(),
                              auto_calc_params = logical(),
+                             verbose = TRUE,
                              ...) {
   if (auto_calc_params && is.character(prob_distribution)) {
     # calculate parameters if not provided
     prob_distribution_params <- .calc_dist_params(
       prob_distribution = prob_distribution,
       summary_stats = summary_stats,
-      sample_size = metadata$sample_size
+      sample_size = metadata$sample_size,
+      verbose = verbose
     )
     if (!anyNA(prob_distribution_params)) {
       prob_distribution <- create_prob_distribution(
@@ -38,13 +40,16 @@ new_epiparameter <- function(disease = character(),
         prob_distribution_params = prob_distribution_params,
         ...
       )
-      message(
-        "Parameterising the probability distribution with the summary ",
-        "statistics.\n Probability distribution is assumed not to be ",
-        "discretised or truncated."
-      )
+      if (verbose) {
+        message(
+          "Parameterising the probability distribution with the summary ",
+          "statistics.\n Probability distribution is assumed not to be ",
+          "discretised or truncated."
+        )
+      }
     }
-    if (!inherits(prob_distribution, c("distribution", "distcrete"))) {
+    if (!inherits(prob_distribution, c("distribution", "distcrete")) &&
+        verbose) {
       message("Unparameterised <epiparameter> object")
     }
   }
@@ -152,6 +157,7 @@ new_epiparameter <- function(disease = character(),
 #' assessment.
 #' @param notes A `character` string with any additional information about the
 #' data, inference method or disease.
+#' @inheritParams epiparameter_db
 #' @param ... [dots] Extra arguments to be passed to internal functions.
 #'
 #' This is most commonly used to pass arguments to [distcrete::distcrete()]
@@ -227,11 +233,12 @@ epiparameter <- function(disease,
                          ),
                          uncertainty = create_uncertainty(),
                          summary_stats = create_summary_stats(),
-                         citation = create_citation(),
+                         citation = create_citation(verbose = verbose),
                          metadata = create_metadata(),
                          method_assess = create_method_assess(),
                          notes = NULL,
                          auto_calc_params = TRUE,
+                         verbose = getOption("epiparameter")$verbose,
                          ...) {
   # check input
   checkmate::assert_string(disease)
@@ -249,6 +256,7 @@ epiparameter <- function(disease,
     names = "unique",
     null.ok = TRUE
   )
+  checkmate::assert_logical(verbose, len = 1, any.missing = FALSE)
   checkmate::assert_class(citation, classes = "bibentry")
   checkmate::assert_list(metadata)
   checkmate::assert_list(method_assess)
@@ -267,6 +275,7 @@ epiparameter <- function(disease,
     metadata = metadata,
     method_assess = method_assess,
     notes = notes,
+    verbose = verbose,
     ...
   )
 

--- a/R/epiparameter_db.R
+++ b/R/epiparameter_db.R
@@ -88,11 +88,10 @@
 #' which loads from the
 #' [WHO Global Repository of Epidemiological Parameters](https://who-collaboratory.github.io/collaboratory-grepi-web/).
 #'
-#' @param verbose A `logical` controlling whether [message()]s are printed
-#' when loading `<epiparameter>`s. Warnings and errors are not affected.
-#' Defaults to the `verbose` field of `getOption("epiparameter")` (`TRUE`
-#' unless the user has set otherwise via
-#' `options(epiparameter = list(verbose = FALSE))`).
+#' @param verbose A `logical` controlling whether informational [message()]s
+#' are printed. Warnings and errors are not affected. Defaults to the
+#' `verbose` field of `getOption("epiparameter")` (`TRUE` unless the user has
+#' set otherwise via `options(epiparameter = list(verbose = FALSE))`).
 #'
 #' @return An `<epiparameter>` object or list of `<epiparameter>` objects.
 #' @export

--- a/man/create_citation.Rd
+++ b/man/create_citation.Rd
@@ -10,7 +10,8 @@ create_citation(
   title = NA_character_,
   journal = NA_character_,
   doi = NA_character_,
-  pmid = NA_integer_
+  pmid = NA_integer_,
+  verbose = getOption("epiparameter")$verbose
 )
 }
 \arguments{
@@ -35,6 +36,11 @@ assigned to papers which are unique to each paper.}
 
 \item{pmid}{A \code{character} string with the PubMed unique identifier number
 (PMID) assigned to papers to give them a unique identifier within PubMed.}
+
+\item{verbose}{A \code{logical} controlling whether informational \code{\link[=message]{message()}}s
+are printed. Warnings and errors are not affected. Defaults to the
+\code{verbose} field of \code{getOption("epiparameter")} (\code{TRUE} unless the user has
+set otherwise via \code{options(epiparameter = list(verbose = FALSE))}).}
 }
 \value{
 A \verb{<bibentry>} object of the citation

--- a/man/dot-calc_dist_params.Rd
+++ b/man/dot-calc_dist_params.Rd
@@ -5,7 +5,12 @@
 \title{Calculate the parameters of a probability distribution from a list of
 summary statistics}
 \usage{
-.calc_dist_params(prob_distribution, summary_stats, sample_size)
+.calc_dist_params(
+  prob_distribution,
+  summary_stats,
+  sample_size,
+  verbose = TRUE
+)
 }
 \arguments{
 \item{prob_distribution}{An S3 class containing the probability
@@ -24,6 +29,11 @@ interval around mean and standard deviation.}
 
 \item{sample_size}{The sample size of the data. Only needed when falling back
 on using the median-range extraction calculation.}
+
+\item{verbose}{A \code{logical} controlling whether informational \code{\link[=message]{message()}}s
+are printed. Warnings and errors are not affected. Defaults to the
+\code{verbose} field of \code{getOption("epiparameter")} (\code{TRUE} unless the user has
+set otherwise via \code{options(epiparameter = list(verbose = FALSE))}).}
 }
 \value{
 A named \code{numeric} vector with parameters.

--- a/man/epiparameter.Rd
+++ b/man/epiparameter.Rd
@@ -11,11 +11,12 @@ epiparameter(
   prob_distribution = create_prob_distribution(prob_distribution = NA_character_),
   uncertainty = create_uncertainty(),
   summary_stats = create_summary_stats(),
-  citation = create_citation(),
+  citation = create_citation(verbose = verbose),
   metadata = create_metadata(),
   method_assess = create_method_assess(),
   notes = NULL,
   auto_calc_params = TRUE,
+  verbose = getOption("epiparameter")$verbose,
   ...
 )
 }
@@ -73,6 +74,11 @@ distribution parameters are not provided. Default is \code{TRUE}. In the case wh
 sufficient summary statistics are provided and the parameter(s) of the
 distribution are not, the \code{\link[=.calc_dist_params]{.calc_dist_params()}} function is called to
 calculate the parameters and add them to the \code{epiparameter} object created.}
+
+\item{verbose}{A \code{logical} controlling whether informational \code{\link[=message]{message()}}s
+are printed. Warnings and errors are not affected. Defaults to the
+\code{verbose} field of \code{getOption("epiparameter")} (\code{TRUE} unless the user has
+set otherwise via \code{options(epiparameter = list(verbose = FALSE))}).}
 
 \item{...}{\link{dots} Extra arguments to be passed to internal functions.
 

--- a/man/epiparameter_db.Rd
+++ b/man/epiparameter_db.Rd
@@ -71,11 +71,10 @@ from the \pkg{epiparameterDB} R package. The other option is \code{"grEPI"},
 which loads from the
 \href{https://who-collaboratory.github.io/collaboratory-grepi-web/}{WHO Global Repository of Epidemiological Parameters}.}
 
-\item{verbose}{A \code{logical} controlling whether \code{\link[=message]{message()}}s are printed
-when loading \verb{<epiparameter>}s. Warnings and errors are not affected.
-Defaults to the \code{verbose} field of \code{getOption("epiparameter")} (\code{TRUE}
-unless the user has set otherwise via
-\code{options(epiparameter = list(verbose = FALSE))}).}
+\item{verbose}{A \code{logical} controlling whether informational \code{\link[=message]{message()}}s
+are printed. Warnings and errors are not affected. Defaults to the
+\code{verbose} field of \code{getOption("epiparameter")} (\code{TRUE} unless the user has
+set otherwise via \code{options(epiparameter = list(verbose = FALSE))}).}
 }
 \value{
 An \verb{<epiparameter>} object or list of \verb{<epiparameter>} objects.

--- a/man/new_epiparameter.Rd
+++ b/man/new_epiparameter.Rd
@@ -16,6 +16,7 @@ new_epiparameter(
   method_assess = list(),
   notes = character(),
   auto_calc_params = logical(),
+  verbose = TRUE,
   ...
 )
 }
@@ -73,6 +74,11 @@ distribution parameters are not provided. Default is \code{TRUE}. In the case wh
 sufficient summary statistics are provided and the parameter(s) of the
 distribution are not, the \code{\link[=.calc_dist_params]{.calc_dist_params()}} function is called to
 calculate the parameters and add them to the \code{epiparameter} object created.}
+
+\item{verbose}{A \code{logical} controlling whether informational \code{\link[=message]{message()}}s
+are printed. Warnings and errors are not affected. Defaults to the
+\code{verbose} field of \code{getOption("epiparameter")} (\code{TRUE} unless the user has
+set otherwise via \code{options(epiparameter = list(verbose = FALSE))}).}
 
 \item{...}{\link{dots} Extra arguments to be passed to internal functions.
 

--- a/tests/testthat/test-epiparameter-utils.R
+++ b/tests/testthat/test-epiparameter-utils.R
@@ -72,6 +72,54 @@ test_that("create_citation works with different author inputs", {
   expect_identical(cit$author$family, list("Smith", "Jones", "Team"))
 })
 
+test_that("create_citation is verbose by default", {
+  expect_message(
+    create_citation(),
+    regexp = "Citation cannot be created"
+  )
+  expect_message(
+    create_citation(
+      author = person(given = "John", family = "Smith"),
+      year = 2002,
+      title = "COVID-19 incubation period",
+      journal = "Epi Journal",
+      doi = "10.19832/j.1366-9516.2012.09147.x" # nolint file.path
+    ),
+    regexp = "Using"
+  )
+})
+
+test_that("create_citation(verbose = FALSE) suppresses messages", {
+  expect_no_message(
+    create_citation(verbose = FALSE)
+  )
+  expect_no_message(
+    create_citation(
+      author = person(given = "John", family = "Smith"),
+      year = 2002,
+      title = "COVID-19 incubation period",
+      journal = "Epi Journal",
+      doi = "10.19832/j.1366-9516.2012.09147.x", # nolint file.path
+      verbose = FALSE
+    )
+  )
+})
+
+test_that("create_citation respects options(epiparameter = list(verbose = FALSE))", { # nolint line_length_linter
+  old <- options(epiparameter = list(verbose = FALSE))
+  on.exit(options(old), add = TRUE)
+  .set_epiparameter_options()
+
+  expect_no_message(create_citation())
+})
+
+test_that("create_citation(verbose) input is validated", {
+  expect_error(
+    create_citation(verbose = "yes"),
+    regexp = "verbose"
+  )
+})
+
 test_that("create_citation works with PMID", {
   # suppress message about citation
   citation <- suppressMessages(

--- a/tests/testthat/test-epiparameter.R
+++ b/tests/testthat/test-epiparameter.R
@@ -1308,3 +1308,90 @@ test_that("c.epiparameter fails as expected", {
     regexp = "Can only combine <epiparameter> or <multi_epiparameter> objects"
   )
 })
+
+test_that("epiparameter is verbose by default", {
+  expect_message(
+    epiparameter(
+      disease = "ebola",
+      epi_name = "incubation",
+      prob_distribution = create_prob_distribution(
+        prob_distribution = "gamma",
+        prob_distribution_params = c(shape = 1, scale = 1)
+      )
+    ),
+    regexp = "Citation cannot be created"
+  )
+})
+
+test_that("epiparameter(verbose = FALSE) suppresses informational messages", {
+  expect_no_message(
+    ebola_dist <- epiparameter(
+      disease = "ebola",
+      epi_name = "incubation",
+      prob_distribution = create_prob_distribution(
+        prob_distribution = "gamma",
+        prob_distribution_params = c(shape = 1, scale = 1)
+      ),
+      verbose = FALSE
+    )
+  )
+  expect_s3_class(ebola_dist, class = "epiparameter")
+})
+
+test_that("epiparameter respects options(epiparameter = list(verbose = FALSE))", { # nolint line_length_linter
+  old <- options(epiparameter = list(verbose = FALSE))
+  on.exit(options(old), add = TRUE)
+  .set_epiparameter_options()
+
+  expect_no_message(
+    ebola_dist <- epiparameter(
+      disease = "ebola",
+      epi_name = "incubation",
+      prob_distribution = create_prob_distribution(
+        prob_distribution = "gamma",
+        prob_distribution_params = c(shape = 1, scale = 1)
+      )
+    )
+  )
+  expect_s3_class(ebola_dist, class = "epiparameter")
+})
+
+test_that("epiparameter(verbose = FALSE) suppresses parameterisation message", {
+  expect_no_message(
+    ebola_dist <- epiparameter(
+      disease = "ebola",
+      epi_name = "incubation",
+      prob_distribution = "gamma",
+      summary_stats = create_summary_stats(mean = 2, sd = 1),
+      verbose = FALSE
+    )
+  )
+  expect_s3_class(ebola_dist, class = "epiparameter")
+})
+
+test_that("epiparameter(verbose = FALSE) suppresses unparameterised message", {
+  expect_no_message(
+    ebola_dist <- epiparameter(
+      disease = "ebola",
+      epi_name = "incubation",
+      prob_distribution = "gamma",
+      verbose = FALSE
+    )
+  )
+  expect_s3_class(ebola_dist, class = "epiparameter")
+})
+
+test_that("epiparameter(verbose) input is validated", {
+  expect_error(
+    epiparameter(
+      disease = "ebola",
+      epi_name = "incubation",
+      prob_distribution = create_prob_distribution(
+        prob_distribution = "gamma",
+        prob_distribution_params = c(shape = 1, scale = 1)
+      ),
+      verbose = "yes"
+    ),
+    regexp = "verbose"
+  )
+})


### PR DESCRIPTION
This PR closes #474 by adding a `verbose` argument to the `epiparameter()` function. Allowing messages, including the message about citation not being created mentioned in #474, to be turned off when `verbose = FALSE`.

This PR follows on from PR #482 and uses the `verbose` package option added in that PR. The `verbose` default for `epiparameter()` follows the default for `epiparameter_db()`: `getOption("epiparameter")$verbose`.

The `verbose` argument is also added to the `.calc_dist_params()`, `create_citation()`, `new_epiparameter()` which are either called by `epiparameter()` or are called when constructing arguments for `epiparameter()`. 

The `verbose` argument documentation (`@param verbose`) is generlised in `epiparameter_db()` so it can be inherited in `epiparameter()` and other functions.

New unit tests are added for `epiparameter()` and `create_citation()` to ensure messages are correctly handled by `verbose`.