### PR TITLE
Fix `doi` extraction for grEPI v3.0.1 article_DOI removal (#490)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # epiparameter (development version)
 
+## Bug fixes
+
+* `.grepi_to_epiparameter()` now reads the article DOI from `article_Unique_Identifier` (gated on `article_Unique_Identifier_Type`) instead of the removed `article_DOI` field, to match the grEPI v3.0.1 API restructure (#490).
+
+## Minor changes
+
+* `.read_grepi()` gains a `base_url` argument (defaulting to the production grEPI endpoint) so tests and manual checks can target the grEPI UAT environment (#490).
+
 # epiparameter 0.4.1
 
 A patch release resolving issues flagged by CRAN checks. 

--- a/R/grepi.R
+++ b/R/grepi.R
@@ -13,7 +13,8 @@
                         author,
                         subset,
                         single_epiparameter,
-                        verbose) {
+                        verbose,
+                        base_url = "https://collaboratory.who.int/grepi/api/EpiParameterEstimates") { # nolint
 
   if (!is.null(author)) {
     warning(
@@ -40,9 +41,7 @@
     )
   }
 
-  req <- httr2::request(
-    "https://collaboratory.who.int/grepi/api/EpiParameterEstimates"
-  )
+  req <- httr2::request(base_url)
   if (!identical(disease, "all")) {
     req <- httr2::req_url_query(req, Disease_Name_Preferred = disease)
   }
@@ -277,7 +276,12 @@
       year = x$article_Publication_Year,
       title = x$article_Title,
       journal = x$literature_Source_Name,
-      doi = x$article_DOI
+      doi = if (identical(x$article_Unique_Identifier_Type,
+                          "Digital Object Identifier (DOI)")) {
+        x$article_Unique_Identifier
+      } else {
+        NA_character_
+      }
     )
   )
 
@@ -312,9 +316,9 @@
       region = region
     ),
     method_assess = create_method_assess(
-      censored = x$epi_Parameter_Method_Inference_DataIsCensored,
-      right_truncated = x$epi_Parameter_Method_Inference_DataIsTruncated,
-      phase_bias_adjusted = x$epi_Parameter_Method_Inference_DataIsBiasAdjusted
+      censored = x$epi_Parameter_Method_Inference_DataIsCensored %||% NA,
+      right_truncated = x$epi_Parameter_Method_Inference_DataIsTruncated %||% NA, # nolint
+      phase_bias_adjusted = x$epi_Parameter_Method_Inference_DataIsBiasAdjusted %||% NA # nolint
     ),
     notes = paste0(
       "Loaded from the ", x$epi_Parameter_DataSource_Name, " (",

--- a/tests/testthat/test-grepi.R
+++ b/tests/testthat/test-grepi.R
@@ -1,0 +1,69 @@
+# A minimal grEPI record that takes the point-estimate branch of
+# .grepi_to_epiparameter(), so the fixture stays independent of the
+# parameterised-distribution logic. `unique_id_type`/`unique_id` are the
+# fields under test.
+grepi_record <- function(unique_id_type = "Digital Object Identifier (DOI)",
+                         unique_id = "10.1234/example.doi") {
+  list(
+    disease_Name_Preferred = "Test Disease",
+    pathogen_Species_Name_Preferred = "Test Pathogen",
+    epiParameter_Estimate_Subtype = NA_character_,
+    epiParameter_Estimate_Type = "Serial interval",
+    epiParameter_Distribution_Type = NA_character_,
+    epiParameter_Estimate_IsPoint = TRUE,
+    epiParameter_Estimate_Point_Value = 5,
+    epiParameter_Estimate_Value_Type = "Mean",
+    epiParameter_Estimate_Unit = "Days",
+    epi_Parameter_Population_Sample_Size = 100,
+    epi_Parameter_Method_Inference = "MLE",
+    epi_Parameter_Population_Country_list = list(
+      list(country_Name = "Testland")
+    ),
+    epi_Parameter_Method_Inference_DataIsCensored = NA,
+    epi_Parameter_Method_Inference_DataIsTruncated = NA,
+    epi_Parameter_Method_Inference_DataIsBiasAdjusted = NA,
+    epi_Parameter_DataSource_Name = "Test Source",
+    epi_Parameter_DataSource_Location = "Test Location",
+    epi_Parameter_Data_ExtractedBy_OrganizationGroup_Name = "Test Org",
+    epi_Parameter_DataSource_Primary_Import_Comment = "Test comment",
+    epi_Parameter_DataSource_Primary_ImportedFrom_Project = "Test project",
+    article_Authors = list("Smith, John"),
+    article_Publication_Year = 2020,
+    article_Title = "A test title",
+    literature_Source_Name = "Test Journal",
+    article_Unique_Identifier_Type = unique_id_type,
+    article_Unique_Identifier = unique_id,
+    grEPI_ID = "TEST-1"
+  )
+}
+
+test_that(".grepi_to_epiparameter() reads the DOI from
+           article_Unique_Identifier when typed as a DOI", {
+  x <- grepi_record()
+  ep <- suppressMessages(epiparameter:::.grepi_to_epiparameter(x))
+
+  expect_s3_class(ep, "epiparameter")
+  expect_identical(ep$citation$doi, "10.1234/example.doi")
+})
+
+test_that(".grepi_to_epiparameter() drops the DOI when
+           article_Unique_Identifier_Type is not a DOI", {
+  x <- grepi_record(
+    unique_id_type = "PubMed ID",
+    unique_id = "12345678"
+  )
+  ep <- suppressMessages(epiparameter:::.grepi_to_epiparameter(x))
+
+  expect_null(ep$citation$doi)
+})
+
+test_that(".grepi_to_epiparameter() drops the DOI when the
+           article_Unique_Identifier fields are absent
+           (pre-v3.0.1 grEPI shape)", {
+  x <- grepi_record()
+  x$article_Unique_Identifier_Type <- NULL
+  x$article_Unique_Identifier <- NULL
+  ep <- suppressMessages(epiparameter:::.grepi_to_epiparameter(x))
+
+  expect_null(ep$citation$doi)
+})


### PR DESCRIPTION
Fixes #490

grEPI v3.0.1 removes `article_DOI` from the `GET /api/EpiParameterEstimates` response and instead carries the DOI under `article_Unique_Identifier`, typed by `article_Unique_Identifier_Type`. This updates `.grepi_to_epiparameter()` in `R/grepi.R` to read the DOI from the new field, gated on the identifier type being `"Digital Object Identifier (DOI)"`

Also included, as noted in the issue's testing section:
- Added a `base_url` argument to `.read_grepi()` (default: production endpoint) so the grEPI UAT environment can be targeted without editing the source.
- Added `%||% NA` fallbacks for `censored`, `right_truncated`, and `phase_bias_adjusted` in the `create_method_assess()` call, guarding against these fields being absent on some UAT records.

This is our first PR to epiparameter, so any feedback on the approach is welcome. The PR also goes slightly beyond #490: the base_url argument and %||% NA guards were added for UAT testing and aren't required for the DOI fix. Happy to split those out into a separate PR or drop entirely if preferred.

* **Please check if the PR fulfills these requirements**

- [x] I have read the CONTRIBUTING guidelines
- [x] A new item has been added to `NEWS.md`
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Checks have been run locally and pass

* **What kind of change does this PR introduce?**

Bug fix (plus one small enhancement: a `base_url` parameter for testability).

* **What is the current behavior?**

`.grepi_to_epiparameter()` reads the citation DOI from `x$article_DOI`. As of grEPI v3.0.1, that field is removed from the API response, so every converted `<epiparameter>` object's `doi` slot silently becomes `NA`. See #490.

* **What is the new behavior (if this is a feature change)?**

The DOI is read from `x$article_Unique_Identifier` when `x$article_Unique_Identifier_Type` is `"Digital Object Identifier (DOI)"`, otherwise `NA_character_` as before. `.read_grepi()` also accepts an optional `base_url` so the UAT endpoint can be targeted for testing.

* **Does this PR introduce a breaking change?**

No. `base_url` is a new argument with a production default, so existing calls are unaffected. The `doi` field's behavior is unchanged for records that carry a DOI.

* **Other information**:

Tested against the grEPI UAT environment (https://collaboratory-uat.who.int) ahead of the PROD release.