### PR TITLE
grEPI v3.0.4 property renames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # epiparameter (development version)
 
+* Update `.read_grepi()` and `.grepi_to_epiparameter()` for the grEPI v3.0.4
+  property renames on the `EpiParameterEstimates` endpoint
+  (`disease_Name_Preferred` -> `disease`,
+  `pathogen_Species_Name_preferred` -> `pathogen_species`) (#495).
+
 # epiparameter 0.4.1
 
 A patch release resolving issues flagged by CRAN checks. 

--- a/R/grepi.R
+++ b/R/grepi.R
@@ -44,10 +44,10 @@
     "https://collaboratory.who.int/grepi/api/EpiParameterEstimates"
   )
   if (!identical(disease, "all")) {
-    req <- httr2::req_url_query(req, Disease_Name_Preferred = disease)
+    req <- httr2::req_url_query(req, disease = disease)
   }
   if (!identical(pathogen, "all")) {
-    req <- httr2::req_url_query(req, pathogen_Species_Name_Preferred = pathogen)
+    req <- httr2::req_url_query(req, pathogen_species = pathogen)
   }
 
   if (verbose) {
@@ -298,8 +298,8 @@
 
   # return <epiparameter>
   epiparameter(
-    disease = x$disease_Name_Preferred,
-    pathogen = x$pathogen_Species_Name_Preferred,
+    disease = x$disease,
+    pathogen = x$pathogen_species,
     epi_name = epi_name,
     prob_distribution = prob_distribution,
     uncertainty = uncertainty,


### PR DESCRIPTION
cc: @joshwlambert @CarmenTamayo

* **Please check if the PR fulfills these requirements**
- [x] I have read the CONTRIBUTING guidelines
- [x] A new item has been added to `NEWS.md`
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Checks have been run locally and pass

* **What kind of change does this PR introduce?**
Bug fix / upstream grEPI API integration.

* **What is the current behavior?**
`.read_grepi()` and `.grepi_to_epiparameter()` read `disease_Name_Preferred` /
`pathogen_Species_Name_Preferred` from the grEPI `EpiParameterEstimates`
response and send them as query parameter names. grEPI v3.0.4 renames these
to `disease` / `pathogen_species`; once v3.0.4 reaches PROD, both fields
will silently return `NA`. Fixes #495.

* **What is the new behavior?**
Reads and query parameters use the new names. Values/types are unchanged.

* **Does this PR introduce a breaking change?**
No breaking changes. This PR anticipates and addresses breaking changes for grEPI integration.

* **Other information**
Independent of #494 (base_url argument,`fix/grepi-doi-restructure`).