### PR TITLE
grEPI v3.0.6 EpiParameterEstimates property renames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,23 @@
   `epiParameter_Distribution_Type` -> `distribution_type`,
   `epi_Parameter_Method_Inference` -> `inference_method`) (#498).
 
+* Fix two further `.grepi_to_epiparameter()` parsing failures found while
+  testing the above against grEPI UAT. Neither is caused by v3.0.6; both
+  are pre-existing API behaviour that predates it and were only surfaced
+  by this round of testing:
+  - `epi_Parameter_Population_Sample_Size` sometimes returns the sentinel
+    string `"Unspecified"` instead of a number, which coerces the whole
+    response column to character on ingestion and broke parsing for the
+    majority of records, not just the ones carrying the sentinel. The
+    value is now coerced to numeric, with non-numeric text treated as
+    unspecified (`NA`).
+  - `epi_Parameter_Method_Inference_DataIsCensored`/`DataIsTruncated` have
+    been split into `_Left`/`_Right`/`_Interval` fields, so the old
+    (removed) field names always read as `NULL`. `censored` is now `TRUE`
+    if any of the three censoring flags is `TRUE`; `right_truncated` now
+    reads `..._DataIsTruncated_Right` directly (left-truncation has no
+    equivalent slot in `create_method_assess()`).
+
 # epiparameter 0.4.1
 
 A patch release resolving issues flagged by CRAN checks. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # epiparameter (development version)
 
+* Update `.read_grepi()` and `.grepi_to_epiparameter()` for the grEPI v3.0.6
+  property renames on the `EpiParameterEstimates` endpoint
+  (`epiParameter_Estimate_Type` -> `parameter_type`,
+  `epiParameter_Estimate_Subtype` -> `parameter_subtype`,
+  `epiParameter_EventFrom` -> `delay_event_start`,
+  `epiParameter_EventTo` -> `delay_event_end`,
+  `epiParameter_Estimate_Unit` -> `estimate_unit`,
+  `epiParameter_Distribution_Type` -> `distribution_type`,
+  `epi_Parameter_Method_Inference` -> `inference_method`) (#498).
+
 # epiparameter 0.4.1
 
 A patch release resolving issues flagged by CRAN checks. 

--- a/R/grepi.R
+++ b/R/grepi.R
@@ -296,6 +296,31 @@
     region <- x$epi_Parameter_Population_Country_list[[1]]$country_Name
   }
 
+  # grEPI mixes numeric sample sizes with the sentinel string "Unspecified"
+  # in this field, which coerces the whole API response column to character
+  # on ingestion. Recover the numeric value here, treating non-numeric text
+  # (e.g. "Unspecified") as unspecified (NA) rather than failing to parse.
+  sample_size <- if (is.null(x$epi_Parameter_Population_Sample_Size)) {
+    NULL
+  } else {
+    suppressWarnings(as.numeric(x$epi_Parameter_Population_Sample_Size))
+  }
+
+  # grEPI now reports censoring/truncation as separate Left/Right/Interval
+  # flags rather than a single boolean. epiparameter only tracks whether
+  # data was censored at all (any of the three), and truncation on the
+  # right specifically, so left-truncation has no home in method_assess.
+  censored_flags <- c(
+    x$epi_Parameter_Method_Inference_DataIsCensored_Left %||% NA,
+    x$epi_Parameter_Method_Inference_DataIsCensored_Right %||% NA,
+    x$epi_Parameter_Method_Inference_DataIsCensored_Interval %||% NA
+  )
+  censored <- if (all(is.na(censored_flags))) {
+    NA
+  } else {
+    any(censored_flags, na.rm = TRUE)
+  }
+
   # return <epiparameter>
   epiparameter(
     disease = x$disease_Name_Preferred,
@@ -307,13 +332,13 @@
     citation = citation,
     metadata = create_metadata(
       units = x$estimate_unit,
-      sample_size = x$epi_Parameter_Population_Sample_Size,
+      sample_size = sample_size,
       inference_method = x$inference_method,
       region = region
     ),
     method_assess = create_method_assess(
-      censored = x$epi_Parameter_Method_Inference_DataIsCensored,
-      right_truncated = x$epi_Parameter_Method_Inference_DataIsTruncated,
+      censored = censored,
+      right_truncated = x$epi_Parameter_Method_Inference_DataIsTruncated_Right %||% NA, # nolint
       phase_bias_adjusted = x$epi_Parameter_Method_Inference_DataIsBiasAdjusted
     ),
     notes = paste0(

--- a/R/grepi.R
+++ b/R/grepi.R
@@ -78,15 +78,15 @@
   }
 
   # epi_name is filtered locally: the grEPI API ignores the
-  # epiParameter_Estimate_Type query parameter
+  # parameter_type query parameter
   # matched case-insensitively against either the
   # broad Estimate_Type category (e.g. "Human Delay") or the specific Subtype
   # (e.g. "Incubation period").
   if (!identical(epi_name, "all")) {
     en <- .clean_string(epi_name)
     grepi_types <- c(
-      tolower(grepi_params$epiParameter_Estimate_Type),
-      tolower(grepi_params$epiParameter_Estimate_Subtype)
+      tolower(grepi_params$parameter_type),
+      tolower(grepi_params$parameter_subtype)
     )
     tryCatch(
       {
@@ -131,8 +131,8 @@
         }
       }
     )
-    keep <- tolower(grepi_params$epiParameter_Estimate_Type) == en |
-            tolower(grepi_params$epiParameter_Estimate_Subtype) == en
+    keep <- tolower(grepi_params$parameter_type) == en |
+            tolower(grepi_params$parameter_subtype) == en
     keep[is.na(keep)] <- FALSE
     grepi_params <- grepi_params[keep, , drop = FALSE]
     if (nrow(grepi_params) == 0L) {
@@ -170,7 +170,7 @@
   # family, extend dist_lookup; the rest of the branch is family-agnostic.
   dist_lookup <- c(Weibull = "weibull", Gamma = "gamma",
                    "Log-normal" = "lnorm")
-  dist_raw <- x$epiParameter_Distribution_Type
+  dist_raw <- x$distribution_type
   has_dist <- !is.null(dist_raw) && !is.na(dist_raw) &&
               dist_raw %in% names(dist_lookup)
   dist <- if (has_dist) unname(dist_lookup[[dist_raw]]) else NA_character_
@@ -282,12 +282,12 @@
   )
 
   # format epi_name
-  subtype <- x$epiParameter_Estimate_Subtype
+  subtype <- x$parameter_subtype
   subtype[is.na(subtype)] <- ""
   if (subtype == "Other") {
-    subtype <- paste(x$epiParameter_EventFrom, "to", x$epiParameter_EventTo)
+    subtype <- paste(x$delay_event_start, "to", x$delay_event_end)
   }
-  epi_name <- trimws(paste(subtype, x$epiParameter_Estimate_Type))
+  epi_name <- trimws(paste(subtype, x$parameter_type))
 
   # handle entries missing Country info
   if (is.null(x$epi_Parameter_Population_Country_list[[1]]$country_Name)) {
@@ -306,9 +306,9 @@
     summary_stats = summary_stats,
     citation = citation,
     metadata = create_metadata(
-      units = x$epiParameter_Estimate_Unit,
+      units = x$estimate_unit,
       sample_size = x$epi_Parameter_Population_Sample_Size,
-      inference_method = x$epi_Parameter_Method_Inference,
+      inference_method = x$inference_method,
       region = region
     ),
     method_assess = create_method_assess(


### PR DESCRIPTION
## Summary

- Updates `.read_grepi()` and `.grepi_to_epiparameter()` in `R/grepi.R` for the grEPI v3.0.6 property renames on the `EpiParameterEstimates` endpoint: `epiParameter_Estimate_Type` -> `parameter_type`, `epiParameter_Estimate_Subtype` -> `parameter_subtype`, `epiParameter_EventFrom` -> `delay_event_start`, `epiParameter_EventTo` -> `delay_event_end`, `epiParameter_Estimate_Unit` -> `estimate_unit`, `epiParameter_Distribution_Type` -> `distribution_type`, `epi_Parameter_Method_Inference` -> `inference_method`.

Fixes #498.

- **Also fixes two pieces of pre-existing debt surfaced while testing the above against UAT** (not caused by v3.0.6 — both are already live on PROD today, just previously unnoticed):
  - `epi_Parameter_Population_Sample_Size` sometimes returns the sentinel string `"Unspecified"` instead of a number. Because the API mixes numeric and string values in this field, JSON deserialization coerces the *entire* response column to character, which broke parsing for the large majority of records, not just the ones carrying the sentinel. Now coerced to numeric, with non-numeric text treated as unspecified (`NA`).
  - `epi_Parameter_Method_Inference_DataIsCensored`/`DataIsTruncated` have been split into `_Left`/`_Right`/`_Interval` fields, so the old field names always read `NULL` and crashed `create_method_assess()`. `censored` is now `TRUE` if any of the three censoring flags is `TRUE`; `right_truncated` now reads `..._DataIsTruncated_Right` directly (left-truncation has no equivalent slot in `create_method_assess()`).

## Test plan

- [x] Confirm against grEPI UAT once it carries v3.0.6 — ran `.grepi_to_epiparameter()` over all 2,269 live UAT records (patching in the still-open #494/#496 fixes to isolate this PR's scope): 1,990 converted with zero errors, the remaining 279 hit the pre-existing "unsupported distribution" skip path, unrelated to any of these fixes.
- [x] `Rscript -e 'parse("R/grepi.R")'` succeeds